### PR TITLE
feat: add content library with SEO-optimized articles

### DIFF
--- a/backend/app/alembic/versions/k1f2g3h4i5j6_add_article_tables.py
+++ b/backend/app/alembic/versions/k1f2g3h4i5j6_add_article_tables.py
@@ -1,0 +1,144 @@
+"""Add article tables
+
+Revision ID: k1f2g3h4i5j6
+Revises: j0e1f2g3h4i5
+Create Date: 2026-02-17 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'k1f2g3h4i5j6'
+down_revision = 'j0e1f2g3h4i5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create enum types with existence check
+    connection = op.get_bind()
+
+    for enum_name, values in [
+        ('articlecategory', ['buying_process', 'costs_and_taxes', 'regulations', 'common_pitfalls']),
+        ('articlestatus', ['draft', 'published', 'archived']),
+        ('difficultylevel', ['beginner', 'intermediate', 'advanced']),
+    ]:
+        result = connection.execute(
+            sa.text("SELECT 1 FROM pg_type WHERE typname = :name"),
+            {"name": enum_name}
+        )
+        if not result.fetchone():
+            values_str = ", ".join(f"'{v}'" for v in values)
+            connection.execute(
+                sa.text(f"CREATE TYPE {enum_name} AS ENUM ({values_str})")
+            )
+
+    # Define enums for table creation
+    articlecategory = postgresql.ENUM(
+        'buying_process', 'costs_and_taxes', 'regulations', 'common_pitfalls',
+        name='articlecategory', create_type=False
+    )
+    articlestatus = postgresql.ENUM(
+        'draft', 'published', 'archived',
+        name='articlestatus', create_type=False
+    )
+    difficultylevel = postgresql.ENUM(
+        'beginner', 'intermediate', 'advanced',
+        name='difficultylevel', create_type=False
+    )
+
+    # Create article table
+    op.create_table(
+        'article',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('slug', sa.String(length=255), nullable=False),
+        sa.Column('title', sa.String(length=500), nullable=False),
+        sa.Column('meta_description', sa.String(length=320), nullable=False),
+        sa.Column('category', articlecategory, nullable=False),
+        sa.Column('difficulty_level', difficultylevel, nullable=False),
+        sa.Column('status', articlestatus, nullable=False, server_default='draft'),
+        sa.Column('excerpt', sa.Text(), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('key_takeaways', postgresql.JSONB(), nullable=False, server_default='[]'),
+        sa.Column('reading_time_minutes', sa.Integer(), nullable=False, server_default='1'),
+        sa.Column('view_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('author_name', sa.String(length=255), nullable=False),
+        sa.Column('related_law_ids', postgresql.JSONB(), nullable=True, server_default='[]'),
+        sa.Column('related_calculator_types', postgresql.JSONB(), nullable=True, server_default='[]'),
+        sa.Column('search_vector', postgresql.TSVECTOR(), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_article_slug'), 'article', ['slug'], unique=True)
+    op.create_index(op.f('ix_article_category'), 'article', ['category'], unique=False)
+    op.create_index(op.f('ix_article_status'), 'article', ['status'], unique=False)
+    op.create_index('ix_article_search_vector', 'article', ['search_vector'], unique=False, postgresql_using='gin')
+
+    # Create article_rating table
+    op.create_table(
+        'article_rating',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('article_id', sa.UUID(), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('is_helpful', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(['article_id'], ['article.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('article_id', 'user_id', name='uq_article_rating_user')
+    )
+    op.create_index(op.f('ix_article_rating_article_id'), 'article_rating', ['article_id'], unique=False)
+    op.create_index(op.f('ix_article_rating_user_id'), 'article_rating', ['user_id'], unique=False)
+
+    # Create trigger function for updating search_vector
+    op.execute("""
+        CREATE OR REPLACE FUNCTION article_search_vector_update() RETURNS trigger AS $$
+        BEGIN
+            NEW.search_vector :=
+                setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(NEW.excerpt, '')), 'B') ||
+                setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'C') ||
+                setweight(to_tsvector('english', COALESCE(
+                    array_to_string(
+                        ARRAY(SELECT jsonb_array_elements_text(COALESCE(NEW.key_takeaways, '[]'::jsonb))),
+                        ' '
+                    ),
+                    ''
+                )), 'D');
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """)
+
+    # Create trigger
+    op.execute("""
+        CREATE TRIGGER article_search_vector_trigger
+        BEFORE INSERT OR UPDATE ON article
+        FOR EACH ROW
+        EXECUTE FUNCTION article_search_vector_update();
+    """)
+
+
+def downgrade() -> None:
+    # Drop trigger
+    op.execute("DROP TRIGGER IF EXISTS article_search_vector_trigger ON article")
+    op.execute("DROP FUNCTION IF EXISTS article_search_vector_update()")
+
+    # Drop tables
+    op.drop_index(op.f('ix_article_rating_user_id'), table_name='article_rating')
+    op.drop_index(op.f('ix_article_rating_article_id'), table_name='article_rating')
+    op.drop_table('article_rating')
+    op.drop_index('ix_article_search_vector', table_name='article')
+    op.drop_index(op.f('ix_article_status'), table_name='article')
+    op.drop_index(op.f('ix_article_category'), table_name='article')
+    op.drop_index(op.f('ix_article_slug'), table_name='article')
+    op.drop_table('article')
+
+    # Drop enums
+    op.execute('DROP TYPE IF EXISTS difficultylevel')
+    op.execute('DROP TYPE IF EXISTS articlestatus')
+    op.execute('DROP TYPE IF EXISTS articlecategory')

--- a/backend/app/alembic/versions/k2g3h4i5j6k7_seed_initial_articles.py
+++ b/backend/app/alembic/versions/k2g3h4i5j6k7_seed_initial_articles.py
@@ -1,0 +1,989 @@
+"""Seed initial articles
+
+Revision ID: k2g3h4i5j6k7
+Revises: k1f2g3h4i5j6
+Create Date: 2026-02-17 12:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'k2g3h4i5j6k7'
+down_revision = 'k1f2g3h4i5j6'
+branch_labels = None
+depends_on = None
+
+
+ARTICLES = [
+    # --- Buying Process (3) ---
+    {
+        "slug": "complete-guide-buying-property-germany",
+        "title": "The Complete Guide to Buying Property in Germany as a Foreigner",
+        "meta_description": "Step-by-step guide to purchasing real estate in Germany as a foreign investor or immigrant. From search to keys.",
+        "category": "buying_process",
+        "difficulty_level": "beginner",
+        "status": "published",
+        "excerpt": "Everything you need to know about buying property in Germany as a foreigner, from initial research to getting the keys.",
+        "content": """# The Complete Guide to Buying Property in Germany as a Foreigner
+
+Germany is one of the most stable real estate markets in Europe, and the good news is: **there are no restrictions on foreigners buying property**. Whether you're an EU citizen, a resident, or purchasing from abroad, the process is the same.
+
+## Step 1: Define Your Goals
+
+Before you start browsing listings, clarify what you're looking for:
+
+- **Personal use** or **investment**?
+- **City apartment** or **suburban house**?
+- **Budget range** including all additional costs (typically 10-15% on top of purchase price)
+
+## Step 2: Get Your Finances in Order
+
+German banks offer mortgages to foreigners, but typically require:
+
+- At least **20-30% down payment** (higher for non-residents)
+- Proof of stable income
+- Good credit history (Schufa for residents)
+- Employment contract or business financials
+
+## Step 3: Search for Properties
+
+Popular platforms include:
+- ImmobilienScout24 (largest marketplace)
+- Immowelt
+- eBay Kleinanzeigen (for private sales)
+- Local real estate agents (Makler)
+
+## Step 4: Make an Offer
+
+Unlike many countries, there's **no formal bidding process** in Germany. You negotiate directly with the seller or their agent. Verbal agreements are not binding.
+
+## Step 5: The Notary Process
+
+This is where Germany differs significantly from other countries. **All property transactions must go through a notary** (Notar):
+
+1. The notary drafts the purchase contract
+2. Both parties receive the draft at least 2 weeks before signing
+3. The notary reads the entire contract aloud at the signing appointment
+4. Both parties sign
+
+## Step 6: Payment and Transfer
+
+After signing:
+1. The notary registers a priority notice (Auflassungsvormerkung) in the land registry
+2. You pay the purchase price to the seller's account
+3. You pay the property transfer tax (Grunderwerbsteuer)
+4. The notary arranges the official ownership transfer
+5. You receive the keys
+
+## Timeline
+
+The entire process typically takes **3-6 months** from offer to keys.
+""",
+        "key_takeaways": [
+            "No restrictions on foreigners buying property in Germany",
+            "Budget 10-15% additional costs on top of purchase price",
+            "All transactions must go through a notary (Notar)",
+            "Process typically takes 3-6 months from offer to keys",
+            "Down payment of 20-30% typically required for mortgages"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "understanding-german-notary-process",
+        "title": "Understanding the German Notary Process: What to Expect",
+        "meta_description": "The German notary (Notar) plays a central role in property transactions. Learn what happens at the notary appointment.",
+        "category": "buying_process",
+        "difficulty_level": "intermediate",
+        "status": "published",
+        "excerpt": "The German notary system is unique. Learn exactly what happens before, during, and after the notary appointment.",
+        "content": """# Understanding the German Notary Process
+
+In Germany, the notary (Notar) is not just a witness to the transaction - they are a **neutral legal professional** who ensures both parties' interests are protected.
+
+## Before the Appointment
+
+### Choosing a Notary
+Either party can suggest a notary, but traditionally the **buyer chooses and pays**. The notary must be impartial regardless of who selected them.
+
+### The Draft Contract
+The notary prepares the purchase contract (Kaufvertrag) based on the agreed terms. By law, both parties must receive the draft **at least 2 weeks before the signing appointment**. This is your time to:
+
+- Have the contract reviewed by your own lawyer
+- Ask questions about any clauses you don't understand
+- Negotiate changes if needed
+
+## During the Appointment
+
+The notary appointment (Beurkundung) is a formal legal proceeding:
+
+1. **Identity verification** - Bring your passport or ID
+2. **Full reading** - The notary reads the entire contract aloud in German
+3. **Explanations** - The notary explains legal terms and implications
+4. **Questions** - Both parties can ask questions at any time
+5. **Signing** - Both parties sign each page
+6. **Notarization** - The notary stamps and certifies the document
+
+### Language Considerations
+If you don't speak German fluently, you **must bring a certified interpreter** to the appointment. The notary will ensure you understand every clause.
+
+## After the Appointment
+
+The notary handles several post-signing tasks:
+
+1. **Priority notice** (Auflassungsvormerkung) - Filed in the land registry to protect the buyer
+2. **Tax notification** - Sends details to the tax office for property transfer tax
+3. **Ownership transfer** - Once all conditions are met, registers the change of ownership
+4. **Mortgage registration** - If applicable, registers the bank's lien
+
+## Costs
+
+Notary fees are regulated by law (GNotKG) and typically amount to **1.5-2% of the purchase price**, covering:
+- Contract drafting and notarization
+- Land registry filings
+- Administrative work
+
+These fees are **not negotiable** - all notaries charge the same rates.
+""",
+        "key_takeaways": [
+            "The notary is a neutral legal professional protecting both parties",
+            "You must receive the draft contract at least 2 weeks before signing",
+            "A certified interpreter is required if you don't speak German",
+            "Notary fees are regulated by law at approximately 1.5-2% of purchase price",
+            "The notary handles land registry, tax notifications, and ownership transfer"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "mortgage-options-foreigners-germany",
+        "title": "Mortgage Options for Foreigners in Germany: A Practical Guide",
+        "meta_description": "How to get a mortgage in Germany as a foreigner. Requirements, interest rates, and tips for approval.",
+        "category": "buying_process",
+        "difficulty_level": "advanced",
+        "status": "published",
+        "excerpt": "Getting a mortgage in Germany as a foreigner is possible but requires preparation. Here's what banks look for and how to improve your chances.",
+        "content": """# Mortgage Options for Foreigners in Germany
+
+German banks do offer mortgages to foreigners, but the requirements and terms vary based on your residency status and financial profile.
+
+## Types of German Mortgages
+
+### Annuitaetendarlehen (Annuity Loan)
+The most common type. You pay a fixed monthly amount combining interest and principal repayment. The interest rate is fixed for a period (typically 10-15 years).
+
+### Volltilgerdarlehen (Full Repayment Loan)
+The interest rate is fixed for the entire loan term, and you repay the full amount within that period. Higher monthly payments but complete certainty.
+
+### KfW Loans
+The German state development bank (KfW) offers subsidized loans for energy-efficient properties. These can be combined with regular bank mortgages for lower overall costs.
+
+## Requirements by Residency Status
+
+### EU Citizens Living in Germany
+- **Down payment**: 20-30% recommended
+- **Documentation**: Employment contract, salary slips (3 months), tax returns
+- **Schufa**: Credit score check required
+- **Approval rate**: High, similar to German citizens
+
+### Non-EU Residents in Germany
+- **Down payment**: 30-40% typically required
+- **Documentation**: Residence permit, employment contract, salary slips, tax returns
+- **Additional**: Some banks require permanent residency (Niederlassungserlaubnis)
+- **Approval rate**: Moderate, depends on residency permit type
+
+### Non-Residents (Buying from Abroad)
+- **Down payment**: 40-50% or more
+- **Documentation**: Income proof from home country, credit references
+- **Additional**: Limited bank options, higher interest rates possible
+- **Approval rate**: Lower, specialist brokers recommended
+
+## Interest Rates
+
+As of 2026, typical rates for a 10-year fixed period:
+- Residents with good credit: 3.0-4.0%
+- Non-EU residents: 3.5-4.5%
+- Non-residents: 4.0-5.5%
+
+## Tips for Approval
+
+1. **Save a larger down payment** - This is the single most important factor
+2. **Build a German banking relationship** early
+3. **Get pre-approved** before house hunting
+4. **Use a mortgage broker** (Kreditvermittler) who works with multiple banks
+5. **Prepare complete documentation** in German
+6. **Consider the total cost** - Interest, Tilgung (repayment), and Nebenkosten
+""",
+        "key_takeaways": [
+            "German banks offer mortgages to foreigners with varying requirements",
+            "Down payment requirements range from 20% (EU residents) to 50% (non-residents)",
+            "Interest rates are typically fixed for 10-15 years",
+            "KfW subsidized loans can reduce costs for energy-efficient properties",
+            "Using a mortgage broker improves chances of approval for foreigners"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+
+    # --- Costs & Taxes (3) ---
+    {
+        "slug": "hidden-costs-buying-property-germany",
+        "title": "Hidden Costs of Buying Property in Germany: The Full Breakdown",
+        "meta_description": "Beyond the purchase price: understand all additional costs when buying property in Germany, from transfer tax to notary fees.",
+        "category": "costs_and_taxes",
+        "difficulty_level": "beginner",
+        "status": "published",
+        "excerpt": "The purchase price is just the beginning. Learn about the 10-15% in additional costs that every property buyer in Germany must pay.",
+        "content": """# Hidden Costs of Buying Property in Germany
+
+When budgeting for a property purchase in Germany, the listed price is only part of the story. **Additional costs (Kaufnebenkosten)** typically add 10-15% to the purchase price.
+
+## 1. Property Transfer Tax (Grunderwerbsteuer)
+
+This is the largest additional cost and varies by federal state:
+
+| State | Rate |
+|-------|------|
+| Bayern (Bavaria) | 3.5% |
+| Hamburg | 5.5% |
+| Berlin | 6.0% |
+| Brandenburg | 6.5% |
+| Nordrhein-Westfalen | 6.5% |
+
+**Example**: For a EUR 300,000 property in Berlin, the transfer tax is EUR 18,000.
+
+## 2. Notary Fees (Notarkosten)
+
+Notary fees are regulated by law and typically amount to **1.5% of the purchase price**. This covers:
+- Contract drafting and notarization
+- Land registry filings
+- Administrative correspondence
+
+## 3. Land Registry Fee (Grundbuchkosten)
+
+The fee for registering ownership in the land registry is approximately **0.5% of the purchase price**.
+
+## 4. Real Estate Agent Commission (Maklerprovision)
+
+Since December 2020, the agent's commission is **split equally** between buyer and seller (Bestellerprinzip for sales). The total commission is typically 5.95-7.14% (including VAT), so the buyer's share is approximately **3-3.57%**.
+
+Note: Not all properties involve an agent. Private sales (provisionsfrei) have no agent commission.
+
+## 5. Often Overlooked Costs
+
+- **Property survey** (Gutachten): EUR 500-2,000
+- **Renovation/repairs**: Budget at least 5% for unforeseen issues
+- **Moving costs**: EUR 500-3,000 depending on distance
+- **Furnishing**: Varies widely
+- **Building insurance** (Wohngebaeudeversicherung): EUR 200-800/year
+
+## Total Example
+
+For a EUR 400,000 apartment in Berlin:
+
+| Cost | Amount |
+|------|--------|
+| Purchase price | EUR 400,000 |
+| Transfer tax (6.0%) | EUR 24,000 |
+| Notary fees (1.5%) | EUR 6,000 |
+| Land registry (0.5%) | EUR 2,000 |
+| Agent commission (3.57%) | EUR 14,280 |
+| **Total** | **EUR 446,280** |
+
+That's an additional **EUR 46,280** or **11.6%** on top of the purchase price.
+""",
+        "key_takeaways": [
+            "Additional costs add 10-15% to the purchase price",
+            "Property transfer tax is the largest cost, ranging from 3.5% to 6.5% by state",
+            "Notary fees (1.5%) and land registry (0.5%) are fixed by law",
+            "Agent commission is split equally between buyer and seller since 2020",
+            "Always budget for renovation, moving, and furnishing costs"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "property-tax-germany-explained",
+        "title": "Property Tax in Germany: Annual Costs Every Owner Must Know",
+        "meta_description": "Understanding Grundsteuer, income tax on rental income, and other ongoing tax obligations for property owners in Germany.",
+        "category": "costs_and_taxes",
+        "difficulty_level": "intermediate",
+        "status": "published",
+        "excerpt": "Owning property in Germany comes with ongoing tax obligations. Learn about Grundsteuer, rental income tax, and the speculation tax.",
+        "content": """# Property Tax in Germany: What Every Owner Needs to Know
+
+After purchasing property in Germany, you'll face several ongoing tax obligations. Understanding these is crucial for accurate investment planning.
+
+## Grundsteuer (Property Tax)
+
+The Grundsteuer is an annual tax paid to the local municipality. Following the 2025 reform, it's calculated based on:
+
+- **Property value** (new assessment model)
+- **Municipal multiplier** (Hebesatz) - varies by city
+- **Property type** (residential vs. commercial)
+
+Typical annual amounts:
+- Small apartment: EUR 200-500/year
+- Family home: EUR 400-1,000/year
+- Large property: EUR 1,000-3,000/year
+
+## Income Tax on Rental Income
+
+If you rent out your property, the rental income is taxable:
+
+### Residents
+- Added to your regular income and taxed at your marginal rate (14-45%)
+- You can deduct expenses: mortgage interest, maintenance, depreciation, insurance
+
+### Non-Residents
+- Taxed at a flat rate or your average tax rate (minimum 14%)
+- Must file a German tax return
+- Can deduct the same expenses as residents
+
+### Key Deductions
+- **Depreciation** (AfA): 2% per year for buildings constructed after 1924, 2.5% for older buildings
+- **Mortgage interest**: Fully deductible against rental income
+- **Maintenance and repairs**: Deductible in the year incurred
+- **Property management fees**: Fully deductible
+- **Insurance premiums**: Fully deductible
+
+## Speculation Tax (Spekulationssteuer)
+
+If you sell a property **within 10 years** of purchase and make a profit, the gain is taxed as income. After 10 years, the sale is **completely tax-free** (for private investors).
+
+Exception: If you lived in the property yourself for at least the last 2 years before sale, the gain is tax-free regardless of holding period.
+
+## VAT Considerations
+
+- Residential property sales are **VAT-exempt**
+- Commercial property may be subject to 19% VAT
+- New-build properties from developers include VAT in the price
+""",
+        "key_takeaways": [
+            "Grundsteuer is an annual property tax paid to the local municipality",
+            "Rental income is taxable but many expenses are deductible",
+            "Depreciation (AfA) of 2-2.5% per year is a powerful tax deduction",
+            "Property sale profits are tax-free after a 10-year holding period",
+            "Non-residents must file German tax returns for rental income"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "renovation-costs-budgeting-guide",
+        "title": "Renovation Costs in Germany: Budgeting Guide for Property Buyers",
+        "meta_description": "How much does renovation cost in Germany? Detailed cost estimates for common renovation projects and tips for budgeting.",
+        "category": "costs_and_taxes",
+        "difficulty_level": "advanced",
+        "status": "published",
+        "excerpt": "Planning renovations for your German property? Here's a detailed breakdown of costs for common projects, from kitchen remodels to full gut renovations.",
+        "content": """# Renovation Costs in Germany: A Practical Budgeting Guide
+
+Renovation costs in Germany have risen significantly in recent years due to material costs and skilled labor shortages. Here's what to expect.
+
+## Cost Ranges by Project Type
+
+### Kitchen Renovation
+- **Basic refresh** (new fronts, countertop): EUR 5,000-10,000
+- **Mid-range new kitchen**: EUR 15,000-30,000
+- **High-end kitchen**: EUR 30,000-60,000+
+
+### Bathroom Renovation
+- **Basic refresh**: EUR 5,000-10,000
+- **Complete renovation** (4-6 sqm): EUR 10,000-20,000
+- **Luxury bathroom**: EUR 20,000-40,000+
+
+### Flooring
+- **Laminate**: EUR 20-40/sqm (installed)
+- **Hardwood parquet**: EUR 50-120/sqm (installed)
+- **Tiles**: EUR 40-80/sqm (installed)
+
+### Windows
+- **Standard double-glazed**: EUR 400-700 per window
+- **Triple-glazed (energy-efficient)**: EUR 600-1,000 per window
+- **Including installation**: Add EUR 100-200 per window
+
+### Heating System
+- **Gas condensing boiler**: EUR 6,000-10,000
+- **Heat pump**: EUR 15,000-25,000
+- **Pellet heating**: EUR 15,000-20,000
+
+Note: Government subsidies (BAFA/KfW) can cover 20-40% of costs for energy-efficient upgrades.
+
+### Full Renovation
+- **Cosmetic refresh**: EUR 300-600/sqm
+- **Standard renovation**: EUR 600-1,200/sqm
+- **Complete gut renovation**: EUR 1,200-2,500/sqm
+
+## Energy Efficiency Requirements
+
+Germany has strict energy efficiency standards (GEG - Gebaeudeenergiegesetz). When renovating, you may be required to:
+
+- Insulate the roof or top floor ceiling
+- Replace windows older than 1995
+- Upgrade the heating system if it's over 30 years old
+
+## Tips for Managing Renovation Costs
+
+1. **Get at least 3 quotes** from different contractors (Handwerker)
+2. **Check for subsidies** - KfW and BAFA offer significant funding for energy renovations
+3. **Plan a 15-20% contingency** for unexpected issues
+4. **Phase your renovation** if budget is tight - prioritize structural and energy work
+5. **Consider a Bausachverstaendiger** (building surveyor) before purchase to identify hidden issues
+""",
+        "key_takeaways": [
+            "Full renovation costs range from EUR 600-2,500 per square meter",
+            "Government subsidies (KfW/BAFA) can cover 20-40% of energy renovation costs",
+            "Always budget a 15-20% contingency for unexpected issues",
+            "Energy efficiency upgrades may be legally required when renovating",
+            "Get at least 3 quotes from different contractors before committing"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+
+    # --- Regulations (3) ---
+    {
+        "slug": "foreign-ownership-rules-germany",
+        "title": "Foreign Ownership Rules: Can Anyone Buy Property in Germany?",
+        "meta_description": "Germany has no restrictions on foreign property ownership. Learn about the rules, tax implications, and special considerations.",
+        "category": "regulations",
+        "difficulty_level": "beginner",
+        "status": "published",
+        "excerpt": "Germany is one of the most open real estate markets in the world for foreign buyers. Here's what you need to know about ownership rules.",
+        "content": """# Foreign Ownership Rules in Germany
+
+One of the most attractive aspects of the German property market is its openness to foreign buyers. Let's break down what this means in practice.
+
+## No Restrictions on Foreign Ownership
+
+Unlike many countries, Germany imposes **no restrictions on foreign property ownership**. This means:
+
+- **Any nationality** can buy property
+- **No residency requirement** - you don't need to live in Germany
+- **No special permits** needed for foreign buyers
+- **Same rights** as German citizens regarding property ownership
+- **No limit** on the number of properties you can own
+
+## Legal Requirements
+
+While there are no ownership restrictions, you must follow the standard legal process:
+
+1. **Tax identification number** (Steuer-ID) - Required for the transaction
+2. **German bank account** - Recommended for payments and ongoing costs
+3. **Notary process** - All property transactions must be notarized
+4. **Land registry** (Grundbuch) - Your ownership is officially recorded
+
+## Tax Considerations for Foreign Owners
+
+### Non-EU Residents
+- Must pay property transfer tax (same rates as everyone)
+- Rental income is taxable in Germany
+- May need to file annual German tax returns
+- Double taxation treaties may apply
+
+### EU Citizens
+- Same tax treatment as German citizens
+- Free movement rights simplify the process
+- No additional documentation required
+
+## Special Considerations
+
+### Company Ownership
+- Properties can be held through German or foreign companies
+- Different tax implications (trade tax, corporate tax)
+- Asset deal vs. share deal considerations for commercial properties
+
+### Agricultural Land
+- Some restrictions on purchasing agricultural land in certain states
+- Designed to prevent speculation on farmland
+- Rarely affects residential or commercial buyers
+
+### Heritage-Listed Properties
+- Buying is unrestricted, but renovations must follow preservation rules
+- Tax benefits available for heritage renovation costs
+- Additional approval needed for modifications
+""",
+        "key_takeaways": [
+            "Germany has no restrictions on foreign property ownership",
+            "No residency requirement or special permits needed",
+            "A tax identification number and notary process are required",
+            "Non-residents must pay taxes on German rental income",
+            "Double taxation treaties may reduce tax burden for foreign owners"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "tenant-rights-landlord-obligations",
+        "title": "Tenant Rights and Landlord Obligations in Germany",
+        "meta_description": "Germany has strong tenant protection laws. Essential guide for property investors on landlord obligations and tenant rights.",
+        "category": "regulations",
+        "difficulty_level": "intermediate",
+        "status": "published",
+        "excerpt": "Germany is known for its strong tenant protections. If you're buying an investment property, understanding these rules is essential.",
+        "content": """# Tenant Rights and Landlord Obligations in Germany
+
+Germany has some of the strongest tenant protection laws in Europe. As a landlord, understanding these rules is critical to successful property investment.
+
+## Lease Agreements
+
+### Unlimited vs. Limited Contracts
+- Most residential leases are **unlimited** (unbefristeter Mietvertrag)
+- Limited-term leases are only allowed with a **valid reason** (e.g., landlord's own use planned)
+- Tenants can terminate with **3 months' notice** at any time
+
+### Landlord's Right to Terminate
+Landlords can only terminate a lease for specific reasons:
+1. **Personal use** (Eigenbedarf) - You or close family need the apartment
+2. **Significant breach** - Non-payment of rent, damage to property
+3. **Economic necessity** - Property cannot be economically maintained otherwise
+
+Even with valid reasons, notice periods are:
+- Up to 5 years of tenancy: **3 months**
+- 5-8 years: **6 months**
+- Over 8 years: **9 months**
+
+## Rent Control (Mietpreisbremse)
+
+In designated areas (most major cities), rent increases are limited:
+
+- **New leases**: Rent cannot exceed 10% above the local reference rent (Mietspiegel)
+- **Existing leases**: Maximum increase of 20% within 3 years (15% in some cities)
+- **Exceptions**: New-build properties and extensive renovations
+
+## Maintenance and Repairs
+
+### Landlord Responsibilities
+- **Structural repairs** (roof, walls, foundation)
+- **Heating, plumbing, electrical systems**
+- **Common areas** maintenance
+- **Appliances** provided with the apartment
+
+### Tenant Responsibilities
+- **Minor repairs** (Kleinreparaturen) up to EUR 75-100 per repair, max EUR 200-300/year
+- Must be explicitly stated in the lease
+- **Cosmetic repairs** (Schoenheitsreparaturen) - recent court rulings have limited landlord's ability to require these
+
+## Deposit Rules
+
+- Maximum **3 months' cold rent** (Kaltmiete)
+- Must be held in a **separate account**
+- **Interest** earned belongs to the tenant
+- Must be returned within **6 months** after lease end (with deductions for damages if applicable)
+
+## Utility Costs (Nebenkosten)
+
+Landlords must provide an annual utility cost statement (Nebenkostenabrechnung) within **12 months** of the billing period end. Late statements cannot be charged to tenants.
+""",
+        "key_takeaways": [
+            "Most German residential leases are unlimited-term",
+            "Landlords can only terminate for specific legal reasons",
+            "Rent increases are capped at 20% over 3 years in most cases",
+            "Security deposits are limited to 3 months' cold rent",
+            "Annual utility cost statements must be provided within 12 months"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "energy-efficiency-requirements-buildings",
+        "title": "Energy Efficiency Requirements for Buildings in Germany (GEG)",
+        "meta_description": "Understanding Germany's Building Energy Act (GEG) and what it means for property buyers and renovators.",
+        "category": "regulations",
+        "difficulty_level": "advanced",
+        "status": "published",
+        "excerpt": "Germany's Building Energy Act (GEG) sets strict requirements for building energy performance. Here's what property buyers need to know.",
+        "content": """# Energy Efficiency Requirements for Buildings in Germany
+
+The Gebaeudeenergiegesetz (GEG) - Building Energy Act - is Germany's primary legislation governing energy efficiency in buildings. It significantly impacts property purchase and renovation decisions.
+
+## Energy Performance Certificate (Energieausweis)
+
+Every property for sale or rent must have an energy certificate. There are two types:
+
+### Consumption-Based (Verbrauchsausweis)
+- Based on actual energy consumption over 3 years
+- Cheaper to obtain (EUR 50-100)
+- Less accurate, depends on occupant behavior
+
+### Demand-Based (Bedarfsausweis)
+- Based on building characteristics and theoretical demand
+- Required for buildings with fewer than 5 units built before 1977
+- More expensive (EUR 300-500) but more accurate
+
+## Energy Efficiency Classes
+
+Properties are rated from A+ to H:
+
+| Class | kWh/sqm/year | Description |
+|-------|-------------|-------------|
+| A+ | < 30 | Passive house standard |
+| A | 30-49 | New-build standard |
+| B | 50-74 | Very good |
+| C | 75-99 | Good |
+| D | 100-129 | Average |
+| E | 130-159 | Below average |
+| F | 160-199 | Poor |
+| G | 200-249 | Very poor |
+| H | > 250 | Worst rating |
+
+## Renovation Obligations
+
+When buying a property, certain energy upgrades may be **legally required**:
+
+### Mandatory Within 2 Years of Purchase
+- **Roof/top floor insulation**: If not already meeting minimum standards
+- **Heating pipe insulation**: Exposed pipes in unheated areas
+- **Old heating replacement**: Oil/gas boilers older than 30 years must be replaced
+
+### Exemptions
+- Buildings used less than 4 months per year
+- Listed buildings where changes would alter character
+- Owners who have lived in the property since before Feb 2002
+
+## Government Subsidies
+
+Significant funding is available for energy renovations:
+
+### KfW Programs
+- **Energy-efficient renovation**: Up to EUR 150,000 per unit at subsidized rates
+- **Individual measures**: Up to EUR 60,000 per unit
+- **Tilgungszuschuss**: Repayment grants up to 45%
+
+### BAFA Subsidies
+- **Heat pumps**: Up to 40% of costs
+- **Building envelope**: Up to 20% of costs
+- **Heating optimization**: Up to 20% of costs
+
+## Impact on Property Value
+
+Energy efficiency increasingly affects property values:
+- Properties rated A-C command **5-15% premium**
+- Properties rated F-H may sell at **10-20% discount**
+- Energy costs are a growing concern for buyers
+- Future regulations will likely tighten requirements further
+""",
+        "key_takeaways": [
+            "Every property for sale must have an energy performance certificate",
+            "Properties are rated A+ (best) to H (worst) for energy efficiency",
+            "Certain energy upgrades are legally required within 2 years of purchase",
+            "Government subsidies can cover 20-45% of energy renovation costs",
+            "Energy-efficient properties command a 5-15% price premium"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+
+    # --- Common Pitfalls (3) ---
+    {
+        "slug": "top-mistakes-foreign-buyers-germany",
+        "title": "Top 10 Mistakes Foreign Buyers Make in Germany",
+        "meta_description": "Avoid these common mistakes when buying property in Germany as a foreigner. From underestimating costs to skipping due diligence.",
+        "category": "common_pitfalls",
+        "difficulty_level": "beginner",
+        "status": "published",
+        "excerpt": "Buying property in Germany can be straightforward, but foreign buyers often make preventable mistakes. Here are the top 10 to avoid.",
+        "content": """# Top 10 Mistakes Foreign Buyers Make in Germany
+
+Based on years of experience helping foreign investors and immigrants buy property in Germany, these are the most common and costly mistakes.
+
+## 1. Underestimating Additional Costs
+
+**The mistake**: Budgeting only for the purchase price.
+
+**Reality**: Additional costs (Kaufnebenkosten) add 10-15% to the purchase price. This includes transfer tax, notary fees, agent commission, and land registry fees.
+
+## 2. Not Getting Pre-Approved for a Mortgage
+
+**The mistake**: Finding the perfect property, then scrambling for financing.
+
+**Reality**: German mortgage approvals can take 2-4 weeks. Sellers prefer buyers with financing secured. Get pre-approved before you start searching.
+
+## 3. Skipping the Building Survey
+
+**The mistake**: Trusting that the property is in good condition based on appearance.
+
+**Reality**: Hidden issues like damp, structural problems, or outdated electrical systems can cost tens of thousands to fix. Invest EUR 500-1,000 in a professional survey (Baugutachten).
+
+## 4. Ignoring the Hausverwaltung for Apartments
+
+**The mistake**: Not reviewing the building management (Hausverwaltung) records before buying an apartment.
+
+**Reality**: Check the minutes of owners' meetings (Eigentuememerversammlung protocols), the maintenance reserve fund (Instandhaltungsruecklage), and any planned special assessments (Sonderumlagen). A low reserve fund means unexpected bills.
+
+## 5. Not Understanding Eigentuemergemeinschaft
+
+**The mistake**: Thinking apartment ownership gives you complete freedom.
+
+**Reality**: In a condominium (Eigentumswohnung), many decisions require approval from the owners' association. Changes to external appearance, noise regulations, and pet policies may be restricted.
+
+## 6. Rushing the Notary Process
+
+**The mistake**: Signing the contract without fully understanding it.
+
+**Reality**: You have a legal right to receive the draft contract 2 weeks before signing. Use this time to have it reviewed by an independent lawyer, especially if you don't speak German.
+
+## 7. Forgetting About Ongoing Costs
+
+**The mistake**: Only considering the purchase costs.
+
+**Reality**: Monthly costs include Hausgeld (for apartments), property tax, insurance, and maintenance. Budget EUR 3-5 per square meter per month for apartments.
+
+## 8. Not Checking the Grundbuch (Land Registry)
+
+**The mistake**: Assuming the seller has clear ownership.
+
+**Reality**: The land registry may reveal existing liens, rights of way, or restrictions. Your notary will check this, but understanding what's there is important.
+
+## 9. Underestimating Renovation Timelines
+
+**The mistake**: Planning to move in right after purchase with quick renovations.
+
+**Reality**: Finding reliable contractors (Handwerker) in Germany can take months. Major renovations can take 6-12 months to complete. Plan accordingly.
+
+## 10. Neglecting Tax Planning
+
+**The mistake**: Not considering the tax implications before purchase.
+
+**Reality**: How you structure the purchase (personal vs. company), your residency status, and your long-term plans all affect your tax obligations. Consult a German tax advisor (Steuerberater) before buying.
+""",
+        "key_takeaways": [
+            "Always budget 10-15% additional costs on top of the purchase price",
+            "Get mortgage pre-approval before searching for properties",
+            "Invest in a professional building survey before purchasing",
+            "Review building management records and reserve funds for apartments",
+            "Consult a German tax advisor to optimize your purchase structure"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "due-diligence-checklist-property-buyers",
+        "title": "Due Diligence Checklist for Property Buyers in Germany",
+        "meta_description": "Essential due diligence steps before buying property in Germany. From land registry checks to building inspections.",
+        "category": "common_pitfalls",
+        "difficulty_level": "intermediate",
+        "status": "published",
+        "excerpt": "Thorough due diligence can save you from costly surprises. Here's a comprehensive checklist for property buyers in Germany.",
+        "content": """# Due Diligence Checklist for Property Buyers in Germany
+
+Before signing any purchase agreement, thorough due diligence is essential. This checklist covers all the critical areas.
+
+## Legal Due Diligence
+
+### Land Registry (Grundbuch)
+- [ ] Verify seller's ownership
+- [ ] Check for existing mortgages or liens (Abteilung III)
+- [ ] Review easements and rights of way (Abteilung II)
+- [ ] Confirm property boundaries match the Liegenschaftskataster
+- [ ] Check for Vorkaufsrecht (pre-emption rights) by the municipality
+
+### Zoning and Planning
+- [ ] Review the Bebauungsplan (local development plan)
+- [ ] Check for planned construction nearby that might affect value
+- [ ] Verify permitted use (residential, commercial, mixed)
+- [ ] Check for heritage protection (Denkmalschutz) status
+
+### Building Permits
+- [ ] Verify all structures have proper building permits
+- [ ] Check for any outstanding building code violations
+- [ ] Review any pending or rejected permit applications
+
+## Financial Due Diligence
+
+### For Apartments (Eigentumswohnung)
+- [ ] Review last 3 years of Eigentuemerversammlung protocols
+- [ ] Check the Instandhaltungsruecklage (maintenance reserve)
+- [ ] Review current Hausgeld and any planned increases
+- [ ] Check for pending Sonderumlagen (special assessments)
+- [ ] Review the Teilungserklaerung (declaration of division)
+- [ ] Check the Gemeinschaftsordnung (community rules)
+
+### Rental Properties
+- [ ] Review all existing lease agreements
+- [ ] Verify current rent levels against Mietspiegel
+- [ ] Check rental payment history
+- [ ] Review any ongoing disputes with tenants
+- [ ] Calculate actual vs. advertised yield
+
+## Physical Due Diligence
+
+### Building Inspection
+- [ ] Structural integrity (foundation, walls, roof)
+- [ ] Moisture and damp issues (especially basement)
+- [ ] Electrical system condition and compliance
+- [ ] Plumbing and drainage
+- [ ] Heating system age and efficiency
+- [ ] Window condition (single, double, or triple-glazed)
+- [ ] Insulation levels (roof, walls, floor)
+
+### Energy Assessment
+- [ ] Review the Energieausweis (energy certificate)
+- [ ] Assess required energy upgrades under GEG
+- [ ] Estimate costs for bringing to current standards
+- [ ] Check eligibility for energy renovation subsidies
+
+### Environmental
+- [ ] Check for contaminated land (Altlasten)
+- [ ] Review flood risk maps
+- [ ] Check for radon risk in the area
+- [ ] Noise levels (traffic, flight paths, industrial)
+
+## Neighborhood Assessment
+- [ ] Local infrastructure (schools, shops, transport)
+- [ ] Planned development projects in the area
+- [ ] Crime statistics
+- [ ] Property value trends in the micro-location
+- [ ] Demographic trends
+""",
+        "key_takeaways": [
+            "Always verify the land registry for liens, easements, and ownership",
+            "Review at least 3 years of owners' meeting minutes for apartments",
+            "Commission a professional building inspection before purchase",
+            "Check the energy certificate and assess required upgrades",
+            "Research the neighborhood including planned developments and trends"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+    {
+        "slug": "avoiding-rental-yield-traps",
+        "title": "Avoiding Rental Yield Traps: What the Numbers Don't Tell You",
+        "meta_description": "High rental yields can be misleading. Learn how to properly evaluate investment properties and avoid common yield traps in Germany.",
+        "category": "common_pitfalls",
+        "difficulty_level": "advanced",
+        "status": "published",
+        "excerpt": "A property advertising 8% yield might actually deliver 3% net. Learn how to see through misleading yield calculations and evaluate true returns.",
+        "content": """# Avoiding Rental Yield Traps in Germany
+
+Rental yield is the most commonly cited metric for investment properties, but it's also the most frequently manipulated. Here's how to evaluate returns properly.
+
+## Gross vs. Net Yield
+
+### Gross Yield
+The simple calculation often advertised:
+```
+Gross Yield = Annual Rent / Purchase Price x 100
+```
+
+A EUR 200,000 property with EUR 10,000 annual rent = 5% gross yield.
+
+### Net Yield (What Actually Matters)
+```
+Net Yield = (Annual Rent - All Costs) / (Purchase Price + Additional Costs) x 100
+```
+
+For the same property:
+- Annual rent: EUR 10,000
+- Non-recoverable costs: EUR 2,500 (management, maintenance, insurance, vacancy)
+- Purchase price with Nebenkosten: EUR 225,000
+- **Net yield: 3.3%** - significantly lower than the advertised 5%
+
+## Common Yield Traps
+
+### Trap 1: Ignoring Vacancy Risk
+Advertised yields assume 100% occupancy. In reality:
+- Budget for **4-8% vacancy** (1-2 months over 2 years)
+- Consider local vacancy rates
+- Factor in tenant turnover costs (renovation between tenants)
+
+### Trap 2: Understating Maintenance Costs
+Rule of thumb: Budget **1-1.5% of property value** annually for maintenance.
+- Older buildings need more maintenance
+- Energy renovations may be required
+- The Hausgeld covers common areas, not your unit's interior
+
+### Trap 3: Optimistic Rent Assumptions
+- Verify rents against the local Mietspiegel (rent index)
+- Account for Mietpreisbremse (rent control) in applicable areas
+- Don't assume you can immediately raise below-market rents
+
+### Trap 4: Ignoring Tax Impact
+Your actual return depends heavily on your tax situation:
+- Rental income is taxed at your marginal rate (up to 45%)
+- Depreciation provides significant tax savings (2-2.5% of building value/year)
+- Interest payments are deductible
+- The net after-tax return may be very different from pre-tax
+
+### Trap 5: Cash-on-Cash Confusion
+When using leverage (mortgage), the relevant metric is **cash-on-cash return**:
+```
+Cash-on-Cash = Annual Cash Flow / Total Cash Invested x 100
+```
+
+This accounts for your actual capital deployed, not the total property value.
+
+## Red Flags in Property Listings
+
+- Yield calculated on cold rent only (should include all income)
+- No mention of Hausgeld or service charges
+- "Potential yield" based on future rent increases
+- Recently renovated to temporarily boost rent
+- Very high yield in a stagnant market (usually a reason why)
+
+## How to Calculate True Returns
+
+1. Start with actual current rent (verify with existing leases)
+2. Subtract all non-recoverable costs
+3. Add all purchase costs to the investment base
+4. Calculate the after-tax return based on your personal tax rate
+5. Model different scenarios (vacancy, repairs, rent changes)
+6. Compare the net return with alternative investments
+""",
+        "key_takeaways": [
+            "Net yield is typically 30-40% lower than advertised gross yield",
+            "Budget 4-8% for vacancy and 1-1.5% of property value for annual maintenance",
+            "Always verify rents against the local Mietspiegel (rent index)",
+            "Tax impact (up to 45% marginal rate) significantly affects true returns",
+            "Use cash-on-cash return when evaluating leveraged investments"
+        ],
+        "author_name": "HeimPath Editorial",
+    },
+]
+
+
+def _calculate_reading_time(content: str) -> int:
+    """Calculate estimated reading time in minutes (200 WPM, min 1)."""
+    import math
+    word_count = len(content.split())
+    return max(1, math.ceil(word_count / 200))
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    for article in ARTICLES:
+        reading_time = _calculate_reading_time(article["content"])
+
+        # Convert key_takeaways list to JSON string
+        import json
+        takeaways_json = json.dumps(article.get("key_takeaways", []))
+        related_law_ids_json = json.dumps(article.get("related_law_ids", []))
+        related_calc_json = json.dumps(article.get("related_calculator_types", []))
+
+        connection.execute(
+            sa.text("""
+                INSERT INTO article (
+                    id, slug, title, meta_description, category, difficulty_level,
+                    status, excerpt, content, key_takeaways, reading_time_minutes,
+                    view_count, author_name, related_law_ids, related_calculator_types,
+                    created_at, updated_at
+                ) VALUES (
+                    gen_random_uuid(), :slug, :title, :meta_description, :category,
+                    :difficulty_level, :status, :excerpt, :content,
+                    CAST(:key_takeaways AS jsonb), :reading_time, 0, :author_name,
+                    CAST(:related_law_ids AS jsonb), CAST(:related_calc AS jsonb),
+                    now(), now()
+                )
+            """),
+            {
+                "slug": article["slug"],
+                "title": article["title"],
+                "meta_description": article["meta_description"],
+                "category": article["category"],
+                "difficulty_level": article["difficulty_level"],
+                "status": article["status"],
+                "excerpt": article["excerpt"],
+                "content": article["content"],
+                "key_takeaways": takeaways_json,
+                "reading_time": reading_time,
+                "author_name": article["author_name"],
+                "related_law_ids": related_law_ids_json,
+                "related_calc": related_calc_json,
+            }
+        )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM article")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -19,6 +19,11 @@ reusable_oauth2 = OAuth2PasswordBearer(
     tokenUrl=f"{settings.API_V1_STR}/login/access-token"
 )
 
+reusable_oauth2_optional = OAuth2PasswordBearer(
+    tokenUrl=f"{settings.API_V1_STR}/login/access-token",
+    auto_error=False,
+)
+
 
 def get_db() -> Generator[Session, None, None]:
     with Session(engine) as session:
@@ -59,6 +64,29 @@ def get_current_user(session: SessionDep, token: TokenDep) -> User:
 
 
 CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+def get_optional_current_user(
+    session: SessionDep,
+    token: Annotated[str | None, Depends(reusable_oauth2_optional)] = None,
+) -> User | None:
+    """Return the current user if a valid token is provided, otherwise None."""
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[security.ALGORITHM]
+        )
+        token_data = TokenPayload(**payload)
+    except (InvalidTokenError, ValidationError):
+        return None
+    user = session.get(User, token_data.sub)
+    if not user or not user.is_active:
+        return None
+    return user
+
+
+OptionalCurrentUser = Annotated[User | None, Depends(get_optional_current_user)]
 
 
 def get_current_active_superuser(current_user: CurrentUser) -> User:

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.routes import (
+    articles,
     auth,
     calculators,
     dashboard,
@@ -34,6 +35,7 @@ api_router.include_router(calculators.router)
 api_router.include_router(financing.router)
 api_router.include_router(dashboard.router)
 api_router.include_router(notifications.router)
+api_router.include_router(articles.router)
 
 
 if settings.ENVIRONMENT == "local":

--- a/backend/app/api/routes/articles.py
+++ b/backend/app/api/routes/articles.py
@@ -1,0 +1,245 @@
+"""Content Library article API endpoints."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlmodel import Session
+
+from app.api.deps import (
+    CurrentUser,
+    OptionalCurrentUser,
+    get_current_active_superuser,
+    get_db,
+)
+from app.models.article import ArticleCategory, DifficultyLevel
+from app.schemas.article import (
+    ArticleCategoryInfo,
+    ArticleCreateRequest,
+    ArticleDetailResponse,
+    ArticleListResponse,
+    ArticleRatingRequest,
+    ArticleRatingResponse,
+    ArticleSearchResponse,
+    ArticleSearchResult,
+    ArticleSummary,
+    ArticleUpdateRequest,
+)
+from app.services import article_service
+
+router = APIRouter(prefix="/articles", tags=["articles"])
+
+
+# ---------------------------------------------------------------------------
+# Public endpoints (no auth required)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/", response_model=ArticleListResponse)
+def list_articles(
+    session: Session = Depends(get_db),
+    category: ArticleCategory | None = None,
+    difficulty_level: DifficultyLevel | None = None,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+) -> ArticleListResponse:
+    """Get paginated list of published articles."""
+    articles, total = article_service.get_articles(
+        session,
+        category=category,
+        difficulty_level=difficulty_level,
+        page=page,
+        page_size=page_size,
+    )
+    summaries = [ArticleSummary.model_validate(a) for a in articles]
+    return ArticleListResponse(
+        data=summaries,
+        count=len(summaries),
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/search", response_model=ArticleSearchResponse)
+def search_articles(
+    q: str = Query(..., min_length=2, description="Search query"),
+    limit: int = Query(20, ge=1, le=100),
+    session: Session = Depends(get_db),
+) -> ArticleSearchResponse:
+    """Search articles using full-text search."""
+    results = article_service.search_articles(session, q, limit)
+    search_results = []
+    for article, score in results:
+        summary = ArticleSummary.model_validate(article)
+        search_results.append(
+            ArticleSearchResult(
+                **summary.model_dump(),
+                relevance_score=score,
+            )
+        )
+    return ArticleSearchResponse(
+        data=search_results,
+        count=len(search_results),
+        query=q,
+    )
+
+
+@router.get("/categories", response_model=list[ArticleCategoryInfo])
+def get_categories(
+    session: Session = Depends(get_db),
+) -> list[ArticleCategoryInfo]:
+    """Get article categories with counts."""
+    return article_service.get_categories(session)
+
+
+@router.get("/{slug}", response_model=ArticleDetailResponse)
+def get_article(
+    slug: str,
+    session: Session = Depends(get_db),
+    current_user: OptionalCurrentUser = None,
+) -> ArticleDetailResponse:
+    """Get article detail by slug. Increments view count."""
+    try:
+        article = article_service.get_article_by_slug(session, slug)
+    except article_service.ArticleNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Article '{slug}' not found",
+        )
+
+    # Increment view count
+    article_service.increment_view_count(session, article.id)
+
+    # Get rating stats
+    user_id = current_user.id if current_user else None
+    rating_stats = article_service.get_article_rating_stats(
+        session, article.id, user_id
+    )
+
+    # Get related articles
+    related = article_service.get_related_articles(session, article)
+    related_summaries = [ArticleSummary.model_validate(a) for a in related]
+
+    return ArticleDetailResponse(
+        **ArticleSummary.model_validate(article).model_dump(),
+        meta_description=article.meta_description,
+        status=article.status,
+        content=article.content,
+        key_takeaways=article.key_takeaways or [],
+        related_law_ids=article.related_law_ids or [],
+        related_calculator_types=article.related_calculator_types or [],
+        updated_at=article.updated_at,
+        helpful_count=rating_stats["helpful_count"],
+        not_helpful_count=rating_stats["not_helpful_count"],
+        user_rating=rating_stats["user_rating"],
+        related_articles=related_summaries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth required endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{slug}/rate",
+    response_model=ArticleRatingResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def rate_article(
+    slug: str,
+    request: ArticleRatingRequest,
+    session: Session = Depends(get_db),
+    current_user: CurrentUser = None,
+) -> ArticleRatingResponse:
+    """Rate an article as helpful or not helpful."""
+    try:
+        article = article_service.get_article_by_slug(session, slug)
+    except article_service.ArticleNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Article '{slug}' not found",
+        )
+
+    article_service.rate_article(
+        session, article.id, current_user.id, request.is_helpful
+    )
+
+    stats = article_service.get_article_rating_stats(
+        session, article.id, current_user.id
+    )
+    return ArticleRatingResponse(**stats)
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints (superuser only)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/",
+    response_model=ArticleDetailResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_article(
+    request: ArticleCreateRequest,
+    session: Session = Depends(get_db),
+    _current_user=Depends(get_current_active_superuser),
+) -> ArticleDetailResponse:
+    """Create a new article (admin only)."""
+    try:
+        article = article_service.create_article(session, request.model_dump())
+    except article_service.ArticleSlugExistsError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    return ArticleDetailResponse.model_validate(article)
+
+
+@router.put("/{article_id}", response_model=ArticleDetailResponse)
+def update_article(
+    article_id: uuid.UUID,
+    request: ArticleUpdateRequest,
+    session: Session = Depends(get_db),
+    _current_user=Depends(get_current_active_superuser),
+) -> ArticleDetailResponse:
+    """Update an article (admin only)."""
+    try:
+        article = article_service.update_article(
+            session,
+            article_id,
+            request.model_dump(exclude_unset=True),
+        )
+    except article_service.ArticleNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Article {article_id} not found",
+        )
+    except article_service.ArticleSlugExistsError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    return ArticleDetailResponse.model_validate(article)
+
+
+@router.delete(
+    "/{article_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_article(
+    article_id: uuid.UUID,
+    session: Session = Depends(get_db),
+    _current_user=Depends(get_current_active_superuser),
+) -> None:
+    """Delete an article (admin only)."""
+    try:
+        article_service.delete_article(session, article_id)
+    except article_service.ArticleNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Article {article_id} not found",
+        )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -35,6 +35,13 @@ from app._models_sqlmodel import (
     UserUpdate,
     UserUpdateMe,
 )
+from app.models.article import (
+    Article,
+    ArticleCategory,
+    ArticleRating,
+    ArticleStatus,
+    DifficultyLevel,
+)
 from app.models.base import Base
 from app.models.calculator import HiddenCostCalculation
 from app.models.document import (
@@ -86,7 +93,12 @@ __all__ = [
     "UserUpdate",
     "UserUpdateMe",
     # New SQLAlchemy models
+    "Article",
+    "ArticleCategory",
+    "ArticleRating",
+    "ArticleStatus",
     "Base",
+    "DifficultyLevel",
     "FinancingAssessment",
     "HiddenCostCalculation",
     "Notification",

--- a/backend/app/models/article.py
+++ b/backend/app/models/article.py
@@ -1,0 +1,155 @@
+"""Content Library article database models."""
+
+from enum import Enum as PyEnum
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import ENUM as PgEnum
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
+from sqlalchemy.orm import relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class ArticleCategory(str, PyEnum):
+    """Categories for content library articles."""
+
+    BUYING_PROCESS = "buying_process"
+    COSTS_AND_TAXES = "costs_and_taxes"
+    REGULATIONS = "regulations"
+    COMMON_PITFALLS = "common_pitfalls"
+
+
+class ArticleStatus(str, PyEnum):
+    """Publication status for articles."""
+
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class DifficultyLevel(str, PyEnum):
+    """Difficulty level for articles."""
+
+    BEGINNER = "beginner"
+    INTERMEDIATE = "intermediate"
+    ADVANCED = "advanced"
+
+
+# PostgreSQL enum definitions (created by migration)
+_article_category_enum = PgEnum(
+    "buying_process",
+    "costs_and_taxes",
+    "regulations",
+    "common_pitfalls",
+    name="articlecategory",
+    create_type=False,
+)
+_article_status_enum = PgEnum(
+    "draft",
+    "published",
+    "archived",
+    name="articlestatus",
+    create_type=False,
+)
+_difficulty_level_enum = PgEnum(
+    "beginner",
+    "intermediate",
+    "advanced",
+    name="difficultylevel",
+    create_type=False,
+)
+
+
+class Article(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """
+    Article database model.
+
+    Represents a content library article with SEO metadata and full-text search.
+    """
+
+    __tablename__ = "article"
+
+    # Core fields
+    slug = Column(String(255), nullable=False, unique=True, index=True)
+    title = Column(String(500), nullable=False)
+    meta_description = Column(String(320), nullable=False)
+    category = Column(_article_category_enum, nullable=False, index=True)
+    difficulty_level = Column(_difficulty_level_enum, nullable=False)
+    status = Column(
+        _article_status_enum,
+        default=ArticleStatus.DRAFT.value,
+        nullable=False,
+        index=True,
+    )
+
+    # Content
+    excerpt = Column(Text, nullable=False)
+    content = Column(Text, nullable=False)
+    key_takeaways = Column(JSONB, nullable=False, default=list)
+
+    # Metadata
+    reading_time_minutes = Column(Integer, nullable=False, default=1)
+    view_count = Column(Integer, nullable=False, default=0)
+    author_name = Column(String(255), nullable=False)
+
+    # Related resources (stored as JSONB)
+    related_law_ids = Column(JSONB, nullable=True, default=list)
+    related_calculator_types = Column(JSONB, nullable=True, default=list)
+
+    # Full-text search
+    search_vector = Column(TSVECTOR)
+
+    # Relationships
+    ratings = relationship(
+        "ArticleRating",
+        back_populates="article",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_article_search_vector",
+            "search_vector",
+            postgresql_using="gin",
+        ),
+    )
+
+
+class ArticleRating(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """
+    Article rating database model.
+
+    Tracks per-user helpfulness ratings for articles.
+    """
+
+    __tablename__ = "article_rating"
+
+    article_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("article.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    is_helpful = Column(Boolean, nullable=False)
+
+    # Relationships
+    article = relationship("Article", back_populates="ratings")
+
+    __table_args__ = (
+        UniqueConstraint("article_id", "user_id", name="uq_article_rating_user"),
+    )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,5 +1,17 @@
 """Pydantic request/response schemas."""
 
+from app.schemas.article import (
+    ArticleCategoryInfo,
+    ArticleCreateRequest,
+    ArticleDetailResponse,
+    ArticleListResponse,
+    ArticleRatingRequest,
+    ArticleRatingResponse,
+    ArticleSearchResponse,
+    ArticleSearchResult,
+    ArticleSummary,
+    ArticleUpdateRequest,
+)
 from app.schemas.auth import (
     AuthToken,
     ForgotPasswordRequest,
@@ -79,6 +91,16 @@ from app.schemas.user import (
 
 __all__ = [
     "ActivityItem",
+    "ArticleCategoryInfo",
+    "ArticleCreateRequest",
+    "ArticleDetailResponse",
+    "ArticleListResponse",
+    "ArticleRatingRequest",
+    "ArticleRatingResponse",
+    "ArticleSearchResponse",
+    "ArticleSearchResult",
+    "ArticleSummary",
+    "ArticleUpdateRequest",
     "ActivityType",
     "AuthToken",
     "BookmarkedLawSummary",

--- a/backend/app/schemas/article.py
+++ b/backend/app/schemas/article.py
@@ -1,0 +1,168 @@
+"""Content Library article schemas for API requests and responses."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.article import ArticleCategory, ArticleStatus, DifficultyLevel
+
+# --- Article Summary (list views) ---
+
+
+class ArticleSummary(BaseModel):
+    """Summary view of an article for list responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    slug: str
+    title: str
+    category: ArticleCategory
+    difficulty_level: DifficultyLevel
+    excerpt: str
+    reading_time_minutes: int
+    view_count: int
+    author_name: str
+    created_at: datetime
+
+
+# --- Article Detail ---
+
+
+class ArticleDetailResponse(BaseModel):
+    """Full detail response for an article."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    slug: str
+    title: str
+    meta_description: str
+    category: ArticleCategory
+    difficulty_level: DifficultyLevel
+    status: ArticleStatus
+    excerpt: str
+    content: str
+    key_takeaways: list[str] = []
+    reading_time_minutes: int
+    view_count: int
+    author_name: str
+    related_law_ids: list[str] = []
+    related_calculator_types: list[str] = []
+    created_at: datetime
+    updated_at: datetime
+
+    # Computed fields (set by route handler)
+    helpful_count: int = 0
+    not_helpful_count: int = 0
+    user_rating: bool | None = None
+    related_articles: list[ArticleSummary] = []
+
+
+# --- List Response ---
+
+
+class ArticleListResponse(BaseModel):
+    """Paginated list of articles."""
+
+    data: list[ArticleSummary]
+    count: int
+    total: int
+    page: int
+    page_size: int
+
+
+# --- Search ---
+
+
+class ArticleSearchResult(BaseModel):
+    """Search result with relevance score."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    slug: str
+    title: str
+    category: ArticleCategory
+    difficulty_level: DifficultyLevel
+    excerpt: str
+    reading_time_minutes: int
+    view_count: int
+    author_name: str
+    created_at: datetime
+    relevance_score: float = Field(..., ge=0)
+
+
+class ArticleSearchResponse(BaseModel):
+    """Search results response."""
+
+    data: list[ArticleSearchResult]
+    count: int
+    query: str
+
+
+# --- Category Info ---
+
+
+class ArticleCategoryInfo(BaseModel):
+    """Category with article count."""
+
+    key: str
+    name: str
+    description: str
+    article_count: int
+
+
+# --- Create/Update (Admin) ---
+
+
+class ArticleCreateRequest(BaseModel):
+    """Request schema for creating an article."""
+
+    title: str = Field(..., max_length=500)
+    slug: str = Field(..., max_length=255)
+    meta_description: str = Field(..., max_length=320)
+    category: ArticleCategory
+    difficulty_level: DifficultyLevel
+    excerpt: str
+    content: str
+    key_takeaways: list[str] = []
+    author_name: str = Field(..., max_length=255)
+    related_law_ids: list[str] = []
+    related_calculator_types: list[str] = []
+    status: ArticleStatus = ArticleStatus.DRAFT
+
+
+class ArticleUpdateRequest(BaseModel):
+    """Request schema for updating an article. All fields optional."""
+
+    title: str | None = Field(None, max_length=500)
+    slug: str | None = Field(None, max_length=255)
+    meta_description: str | None = Field(None, max_length=320)
+    category: ArticleCategory | None = None
+    difficulty_level: DifficultyLevel | None = None
+    excerpt: str | None = None
+    content: str | None = None
+    key_takeaways: list[str] | None = None
+    author_name: str | None = Field(None, max_length=255)
+    related_law_ids: list[str] | None = None
+    related_calculator_types: list[str] | None = None
+    status: ArticleStatus | None = None
+
+
+# --- Rating ---
+
+
+class ArticleRatingRequest(BaseModel):
+    """Request schema for rating an article."""
+
+    is_helpful: bool
+
+
+class ArticleRatingResponse(BaseModel):
+    """Response schema for article rating stats."""
+
+    helpful_count: int
+    not_helpful_count: int
+    user_rating: bool | None = None

--- a/backend/app/services/article_service.py
+++ b/backend/app/services/article_service.py
@@ -1,0 +1,312 @@
+"""Content Library article service."""
+
+import math
+import uuid
+
+from sqlalchemy import func, select, text
+from sqlmodel import Session
+
+from app.models.article import (
+    Article,
+    ArticleCategory,
+    ArticleRating,
+    ArticleStatus,
+    DifficultyLevel,
+)
+from app.schemas.article import ArticleCategoryInfo
+
+
+class ArticleNotFoundError(Exception):
+    """Raised when an article is not found."""
+
+    pass
+
+
+class ArticleSlugExistsError(Exception):
+    """Raised when an article slug already exists."""
+
+    pass
+
+
+# --- Category metadata ---
+
+CATEGORY_INFO: dict[str, dict[str, str]] = {
+    ArticleCategory.BUYING_PROCESS.value: {
+        "name": "Buying Process",
+        "description": "Step-by-step guides to purchasing property in Germany",
+    },
+    ArticleCategory.COSTS_AND_TAXES.value: {
+        "name": "Costs & Taxes",
+        "description": "Understanding hidden costs, taxes, and fees in German real estate",
+    },
+    ArticleCategory.REGULATIONS.value: {
+        "name": "Regulations",
+        "description": "German property laws and regulations explained",
+    },
+    ArticleCategory.COMMON_PITFALLS.value: {
+        "name": "Common Pitfalls",
+        "description": "Mistakes to avoid when buying property in Germany",
+    },
+}
+
+
+def _calculate_reading_time(content: str) -> int:
+    """Calculate estimated reading time in minutes (200 WPM, min 1)."""
+    word_count = len(content.split())
+    return max(1, math.ceil(word_count / 200))
+
+
+def get_articles(
+    session: Session,
+    category: ArticleCategory | None = None,
+    difficulty_level: DifficultyLevel | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> tuple[list[Article], int]:
+    """Get paginated list of published articles."""
+    query = select(Article).where(Article.status == ArticleStatus.PUBLISHED.value)
+
+    if category:
+        query = query.where(Article.category == category.value)
+
+    if difficulty_level:
+        query = query.where(Article.difficulty_level == difficulty_level.value)
+
+    # Total count
+    count_query = select(func.count()).select_from(query.subquery())
+    total = session.exec(count_query).scalar() or 0
+
+    # Pagination
+    offset = (page - 1) * page_size
+    query = query.order_by(Article.created_at.desc()).offset(offset).limit(page_size)
+
+    articles = session.exec(query).scalars().all()
+    return list(articles), total
+
+
+def get_article_by_slug(session: Session, slug: str) -> Article:
+    """Get a published article by slug."""
+    query = select(Article).where(
+        Article.slug == slug,
+        Article.status == ArticleStatus.PUBLISHED.value,
+    )
+    article = session.exec(query).scalars().first()
+    if not article:
+        raise ArticleNotFoundError(f"Article with slug '{slug}' not found")
+    return article
+
+
+def get_article_by_id(session: Session, article_id: uuid.UUID) -> Article:
+    """Get an article by ID (any status, for admin)."""
+    query = select(Article).where(Article.id == article_id)
+    article = session.exec(query).scalars().first()
+    if not article:
+        raise ArticleNotFoundError(f"Article {article_id} not found")
+    return article
+
+
+def search_articles(
+    session: Session,
+    query_text: str,
+    limit: int = 20,
+) -> list[tuple[Article, float]]:
+    """Search articles using full-text search."""
+    search_query = text("""
+        SELECT
+            article.id,
+            ts_rank(article.search_vector, plainto_tsquery('english', :query)) as rank
+        FROM article
+        WHERE article.search_vector @@ plainto_tsquery('english', :query)
+            AND article.status = 'published'
+        ORDER BY rank DESC
+        LIMIT :limit
+    """)
+
+    result = session.execute(search_query, {"query": query_text, "limit": limit})
+
+    articles_with_scores = []
+    for row in result:
+        article = get_article_by_id(session, row.id)
+        articles_with_scores.append((article, float(row.rank)))
+
+    return articles_with_scores
+
+
+def get_categories(session: Session) -> list[ArticleCategoryInfo]:
+    """Get all categories with article counts (published only)."""
+    count_query = (
+        select(Article.category, func.count(Article.id))
+        .where(Article.status == ArticleStatus.PUBLISHED.value)
+        .group_by(Article.category)
+    )
+    counts = {row[0]: row[1] for row in session.execute(count_query)}
+
+    categories = []
+    for key, info in CATEGORY_INFO.items():
+        categories.append(
+            ArticleCategoryInfo(
+                key=key,
+                name=info["name"],
+                description=info["description"],
+                article_count=counts.get(key, 0),
+            )
+        )
+    return categories
+
+
+def increment_view_count(session: Session, article_id: uuid.UUID) -> None:
+    """Increment the view count for an article."""
+    article = get_article_by_id(session, article_id)
+    article.view_count = (article.view_count or 0) + 1
+    session.add(article)
+    session.commit()
+
+
+def rate_article(
+    session: Session,
+    article_id: uuid.UUID,
+    user_id: uuid.UUID,
+    is_helpful: bool,
+) -> None:
+    """Rate an article (upsert: create or update existing rating)."""
+    # Check article exists
+    get_article_by_id(session, article_id)
+
+    query = select(ArticleRating).where(
+        ArticleRating.article_id == article_id,
+        ArticleRating.user_id == user_id,
+    )
+    existing = session.exec(query).scalars().first()
+
+    if existing:
+        existing.is_helpful = is_helpful
+        session.add(existing)
+    else:
+        rating = ArticleRating(
+            article_id=article_id,
+            user_id=user_id,
+            is_helpful=is_helpful,
+        )
+        session.add(rating)
+
+    session.commit()
+
+
+def get_article_rating_stats(
+    session: Session,
+    article_id: uuid.UUID,
+    user_id: uuid.UUID | None = None,
+) -> dict:
+    """Get rating counts and current user's rating for an article."""
+    helpful_count = (
+        session.exec(
+            select(func.count()).where(
+                ArticleRating.article_id == article_id,
+                ArticleRating.is_helpful.is_(True),
+            )
+        ).scalar()
+        or 0
+    )
+
+    not_helpful_count = (
+        session.exec(
+            select(func.count()).where(
+                ArticleRating.article_id == article_id,
+                ArticleRating.is_helpful.is_(False),
+            )
+        ).scalar()
+        or 0
+    )
+
+    user_rating = None
+    if user_id:
+        user_rating_val = session.exec(
+            select(ArticleRating.is_helpful).where(
+                ArticleRating.article_id == article_id,
+                ArticleRating.user_id == user_id,
+            )
+        ).scalar()
+        if user_rating_val is not None:
+            user_rating = user_rating_val
+
+    return {
+        "helpful_count": helpful_count,
+        "not_helpful_count": not_helpful_count,
+        "user_rating": user_rating,
+    }
+
+
+def get_related_articles(
+    session: Session, article: Article, limit: int = 3
+) -> list[Article]:
+    """Get related articles in the same category."""
+    query = (
+        select(Article)
+        .where(
+            Article.category == article.category,
+            Article.id != article.id,
+            Article.status == ArticleStatus.PUBLISHED.value,
+        )
+        .order_by(Article.created_at.desc())
+        .limit(limit)
+    )
+    return list(session.exec(query).scalars().all())
+
+
+def create_article(session: Session, data: dict) -> Article:
+    """Create a new article (admin)."""
+    # Check slug uniqueness
+    existing = (
+        session.exec(select(Article).where(Article.slug == data["slug"]))
+        .scalars()
+        .first()
+    )
+    if existing:
+        raise ArticleSlugExistsError(
+            f"Article with slug '{data['slug']}' already exists"
+        )
+
+    # Calculate reading time
+    data["reading_time_minutes"] = _calculate_reading_time(data.get("content", ""))
+
+    article = Article(**data)
+    session.add(article)
+    session.commit()
+    session.refresh(article)
+    return article
+
+
+def update_article(session: Session, article_id: uuid.UUID, data: dict) -> Article:
+    """Update an article (admin)."""
+    article = get_article_by_id(session, article_id)
+
+    # Check slug uniqueness if changing
+    if "slug" in data and data["slug"] != article.slug:
+        existing = (
+            session.exec(select(Article).where(Article.slug == data["slug"]))
+            .scalars()
+            .first()
+        )
+        if existing:
+            raise ArticleSlugExistsError(
+                f"Article with slug '{data['slug']}' already exists"
+            )
+
+    # Recalculate reading time if content changed
+    if "content" in data:
+        data["reading_time_minutes"] = _calculate_reading_time(data["content"])
+
+    for key, value in data.items():
+        setattr(article, key, value)
+
+    session.add(article)
+    session.commit()
+    session.refresh(article)
+    return article
+
+
+def delete_article(session: Session, article_id: uuid.UUID) -> None:
+    """Delete an article (admin)."""
+    article = get_article_by_id(session, article_id)
+    session.delete(article)
+    session.commit()

--- a/backend/tests/api/routes/test_articles.py
+++ b/backend/tests/api/routes/test_articles.py
@@ -1,0 +1,284 @@
+"""Tests for Content Library article API endpoints."""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app import crud
+from app.core.config import settings
+from app.models import UserCreate
+from app.models.article import (
+    Article,
+    ArticleCategory,
+    ArticleStatus,
+    DifficultyLevel,
+)
+from tests.utils.utils import random_email, random_lower_string
+
+
+def get_auth_headers(client: TestClient, db: Session) -> tuple[dict[str, str], str]:
+    """Create a user and return auth headers and user email."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    crud.create_user(session=db, user_create=user_in)
+
+    login_data = {"username": username, "password": password}
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    tokens = r.json()
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    return headers, username
+
+
+def create_sample_article(
+    db: Session,
+    slug: str | None = None,
+    status: str = ArticleStatus.PUBLISHED.value,
+) -> Article:
+    """Create a sample article for testing."""
+    if slug is None:
+        slug = f"api-test-{uuid.uuid4().hex[:8]}"
+    article = Article(
+        id=uuid.uuid4(),
+        slug=slug,
+        title=f"Test Article {slug}",
+        meta_description="Test meta description for API tests",
+        category=ArticleCategory.BUYING_PROCESS.value,
+        difficulty_level=DifficultyLevel.BEGINNER.value,
+        status=status,
+        excerpt="This is a test excerpt.",
+        content="This is the test content for the article.",
+        key_takeaways=["Key point one", "Key point two"],
+        reading_time_minutes=1,
+        view_count=0,
+        author_name="Test Author",
+    )
+    db.add(article)
+    db.commit()
+    db.refresh(article)
+    return article
+
+
+def test_list_articles(client: TestClient, db: Session) -> None:
+    """Test listing articles returns paginated results."""
+    create_sample_article(db)
+
+    r = client.get(f"{settings.API_V1_STR}/articles/")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert "data" in data
+    assert "count" in data
+    assert "total" in data
+    assert "page" in data
+    assert "page_size" in data
+
+
+def test_list_articles_no_auth_required(client: TestClient, db: Session) -> None:  # noqa: ARG001
+    """Test that listing articles does not require authentication."""
+    r = client.get(f"{settings.API_V1_STR}/articles/")
+    assert r.status_code == 200
+
+
+def test_list_articles_filter_category(client: TestClient, db: Session) -> None:
+    """Test filtering articles by category."""
+    create_sample_article(db, slug=f"filter-cat-{uuid.uuid4().hex[:8]}")
+
+    r = client.get(
+        f"{settings.API_V1_STR}/articles/",
+        params={"category": "buying_process"},
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    for article in data["data"]:
+        assert article["category"] == "buying_process"
+
+
+def test_list_articles_excludes_drafts(client: TestClient, db: Session) -> None:
+    """Test that draft articles are not returned in public list."""
+    draft_slug = f"draft-hidden-{uuid.uuid4().hex[:8]}"
+    create_sample_article(db, slug=draft_slug, status=ArticleStatus.DRAFT.value)
+
+    r = client.get(f"{settings.API_V1_STR}/articles/")
+
+    assert r.status_code == 200
+    slugs = [a["slug"] for a in r.json()["data"]]
+    assert draft_slug not in slugs
+
+
+def test_get_article_by_slug(client: TestClient, db: Session) -> None:
+    """Test getting article detail by slug."""
+    article = create_sample_article(db, slug=f"detail-test-{uuid.uuid4().hex[:8]}")
+
+    r = client.get(f"{settings.API_V1_STR}/articles/{article.slug}")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["slug"] == article.slug
+    assert data["title"] == article.title
+    assert "content" in data
+    assert "key_takeaways" in data
+    assert "helpful_count" in data
+    assert "related_articles" in data
+
+
+def test_get_article_increments_view_count(client: TestClient, db: Session) -> None:
+    """Test that fetching an article increments the view count."""
+    article = create_sample_article(db, slug=f"view-inc-{uuid.uuid4().hex[:8]}")
+    initial_count = article.view_count
+
+    r = client.get(f"{settings.API_V1_STR}/articles/{article.slug}")
+
+    assert r.status_code == 200
+    assert r.json()["view_count"] == initial_count + 1
+
+
+def test_get_article_not_found(client: TestClient) -> None:
+    """Test 404 for non-existent article slug."""
+    r = client.get(f"{settings.API_V1_STR}/articles/nonexistent-slug")
+    assert r.status_code == 404
+
+
+def test_search_articles(client: TestClient, db: Session) -> None:
+    """Test searching articles."""
+    create_sample_article(db, slug=f"search-test-{uuid.uuid4().hex[:8]}")
+
+    r = client.get(
+        f"{settings.API_V1_STR}/articles/search",
+        params={"q": "test content"},
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert "data" in data
+    assert "count" in data
+    assert "query" in data
+
+
+def test_search_articles_min_query_length(client: TestClient) -> None:
+    """Test that search requires minimum 2 characters."""
+    r = client.get(
+        f"{settings.API_V1_STR}/articles/search",
+        params={"q": "a"},
+    )
+    assert r.status_code == 422
+
+
+def test_get_categories(client: TestClient, db: Session) -> None:  # noqa: ARG001
+    """Test getting article categories."""
+    r = client.get(f"{settings.API_V1_STR}/articles/categories")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data) == 4
+    keys = [c["key"] for c in data]
+    assert "buying_process" in keys
+    assert "costs_and_taxes" in keys
+    assert "regulations" in keys
+    assert "common_pitfalls" in keys
+
+
+def test_rate_article_requires_auth(client: TestClient, db: Session) -> None:
+    """Test that rating requires authentication."""
+    article = create_sample_article(db, slug=f"rate-noauth-{uuid.uuid4().hex[:8]}")
+
+    r = client.post(
+        f"{settings.API_V1_STR}/articles/{article.slug}/rate",
+        json={"is_helpful": True},
+    )
+
+    assert r.status_code in (401, 403)
+
+
+def test_rate_article_with_auth(client: TestClient, db: Session) -> None:
+    """Test rating an article with authentication."""
+    headers, _ = get_auth_headers(client, db)
+    article = create_sample_article(db, slug=f"rate-auth-{uuid.uuid4().hex[:8]}")
+
+    r = client.post(
+        f"{settings.API_V1_STR}/articles/{article.slug}/rate",
+        json={"is_helpful": True},
+        headers=headers,
+    )
+
+    assert r.status_code == 201
+    data = r.json()
+    assert "helpful_count" in data
+    assert "not_helpful_count" in data
+    assert data["user_rating"] is True
+
+
+def test_create_article_requires_superuser(client: TestClient, db: Session) -> None:
+    """Test that creating an article requires superuser privileges."""
+    headers, _ = get_auth_headers(client, db)
+
+    r = client.post(
+        f"{settings.API_V1_STR}/articles/",
+        json={
+            "title": "New Article",
+            "slug": "new-article",
+            "meta_description": "Description",
+            "category": "buying_process",
+            "difficulty_level": "beginner",
+            "excerpt": "Excerpt",
+            "content": "Content",
+            "author_name": "Author",
+        },
+        headers=headers,
+    )
+
+    assert r.status_code == 403
+
+
+def test_create_article_as_superuser(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test creating an article as superuser."""
+    slug = f"admin-create-{uuid.uuid4().hex[:8]}"
+
+    r = client.post(
+        f"{settings.API_V1_STR}/articles/",
+        json={
+            "title": "Admin Created Article",
+            "slug": slug,
+            "meta_description": "Description",
+            "category": "buying_process",
+            "difficulty_level": "beginner",
+            "excerpt": "Excerpt",
+            "content": "Content text here for the article body",
+            "author_name": "Admin",
+        },
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 201
+    assert r.json()["slug"] == slug
+
+
+def test_delete_article_requires_superuser(client: TestClient, db: Session) -> None:
+    """Test that deleting an article requires superuser privileges."""
+    headers, _ = get_auth_headers(client, db)
+    article = create_sample_article(db, slug=f"del-nosu-{uuid.uuid4().hex[:8]}")
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/articles/{article.id}",
+        headers=headers,
+    )
+
+    assert r.status_code == 403
+
+
+def test_delete_article_as_superuser(
+    client: TestClient, db: Session, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test deleting an article as superuser."""
+    article = create_sample_article(db, slug=f"del-su-{uuid.uuid4().hex[:8]}")
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/articles/{article.id}",
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 204

--- a/backend/tests/services/test_article_service.py
+++ b/backend/tests/services/test_article_service.py
@@ -1,0 +1,215 @@
+"""Tests for article service module-level functions."""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.article import (
+    Article,
+    ArticleCategory,
+    ArticleRating,
+    ArticleStatus,
+    DifficultyLevel,
+)
+from app.services.article_service import (
+    ArticleNotFoundError,
+    ArticleSlugExistsError,
+    _calculate_reading_time,
+)
+
+# --- Reading time tests (pure function, no mocking needed) ---
+
+
+def test_calculate_reading_time_short_content() -> None:
+    """Test reading time calculation for short content returns minimum 1."""
+    assert _calculate_reading_time("hello world") == 1
+
+
+def test_calculate_reading_time_200_words() -> None:
+    """Test that 200 words = 1 minute."""
+    content = " ".join(["word"] * 200)
+    assert _calculate_reading_time(content) == 1
+
+
+def test_calculate_reading_time_400_words() -> None:
+    """Test that 400 words = 2 minutes."""
+    content = " ".join(["word"] * 400)
+    assert _calculate_reading_time(content) == 2
+
+
+def test_calculate_reading_time_1000_words() -> None:
+    """Test that 1000 words = 5 minutes."""
+    content = " ".join(["word"] * 1000)
+    assert _calculate_reading_time(content) == 5
+
+
+def test_calculate_reading_time_empty_string() -> None:
+    """Test reading time for empty content returns 1."""
+    assert _calculate_reading_time("") == 1
+
+
+# --- Service function tests with mocked session ---
+
+
+def _make_article(**overrides) -> MagicMock:
+    """Create a mock article."""
+    article = MagicMock(spec=Article)
+    article.id = overrides.get("id", uuid.uuid4())
+    article.slug = overrides.get("slug", "test-slug")
+    article.title = overrides.get("title", "Test Article")
+    article.meta_description = overrides.get("meta_description", "Test desc")
+    article.category = overrides.get("category", ArticleCategory.BUYING_PROCESS.value)
+    article.difficulty_level = overrides.get(
+        "difficulty_level", DifficultyLevel.BEGINNER.value
+    )
+    article.status = overrides.get("status", ArticleStatus.PUBLISHED.value)
+    article.excerpt = overrides.get("excerpt", "Test excerpt")
+    article.content = overrides.get("content", "Test content")
+    article.key_takeaways = overrides.get("key_takeaways", [])
+    article.reading_time_minutes = overrides.get("reading_time_minutes", 1)
+    article.view_count = overrides.get("view_count", 0)
+    article.author_name = overrides.get("author_name", "Test Author")
+    article.related_law_ids = overrides.get("related_law_ids", [])
+    article.related_calculator_types = overrides.get("related_calculator_types", [])
+    article.created_at = overrides.get("created_at", None)
+    article.updated_at = overrides.get("updated_at", None)
+    return article
+
+
+@patch("app.services.article_service.select")
+def test_get_article_by_slug_not_found(_mock_select: MagicMock) -> None:
+    """Test that get_article_by_slug raises for non-existent slug."""
+    from app.services.article_service import get_article_by_slug
+
+    session = MagicMock()
+    session.exec.return_value.scalars.return_value.first.return_value = None
+
+    with pytest.raises(ArticleNotFoundError):
+        get_article_by_slug(session, "nonexistent")
+
+
+@patch("app.services.article_service.select")
+def test_get_article_by_slug_found(_mock_select: MagicMock) -> None:
+    """Test that get_article_by_slug returns article when found."""
+    from app.services.article_service import get_article_by_slug
+
+    mock_article = _make_article(slug="found-slug")
+    session = MagicMock()
+    session.exec.return_value.scalars.return_value.first.return_value = mock_article
+
+    result = get_article_by_slug(session, "found-slug")
+    assert result.slug == "found-slug"
+
+
+@patch("app.services.article_service.select")
+def test_get_article_by_id_not_found(_mock_select: MagicMock) -> None:
+    """Test that get_article_by_id raises for non-existent ID."""
+    from app.services.article_service import get_article_by_id
+
+    session = MagicMock()
+    session.exec.return_value.scalars.return_value.first.return_value = None
+
+    with pytest.raises(ArticleNotFoundError):
+        get_article_by_id(session, uuid.uuid4())
+
+
+def test_get_categories_returns_four() -> None:
+    """Test that get_categories returns all 4 categories."""
+    from app.services.article_service import get_categories
+
+    session = MagicMock()
+    session.execute.return_value = []
+
+    categories = get_categories(session)
+    assert len(categories) == 4
+    keys = [c.key for c in categories]
+    assert "buying_process" in keys
+    assert "costs_and_taxes" in keys
+    assert "regulations" in keys
+    assert "common_pitfalls" in keys
+
+
+@patch("app.services.article_service.get_article_by_id")
+def test_increment_view_count(mock_get: MagicMock) -> None:
+    """Test that increment_view_count increments the count."""
+    from app.services.article_service import increment_view_count
+
+    mock_article = _make_article(view_count=5)
+    mock_get.return_value = mock_article
+    session = MagicMock()
+
+    increment_view_count(session, mock_article.id)
+
+    assert mock_article.view_count == 6
+    session.add.assert_called_once_with(mock_article)
+    session.commit.assert_called_once()
+
+
+@patch("app.services.article_service.get_article_by_id")
+@patch("app.services.article_service.select")
+def test_rate_article_creates_new(_mock_select: MagicMock, mock_get: MagicMock) -> None:
+    """Test rating creates new rating when none exists."""
+    from app.services.article_service import rate_article
+
+    mock_get.return_value = _make_article()
+    session = MagicMock()
+    session.exec.return_value.scalars.return_value.first.return_value = None
+
+    rate_article(session, uuid.uuid4(), uuid.uuid4(), True)
+
+    session.add.assert_called_once()
+    session.commit.assert_called_once()
+
+
+@patch("app.services.article_service.get_article_by_id")
+@patch("app.services.article_service.select")
+def test_rate_article_upserts_existing(
+    _mock_select: MagicMock, mock_get: MagicMock
+) -> None:
+    """Test rating updates existing rating."""
+    from app.services.article_service import rate_article
+
+    mock_get.return_value = _make_article()
+    existing_rating = MagicMock(spec=ArticleRating)
+    existing_rating.is_helpful = True
+    session = MagicMock()
+    session.exec.return_value.scalars.return_value.first.return_value = existing_rating
+
+    rate_article(session, uuid.uuid4(), uuid.uuid4(), False)
+
+    assert existing_rating.is_helpful is False
+    session.add.assert_called_once_with(existing_rating)
+
+
+@patch("app.services.article_service.select")
+def test_create_article_duplicate_slug_raises(_mock_select: MagicMock) -> None:
+    """Test that creating with duplicate slug raises."""
+    from app.services.article_service import create_article
+
+    session = MagicMock()
+    session.exec.return_value.scalars.return_value.first.return_value = _make_article()
+
+    with pytest.raises(ArticleSlugExistsError):
+        create_article(
+            session,
+            {
+                "slug": "existing-slug",
+                "content": "test content",
+            },
+        )
+
+
+@patch("app.services.article_service.get_article_by_id")
+def test_delete_article_calls_delete(mock_get: MagicMock) -> None:
+    """Test that delete_article calls session.delete."""
+    from app.services.article_service import delete_article
+
+    mock_article = _make_article()
+    mock_get.return_value = mock_article
+    session = MagicMock()
+
+    delete_article(session, mock_article.id)
+
+    session.delete.assert_called_once_with(mock_article)
+    session.commit.assert_called_once()

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,8 @@
         "react-error-boundary": "^6.0.0",
         "react-hook-form": "^7.68.0",
         "react-icons": "^5.5.0",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.17",
@@ -424,15 +426,29 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.145.4", "", {}, "sha512-CI75JrfqSluhdGwLssgVeQBaCphgfkMQpi8MCY3UJX1hoGzXa8kHYJcUuIFMOLs1q7zqHy++EVVtMK03osR5wQ=="],
 
+    "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
 
     "@types/react": ["@types/react@19.2.9", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.2.2", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.47", "@swc/core": "^1.13.5" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7" } }, "sha512-x+rE6tsxq/gxrEJN3Nv3dIV60lFflPj94c90b+NNo6n1QV1QQUTLoL0MpaOVasUZ0zqVBn7ead1B5ecx1JAGfA=="],
 
@@ -456,6 +472,8 @@
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.16", "", { "bin": "dist/cli.js" }, "sha512-KeUZdBuxngy825i8xvzaK1Ncnkx0tBmb3k8DkEuqjKRkmtvNTjey2ZsNeh8Dw4lfKvbCOu9oeNx2TKm2vHqcRw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
@@ -472,6 +490,16 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001765", "", {}, "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
@@ -485,6 +513,8 @@
     "color-support": ["color-support@1.1.3", "", { "bin": "bin.js" }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@13.0.0", "", {}, "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ=="],
 
@@ -500,6 +530,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "default-browser": ["default-browser@5.4.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg=="],
 
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
@@ -510,11 +542,15 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
@@ -538,7 +574,13 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -584,7 +626,21 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": "cli.js" }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
@@ -592,9 +648,13 @@
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": "cli.js" }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
@@ -636,13 +696,103 @@
 
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -678,6 +828,8 @@
 
     "open": ["open@10.1.2", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "is-wsl": "^3.1.0" } }, "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw=="],
 
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
@@ -696,6 +848,8 @@
 
     "prettier": ["prettier@3.8.0", "", { "bin": "bin/prettier.cjs" }, "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
@@ -710,6 +864,8 @@
 
     "react-icons": ["react-icons@5.5.0", "", { "peerDependencies": { "react": "*" } }, "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -719,6 +875,14 @@
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -740,6 +904,14 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
     "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
@@ -758,6 +930,10 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
@@ -772,6 +948,18 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -782,6 +970,10 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "yaml"], "bin": "bin/vite.js" }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
@@ -791,6 +983,8 @@
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
@@ -885,6 +1079,8 @@
     "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "nypm/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,8 @@
     "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.68.0",
     "react-icons": "^5.5.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -37,6 +37,584 @@ export const ActivityTypeSchema = {
     description: 'Types of user activity tracked on the dashboard.'
 } as const;
 
+export const ArticleCategorySchema = {
+    type: 'string',
+    enum: ['buying_process', 'costs_and_taxes', 'regulations', 'common_pitfalls'],
+    title: 'ArticleCategory',
+    description: 'Categories for content library articles.'
+} as const;
+
+export const ArticleCategoryInfoSchema = {
+    properties: {
+        key: {
+            type: 'string',
+            title: 'Key'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        description: {
+            type: 'string',
+            title: 'Description'
+        },
+        article_count: {
+            type: 'integer',
+            title: 'Article Count'
+        }
+    },
+    type: 'object',
+    required: ['key', 'name', 'description', 'article_count'],
+    title: 'ArticleCategoryInfo',
+    description: 'Category with article count.'
+} as const;
+
+export const ArticleCreateRequestSchema = {
+    properties: {
+        title: {
+            type: 'string',
+            maxLength: 500,
+            title: 'Title'
+        },
+        slug: {
+            type: 'string',
+            maxLength: 255,
+            title: 'Slug'
+        },
+        meta_description: {
+            type: 'string',
+            maxLength: 320,
+            title: 'Meta Description'
+        },
+        category: {
+            '$ref': '#/components/schemas/ArticleCategory'
+        },
+        difficulty_level: {
+            '$ref': '#/components/schemas/DifficultyLevel'
+        },
+        excerpt: {
+            type: 'string',
+            title: 'Excerpt'
+        },
+        content: {
+            type: 'string',
+            title: 'Content'
+        },
+        key_takeaways: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Key Takeaways',
+            default: []
+        },
+        author_name: {
+            type: 'string',
+            maxLength: 255,
+            title: 'Author Name'
+        },
+        related_law_ids: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Related Law Ids',
+            default: []
+        },
+        related_calculator_types: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Related Calculator Types',
+            default: []
+        },
+        status: {
+            '$ref': '#/components/schemas/ArticleStatus',
+            default: 'draft'
+        }
+    },
+    type: 'object',
+    required: ['title', 'slug', 'meta_description', 'category', 'difficulty_level', 'excerpt', 'content', 'author_name'],
+    title: 'ArticleCreateRequest',
+    description: 'Request schema for creating an article.'
+} as const;
+
+export const ArticleDetailResponseSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        slug: {
+            type: 'string',
+            title: 'Slug'
+        },
+        title: {
+            type: 'string',
+            title: 'Title'
+        },
+        meta_description: {
+            type: 'string',
+            title: 'Meta Description'
+        },
+        category: {
+            '$ref': '#/components/schemas/ArticleCategory'
+        },
+        difficulty_level: {
+            '$ref': '#/components/schemas/DifficultyLevel'
+        },
+        status: {
+            '$ref': '#/components/schemas/ArticleStatus'
+        },
+        excerpt: {
+            type: 'string',
+            title: 'Excerpt'
+        },
+        content: {
+            type: 'string',
+            title: 'Content'
+        },
+        key_takeaways: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Key Takeaways',
+            default: []
+        },
+        reading_time_minutes: {
+            type: 'integer',
+            title: 'Reading Time Minutes'
+        },
+        view_count: {
+            type: 'integer',
+            title: 'View Count'
+        },
+        author_name: {
+            type: 'string',
+            title: 'Author Name'
+        },
+        related_law_ids: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Related Law Ids',
+            default: []
+        },
+        related_calculator_types: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Related Calculator Types',
+            default: []
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        updated_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Updated At'
+        },
+        helpful_count: {
+            type: 'integer',
+            title: 'Helpful Count',
+            default: 0
+        },
+        not_helpful_count: {
+            type: 'integer',
+            title: 'Not Helpful Count',
+            default: 0
+        },
+        user_rating: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'User Rating'
+        },
+        related_articles: {
+            items: {
+                '$ref': '#/components/schemas/ArticleSummary'
+            },
+            type: 'array',
+            title: 'Related Articles',
+            default: []
+        }
+    },
+    type: 'object',
+    required: ['id', 'slug', 'title', 'meta_description', 'category', 'difficulty_level', 'status', 'excerpt', 'content', 'reading_time_minutes', 'view_count', 'author_name', 'created_at', 'updated_at'],
+    title: 'ArticleDetailResponse',
+    description: 'Full detail response for an article.'
+} as const;
+
+export const ArticleListResponseSchema = {
+    properties: {
+        data: {
+            items: {
+                '$ref': '#/components/schemas/ArticleSummary'
+            },
+            type: 'array',
+            title: 'Data'
+        },
+        count: {
+            type: 'integer',
+            title: 'Count'
+        },
+        total: {
+            type: 'integer',
+            title: 'Total'
+        },
+        page: {
+            type: 'integer',
+            title: 'Page'
+        },
+        page_size: {
+            type: 'integer',
+            title: 'Page Size'
+        }
+    },
+    type: 'object',
+    required: ['data', 'count', 'total', 'page', 'page_size'],
+    title: 'ArticleListResponse',
+    description: 'Paginated list of articles.'
+} as const;
+
+export const ArticleRatingRequestSchema = {
+    properties: {
+        is_helpful: {
+            type: 'boolean',
+            title: 'Is Helpful'
+        }
+    },
+    type: 'object',
+    required: ['is_helpful'],
+    title: 'ArticleRatingRequest',
+    description: 'Request schema for rating an article.'
+} as const;
+
+export const ArticleRatingResponseSchema = {
+    properties: {
+        helpful_count: {
+            type: 'integer',
+            title: 'Helpful Count'
+        },
+        not_helpful_count: {
+            type: 'integer',
+            title: 'Not Helpful Count'
+        },
+        user_rating: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'User Rating'
+        }
+    },
+    type: 'object',
+    required: ['helpful_count', 'not_helpful_count'],
+    title: 'ArticleRatingResponse',
+    description: 'Response schema for article rating stats.'
+} as const;
+
+export const ArticleSearchResponseSchema = {
+    properties: {
+        data: {
+            items: {
+                '$ref': '#/components/schemas/ArticleSearchResult'
+            },
+            type: 'array',
+            title: 'Data'
+        },
+        count: {
+            type: 'integer',
+            title: 'Count'
+        },
+        query: {
+            type: 'string',
+            title: 'Query'
+        }
+    },
+    type: 'object',
+    required: ['data', 'count', 'query'],
+    title: 'ArticleSearchResponse',
+    description: 'Search results response.'
+} as const;
+
+export const ArticleSearchResultSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        slug: {
+            type: 'string',
+            title: 'Slug'
+        },
+        title: {
+            type: 'string',
+            title: 'Title'
+        },
+        category: {
+            '$ref': '#/components/schemas/ArticleCategory'
+        },
+        difficulty_level: {
+            '$ref': '#/components/schemas/DifficultyLevel'
+        },
+        excerpt: {
+            type: 'string',
+            title: 'Excerpt'
+        },
+        reading_time_minutes: {
+            type: 'integer',
+            title: 'Reading Time Minutes'
+        },
+        view_count: {
+            type: 'integer',
+            title: 'View Count'
+        },
+        author_name: {
+            type: 'string',
+            title: 'Author Name'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        relevance_score: {
+            type: 'number',
+            minimum: 0,
+            title: 'Relevance Score'
+        }
+    },
+    type: 'object',
+    required: ['id', 'slug', 'title', 'category', 'difficulty_level', 'excerpt', 'reading_time_minutes', 'view_count', 'author_name', 'created_at', 'relevance_score'],
+    title: 'ArticleSearchResult',
+    description: 'Search result with relevance score.'
+} as const;
+
+export const ArticleStatusSchema = {
+    type: 'string',
+    enum: ['draft', 'published', 'archived'],
+    title: 'ArticleStatus',
+    description: 'Publication status for articles.'
+} as const;
+
+export const ArticleSummarySchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        slug: {
+            type: 'string',
+            title: 'Slug'
+        },
+        title: {
+            type: 'string',
+            title: 'Title'
+        },
+        category: {
+            '$ref': '#/components/schemas/ArticleCategory'
+        },
+        difficulty_level: {
+            '$ref': '#/components/schemas/DifficultyLevel'
+        },
+        excerpt: {
+            type: 'string',
+            title: 'Excerpt'
+        },
+        reading_time_minutes: {
+            type: 'integer',
+            title: 'Reading Time Minutes'
+        },
+        view_count: {
+            type: 'integer',
+            title: 'View Count'
+        },
+        author_name: {
+            type: 'string',
+            title: 'Author Name'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'slug', 'title', 'category', 'difficulty_level', 'excerpt', 'reading_time_minutes', 'view_count', 'author_name', 'created_at'],
+    title: 'ArticleSummary',
+    description: 'Summary view of an article for list responses.'
+} as const;
+
+export const ArticleUpdateRequestSchema = {
+    properties: {
+        title: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 500
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Title'
+        },
+        slug: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Slug'
+        },
+        meta_description: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 320
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Meta Description'
+        },
+        category: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/ArticleCategory'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        },
+        difficulty_level: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/DifficultyLevel'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        },
+        excerpt: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Excerpt'
+        },
+        content: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Content'
+        },
+        key_takeaways: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Key Takeaways'
+        },
+        author_name: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Author Name'
+        },
+        related_law_ids: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Related Law Ids'
+        },
+        related_calculator_types: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Related Calculator Types'
+        },
+        status: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/ArticleStatus'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        }
+    },
+    type: 'object',
+    title: 'ArticleUpdateRequest',
+    description: 'Request schema for updating an article. All fields optional.'
+} as const;
+
 export const AuthTokenSchema = {
     properties: {
         access_token: {
@@ -525,6 +1103,13 @@ export const DetectedClauseSchema = {
     required: ['clause_type', 'original_text', 'translated_text', 'page_number', 'risk_level'],
     title: 'DetectedClause',
     description: 'A legal clause detected in the document.'
+} as const;
+
+export const DifficultyLevelSchema = {
+    type: 'string',
+    enum: ['beginner', 'intermediate', 'advanced'],
+    title: 'DifficultyLevel',
+    description: 'Difficulty level for articles.'
 } as const;
 
 export const DocumentDetailResponseSchema = {

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,182 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, ItemsReadItemsData, ItemsReadItemsResponse, ItemsCreateItemData, ItemsCreateItemResponse, ItemsReadItemData, ItemsReadItemResponse, ItemsUpdateItemData, ItemsUpdateItemResponse, ItemsDeleteItemData, ItemsDeleteItemResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, PrivateCreateUserData, PrivateCreateUserResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
+import type { ArticlesListArticlesData, ArticlesListArticlesResponse, ArticlesCreateArticleData, ArticlesCreateArticleResponse, ArticlesSearchArticlesData, ArticlesSearchArticlesResponse, ArticlesGetCategoriesResponse, ArticlesGetArticleData, ArticlesGetArticleResponse, ArticlesRateArticleData, ArticlesRateArticleResponse, ArticlesUpdateArticleData, ArticlesUpdateArticleResponse, ArticlesDeleteArticleData, ArticlesDeleteArticleResponse, AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, ItemsReadItemsData, ItemsReadItemsResponse, ItemsCreateItemData, ItemsCreateItemResponse, ItemsReadItemData, ItemsReadItemResponse, ItemsUpdateItemData, ItemsUpdateItemResponse, ItemsDeleteItemData, ItemsDeleteItemResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, PrivateCreateUserData, PrivateCreateUserResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
+
+export class ArticlesService {
+    /**
+     * List Articles
+     * Get paginated list of published articles.
+     * @param data The data for the request.
+     * @param data.category
+     * @param data.difficultyLevel
+     * @param data.page
+     * @param data.pageSize
+     * @returns ArticleListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listArticles(data: ArticlesListArticlesData = {}): CancelablePromise<ArticlesListArticlesResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/articles/',
+            query: {
+                category: data.category,
+                difficulty_level: data.difficultyLevel,
+                page: data.page,
+                page_size: data.pageSize
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Create Article
+     * Create a new article (admin only).
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns ArticleDetailResponse Successful Response
+     * @throws ApiError
+     */
+    public static createArticle(data: ArticlesCreateArticleData): CancelablePromise<ArticlesCreateArticleResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/articles/',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Search Articles
+     * Search articles using full-text search.
+     * @param data The data for the request.
+     * @param data.q Search query
+     * @param data.limit
+     * @returns ArticleSearchResponse Successful Response
+     * @throws ApiError
+     */
+    public static searchArticles(data: ArticlesSearchArticlesData): CancelablePromise<ArticlesSearchArticlesResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/articles/search',
+            query: {
+                q: data.q,
+                limit: data.limit
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Get Categories
+     * Get article categories with counts.
+     * @returns ArticleCategoryInfo Successful Response
+     * @throws ApiError
+     */
+    public static getCategories(): CancelablePromise<ArticlesGetCategoriesResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/articles/categories'
+        });
+    }
+    
+    /**
+     * Get Article
+     * Get article detail by slug. Increments view count.
+     * @param data The data for the request.
+     * @param data.slug
+     * @returns ArticleDetailResponse Successful Response
+     * @throws ApiError
+     */
+    public static getArticle(data: ArticlesGetArticleData): CancelablePromise<ArticlesGetArticleResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/articles/{slug}',
+            path: {
+                slug: data.slug
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Rate Article
+     * Rate an article as helpful or not helpful.
+     * @param data The data for the request.
+     * @param data.slug
+     * @param data.requestBody
+     * @returns ArticleRatingResponse Successful Response
+     * @throws ApiError
+     */
+    public static rateArticle(data: ArticlesRateArticleData): CancelablePromise<ArticlesRateArticleResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/articles/{slug}/rate',
+            path: {
+                slug: data.slug
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Update Article
+     * Update an article (admin only).
+     * @param data The data for the request.
+     * @param data.articleId
+     * @param data.requestBody
+     * @returns ArticleDetailResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateArticle(data: ArticlesUpdateArticleData): CancelablePromise<ArticlesUpdateArticleResponse> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v1/articles/{article_id}',
+            path: {
+                article_id: data.articleId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Delete Article
+     * Delete an article (admin only).
+     * @param data The data for the request.
+     * @param data.articleId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static deleteArticle(data: ArticlesDeleteArticleData): CancelablePromise<ArticlesDeleteArticleResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/articles/{article_id}',
+            path: {
+                article_id: data.articleId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
 
 export class AuthService {
     /**

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -17,6 +17,158 @@ export type ActivityItem = {
 export type ActivityType = 'journey_started' | 'step_completed' | 'document_uploaded' | 'calculation_saved' | 'roi_calculated' | 'financing_assessed' | 'law_bookmarked';
 
 /**
+ * Categories for content library articles.
+ */
+export type ArticleCategory = 'buying_process' | 'costs_and_taxes' | 'regulations' | 'common_pitfalls';
+
+/**
+ * Category with article count.
+ */
+export type ArticleCategoryInfo = {
+    key: string;
+    name: string;
+    description: string;
+    article_count: number;
+};
+
+/**
+ * Request schema for creating an article.
+ */
+export type ArticleCreateRequest = {
+    title: string;
+    slug: string;
+    meta_description: string;
+    category: ArticleCategory;
+    difficulty_level: DifficultyLevel;
+    excerpt: string;
+    content: string;
+    key_takeaways?: Array<(string)>;
+    author_name: string;
+    related_law_ids?: Array<(string)>;
+    related_calculator_types?: Array<(string)>;
+    status?: ArticleStatus;
+};
+
+/**
+ * Full detail response for an article.
+ */
+export type ArticleDetailResponse = {
+    id: string;
+    slug: string;
+    title: string;
+    meta_description: string;
+    category: ArticleCategory;
+    difficulty_level: DifficultyLevel;
+    status: ArticleStatus;
+    excerpt: string;
+    content: string;
+    key_takeaways?: Array<(string)>;
+    reading_time_minutes: number;
+    view_count: number;
+    author_name: string;
+    related_law_ids?: Array<(string)>;
+    related_calculator_types?: Array<(string)>;
+    created_at: string;
+    updated_at: string;
+    helpful_count?: number;
+    not_helpful_count?: number;
+    user_rating?: (boolean | null);
+    related_articles?: Array<ArticleSummary>;
+};
+
+/**
+ * Paginated list of articles.
+ */
+export type ArticleListResponse = {
+    data: Array<ArticleSummary>;
+    count: number;
+    total: number;
+    page: number;
+    page_size: number;
+};
+
+/**
+ * Request schema for rating an article.
+ */
+export type ArticleRatingRequest = {
+    is_helpful: boolean;
+};
+
+/**
+ * Response schema for article rating stats.
+ */
+export type ArticleRatingResponse = {
+    helpful_count: number;
+    not_helpful_count: number;
+    user_rating?: (boolean | null);
+};
+
+/**
+ * Search results response.
+ */
+export type ArticleSearchResponse = {
+    data: Array<ArticleSearchResult>;
+    count: number;
+    query: string;
+};
+
+/**
+ * Search result with relevance score.
+ */
+export type ArticleSearchResult = {
+    id: string;
+    slug: string;
+    title: string;
+    category: ArticleCategory;
+    difficulty_level: DifficultyLevel;
+    excerpt: string;
+    reading_time_minutes: number;
+    view_count: number;
+    author_name: string;
+    created_at: string;
+    relevance_score: number;
+};
+
+/**
+ * Publication status for articles.
+ */
+export type ArticleStatus = 'draft' | 'published' | 'archived';
+
+/**
+ * Summary view of an article for list responses.
+ */
+export type ArticleSummary = {
+    id: string;
+    slug: string;
+    title: string;
+    category: ArticleCategory;
+    difficulty_level: DifficultyLevel;
+    excerpt: string;
+    reading_time_minutes: number;
+    view_count: number;
+    author_name: string;
+    created_at: string;
+};
+
+/**
+ * Request schema for updating an article. All fields optional.
+ */
+export type ArticleUpdateRequest = {
+    title?: (string | null);
+    slug?: (string | null);
+    meta_description?: (string | null);
+    category?: (ArticleCategory | null);
+    difficulty_level?: (DifficultyLevel | null);
+    excerpt?: (string | null);
+    content?: (string | null);
+    key_takeaways?: (Array<(string)> | null);
+    author_name?: (string | null);
+    related_law_ids?: (Array<(string)> | null);
+    related_calculator_types?: (Array<(string)> | null);
+    status?: (ArticleStatus | null);
+};
+
+/**
  * JWT token response with access and refresh tokens.
  */
 export type AuthToken = {
@@ -186,6 +338,11 @@ export type DetectedClause = {
      */
     risk_level: string;
 };
+
+/**
+ * Difficulty level for articles.
+ */
+export type DifficultyLevel = 'beginner' | 'intermediate' | 'advanced';
 
 /**
  * Full document detail with optional translation.
@@ -1467,6 +1624,59 @@ export type VerifyEmailResponse = {
 export type WebhookResponse = {
     received: boolean;
 };
+
+export type ArticlesListArticlesData = {
+    category?: (ArticleCategory | null);
+    difficultyLevel?: (DifficultyLevel | null);
+    page?: number;
+    pageSize?: number;
+};
+
+export type ArticlesListArticlesResponse = (ArticleListResponse);
+
+export type ArticlesCreateArticleData = {
+    requestBody: ArticleCreateRequest;
+};
+
+export type ArticlesCreateArticleResponse = (ArticleDetailResponse);
+
+export type ArticlesSearchArticlesData = {
+    limit?: number;
+    /**
+     * Search query
+     */
+    q: string;
+};
+
+export type ArticlesSearchArticlesResponse = (ArticleSearchResponse);
+
+export type ArticlesGetCategoriesResponse = (Array<ArticleCategoryInfo>);
+
+export type ArticlesGetArticleData = {
+    slug: string;
+};
+
+export type ArticlesGetArticleResponse = (ArticleDetailResponse);
+
+export type ArticlesRateArticleData = {
+    requestBody: ArticleRatingRequest;
+    slug: string;
+};
+
+export type ArticlesRateArticleResponse = (ArticleRatingResponse);
+
+export type ArticlesUpdateArticleData = {
+    articleId: string;
+    requestBody: ArticleUpdateRequest;
+};
+
+export type ArticlesUpdateArticleResponse = (ArticleDetailResponse);
+
+export type ArticlesDeleteArticleData = {
+    articleId: string;
+};
+
+export type ArticlesDeleteArticleResponse = (void);
 
 export type AuthRegisterData = {
     requestBody: RegisterRequest;

--- a/frontend/src/components/Articles/ArticleCard.tsx
+++ b/frontend/src/components/Articles/ArticleCard.tsx
@@ -1,0 +1,137 @@
+/**
+ * Article Card Component
+ * Displays an article summary in a card format
+ */
+
+import { Link } from "@tanstack/react-router"
+import { Clock, Eye } from "lucide-react"
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type {
+  ArticleCategory,
+  ArticleSummary,
+  DifficultyLevel,
+} from "@/models/article"
+
+interface IProps {
+  article: ArticleSummary
+  showCategory?: boolean
+  className?: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const CATEGORY_LABELS: Record<ArticleCategory, string> = {
+  buying_process: "Buying Process",
+  costs_and_taxes: "Costs & Taxes",
+  regulations: "Regulations",
+  common_pitfalls: "Common Pitfalls",
+}
+
+const CATEGORY_COLORS: Record<ArticleCategory, string> = {
+  buying_process:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  costs_and_taxes:
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  regulations:
+    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  common_pitfalls:
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+}
+
+const DIFFICULTY_LABELS: Record<DifficultyLevel, string> = {
+  beginner: "Beginner",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+}
+
+const DIFFICULTY_COLORS: Record<DifficultyLevel, string> = {
+  beginner:
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
+  intermediate:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+  advanced: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Article summary card. */
+function ArticleCard(props: IProps) {
+  const { article, showCategory = true, className } = props
+
+  return (
+    <Card className={cn("transition-shadow hover:shadow-md group", className)}>
+      <CardHeader className="pb-2">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            {showCategory && (
+              <Badge
+                variant="outline"
+                className={cn("text-xs", CATEGORY_COLORS[article.category])}
+              >
+                {CATEGORY_LABELS[article.category]}
+              </Badge>
+            )}
+            <Badge
+              variant="outline"
+              className={cn(
+                "text-xs",
+                DIFFICULTY_COLORS[article.difficultyLevel],
+              )}
+            >
+              {DIFFICULTY_LABELS[article.difficultyLevel]}
+            </Badge>
+          </div>
+          <Link
+            to="/articles/$slug"
+            params={{ slug: article.slug }}
+            className="block"
+          >
+            <CardTitle className="text-base font-semibold group-hover:text-blue-600 transition-colors line-clamp-2">
+              {article.title}
+            </CardTitle>
+          </Link>
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {article.readingTimeMinutes} min read
+            </span>
+            <span className="flex items-center gap-1">
+              <Eye className="h-3 w-3" />
+              {article.viewCount.toLocaleString()} views
+            </span>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground line-clamp-2">
+          {article.excerpt}
+        </p>
+        <Link
+          to="/articles/$slug"
+          params={{ slug: article.slug }}
+          className="inline-block mt-3 text-sm font-medium text-blue-600 hover:text-blue-700"
+        >
+          Read more →
+        </Link>
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export {
+  ArticleCard,
+  CATEGORY_COLORS,
+  CATEGORY_LABELS,
+  DIFFICULTY_COLORS,
+  DIFFICULTY_LABELS,
+}

--- a/frontend/src/components/Articles/ArticleDetail.tsx
+++ b/frontend/src/components/Articles/ArticleDetail.tsx
@@ -1,0 +1,411 @@
+/**
+ * Article Detail Component
+ * Full article view with TOC, rating, sharing, and related content
+ */
+
+import { Link } from "@tanstack/react-router"
+import {
+  ArrowLeft,
+  Check,
+  Clock,
+  Copy,
+  Eye,
+  Lightbulb,
+  Linkedin,
+  ThumbsDown,
+  ThumbsUp,
+  Twitter,
+} from "lucide-react"
+import { useMemo, useState } from "react"
+import Markdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useRateArticle } from "@/hooks/mutations"
+import type { ArticleDetail as ArticleDetailType } from "@/models/article"
+import {
+  ArticleCard,
+  CATEGORY_COLORS,
+  CATEGORY_LABELS,
+  DIFFICULTY_COLORS,
+  DIFFICULTY_LABELS,
+} from "./ArticleCard"
+
+interface IProps {
+  article: ArticleDetailType
+  isLoading?: boolean
+  className?: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+interface TocItem {
+  id: string
+  text: string
+  level: number
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Loading skeleton for article detail. */
+function ArticleDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-3/4" />
+      <div className="flex gap-2">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-5 w-20" />
+      </div>
+      <Skeleton className="h-4 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-64 w-full" />
+    </div>
+  )
+}
+
+/** Table of contents sidebar. */
+function TableOfContents(props: { items: TocItem[] }) {
+  const { items } = props
+
+  if (items.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">
+          Table of Contents
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <nav className="space-y-1">
+          {items.map((item) => (
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              className={cn(
+                "block text-sm text-muted-foreground hover:text-foreground transition-colors",
+                item.level === 2 && "pl-0",
+                item.level === 3 && "pl-4",
+              )}
+            >
+              {item.text}
+            </a>
+          ))}
+        </nav>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Key takeaways box. */
+function KeyTakeaways(props: { takeaways: string[] }) {
+  const { takeaways } = props
+
+  if (takeaways.length === 0) return null
+
+  return (
+    <Card className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold flex items-center gap-2">
+          <Lightbulb className="h-4 w-4 text-amber-600" />
+          Key Takeaways
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <ul className="space-y-2">
+          {takeaways.map((takeaway, i) => (
+            <li key={i} className="flex items-start gap-2 text-sm">
+              <Check className="h-4 w-4 mt-0.5 text-amber-600 shrink-0" />
+              <span>{takeaway}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Rating widget (thumbs up/down). */
+function RatingWidget(props: {
+  slug: string
+  helpfulCount: number
+  notHelpfulCount: number
+  userRating: boolean | null
+}) {
+  const { slug, helpfulCount, notHelpfulCount, userRating } = props
+  const rateArticle = useRateArticle()
+
+  const handleRate = (isHelpful: boolean) => {
+    rateArticle.mutate({ slug, isHelpful })
+  }
+
+  return (
+    <Card>
+      <CardContent className="py-4">
+        <p className="text-sm font-medium text-center mb-3">
+          Was this article helpful?
+        </p>
+        <div className="flex items-center justify-center gap-4">
+          <Button
+            variant={userRating === true ? "default" : "outline"}
+            size="sm"
+            onClick={() => handleRate(true)}
+            disabled={rateArticle.isPending}
+            className="gap-2"
+          >
+            <ThumbsUp className="h-4 w-4" />
+            Yes ({helpfulCount})
+          </Button>
+          <Button
+            variant={userRating === false ? "default" : "outline"}
+            size="sm"
+            onClick={() => handleRate(false)}
+            disabled={rateArticle.isPending}
+            className="gap-2"
+          >
+            <ThumbsDown className="h-4 w-4" />
+            No ({notHelpfulCount})
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Social share buttons. */
+function ShareButtons(props: { title: string; slug: string }) {
+  const { title, slug } = props
+  const [copied, setCopied] = useState(false)
+
+  const articleUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/articles/${slug}`
+      : ""
+
+  const handleCopyLink = async () => {
+    await navigator.clipboard.writeText(articleUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(articleUrl)}`
+  const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(articleUrl)}`
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-muted-foreground">Share:</span>
+      <Button variant="outline" size="icon" className="h-8 w-8" asChild>
+        <a href={twitterUrl} target="_blank" rel="noopener noreferrer">
+          <Twitter className="h-4 w-4" />
+        </a>
+      </Button>
+      <Button variant="outline" size="icon" className="h-8 w-8" asChild>
+        <a href={linkedinUrl} target="_blank" rel="noopener noreferrer">
+          <Linkedin className="h-4 w-4" />
+        </a>
+      </Button>
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-8 w-8"
+        onClick={handleCopyLink}
+      >
+        {copied ? (
+          <Check className="h-4 w-4 text-green-600" />
+        ) : (
+          <Copy className="h-4 w-4" />
+        )}
+      </Button>
+    </div>
+  )
+}
+
+/** Default component. Full article detail view. */
+function ArticleDetail(props: IProps) {
+  const { article, isLoading, className } = props
+
+  // Parse headings from markdown content for TOC
+  const tocItems = useMemo<TocItem[]>(() => {
+    if (!article.content) return []
+    const headingRegex = /^(#{2,3})\s+(.+)$/gm
+    const items: TocItem[] = []
+    let match = headingRegex.exec(article.content)
+    while (match !== null) {
+      const level = match[1].length
+      const text = match[2]
+      const id = text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "")
+      items.push({ id, text, level })
+      match = headingRegex.exec(article.content)
+    }
+    return items
+  }, [article.content])
+
+  if (isLoading) {
+    return <ArticleDetailSkeleton />
+  }
+
+  const formattedDate = new Date(article.createdAt).toLocaleDateString(
+    "en-US",
+    { year: "numeric", month: "long", day: "numeric" },
+  )
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      {/* Back button */}
+      <Button variant="ghost" size="sm" asChild>
+        <Link to="/articles">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to Articles
+        </Link>
+      </Button>
+
+      {/* Header */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge
+            variant="outline"
+            className={cn("text-xs", CATEGORY_COLORS[article.category])}
+          >
+            {CATEGORY_LABELS[article.category]}
+          </Badge>
+          <Badge
+            variant="outline"
+            className={cn(
+              "text-xs",
+              DIFFICULTY_COLORS[article.difficultyLevel],
+            )}
+          >
+            {DIFFICULTY_LABELS[article.difficultyLevel]}
+          </Badge>
+        </div>
+
+        <h1 className="text-3xl font-bold">{article.title}</h1>
+
+        <div className="flex items-center gap-4 text-sm text-muted-foreground flex-wrap">
+          <span>By {article.authorName}</span>
+          <span>{formattedDate}</span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" />
+            {article.readingTimeMinutes} min read
+          </span>
+          <span className="flex items-center gap-1">
+            <Eye className="h-3.5 w-3.5" />
+            {article.viewCount.toLocaleString()} views
+          </span>
+        </div>
+
+        <ShareButtons title={article.title} slug={article.slug} />
+      </div>
+
+      <Separator />
+
+      {/* Key Takeaways */}
+      <KeyTakeaways takeaways={article.keyTakeaways} />
+
+      {/* Main content area with sidebar */}
+      <div className="grid gap-8 lg:grid-cols-[1fr_250px]">
+        {/* Article content */}
+        <div className="prose prose-slate dark:prose-invert max-w-none">
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              h2: ({ children, ...rest }) => {
+                const text = String(children)
+                const id = text
+                  .toLowerCase()
+                  .replace(/[^a-z0-9]+/g, "-")
+                  .replace(/(^-|-$)/g, "")
+                return (
+                  <h2 id={id} {...rest}>
+                    {children}
+                  </h2>
+                )
+              },
+              h3: ({ children, ...rest }) => {
+                const text = String(children)
+                const id = text
+                  .toLowerCase()
+                  .replace(/[^a-z0-9]+/g, "-")
+                  .replace(/(^-|-$)/g, "")
+                return (
+                  <h3 id={id} {...rest}>
+                    {children}
+                  </h3>
+                )
+              },
+            }}
+          >
+            {article.content}
+          </Markdown>
+        </div>
+
+        {/* Sidebar */}
+        <aside className="space-y-4 hidden lg:block">
+          <TableOfContents items={tocItems} />
+
+          {article.relatedLawIds.length > 0 && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-semibold">
+                  Related Laws
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0 space-y-2">
+                {article.relatedLawIds.map((lawId) => (
+                  <Link
+                    key={lawId}
+                    to="/laws/$lawId"
+                    params={{ lawId }}
+                    className="block text-sm text-blue-600 hover:text-blue-700"
+                  >
+                    View law →
+                  </Link>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </aside>
+      </div>
+
+      <Separator />
+
+      {/* Rating */}
+      <RatingWidget
+        slug={article.slug}
+        helpfulCount={article.helpfulCount}
+        notHelpfulCount={article.notHelpfulCount}
+        userRating={article.userRating}
+      />
+
+      {/* Related Articles */}
+      {article.relatedArticles.length > 0 && (
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold">Related Articles</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {article.relatedArticles.map((related) => (
+              <ArticleCard key={related.id} article={related} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ArticleDetail }

--- a/frontend/src/components/Articles/ArticleList.tsx
+++ b/frontend/src/components/Articles/ArticleList.tsx
@@ -1,0 +1,267 @@
+/**
+ * Article List Component
+ * Paginated listing of articles with filters
+ */
+
+import { BookOpen, Loader2 } from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useArticleCategories, useArticles } from "@/hooks/queries"
+import type {
+  ArticleCategory,
+  ArticleFilter,
+  DifficultyLevel,
+} from "@/models/article"
+import { ArticleCard, CATEGORY_LABELS, DIFFICULTY_LABELS } from "./ArticleCard"
+
+interface IProps {
+  initialCategory?: ArticleCategory
+  showCategoryFilter?: boolean
+  pageSize?: number
+  className?: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Loading skeleton for article list. */
+function ArticleListSkeleton(props: { count?: number }) {
+  const { count = 6 } = props
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="space-y-3 rounded-lg border p-4">
+          <div className="flex gap-2">
+            <Skeleton className="h-5 w-20" />
+            <Skeleton className="h-5 w-16" />
+          </div>
+          <Skeleton className="h-6 w-full" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Empty state when no articles found. */
+function EmptyState(props: { category?: ArticleCategory }) {
+  const { category } = props
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <BookOpen className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <h3 className="mt-4 text-lg font-semibold">No articles found</h3>
+      <p className="mt-2 text-sm text-muted-foreground max-w-sm">
+        {category
+          ? "No articles found in this category. Try selecting a different category."
+          : "No articles available. Check back later for updates."}
+      </p>
+    </div>
+  )
+}
+
+/** Category filter bar. */
+function CategoryFilterBar(props: {
+  selected?: ArticleCategory
+  onChange: (category: ArticleCategory | undefined) => void
+}) {
+  const { selected, onChange } = props
+  const { data: categories } = useArticleCategories()
+
+  const allCategories: ArticleCategory[] = [
+    "buying_process",
+    "costs_and_taxes",
+    "regulations",
+    "common_pitfalls",
+  ]
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant={!selected ? "default" : "outline"}
+        size="sm"
+        onClick={() => onChange(undefined)}
+      >
+        All
+      </Button>
+      {allCategories.map((cat) => {
+        const count = categories?.find((c) => c.key === cat)?.articleCount
+        return (
+          <Button
+            key={cat}
+            variant={selected === cat ? "default" : "outline"}
+            size="sm"
+            onClick={() => onChange(cat)}
+            className="gap-1"
+          >
+            {CATEGORY_LABELS[cat]}
+            {count !== undefined && (
+              <Badge variant="secondary" className="ml-1 h-5 px-1.5 text-xs">
+                {count}
+              </Badge>
+            )}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Difficulty filter bar. */
+function DifficultyFilterBar(props: {
+  selected?: DifficultyLevel
+  onChange: (level: DifficultyLevel | undefined) => void
+}) {
+  const { selected, onChange } = props
+  const levels: DifficultyLevel[] = ["beginner", "intermediate", "advanced"]
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant={!selected ? "default" : "outline"}
+        size="sm"
+        onClick={() => onChange(undefined)}
+      >
+        All Levels
+      </Button>
+      {levels.map((level) => (
+        <Button
+          key={level}
+          variant={selected === level ? "default" : "outline"}
+          size="sm"
+          onClick={() => onChange(level)}
+        >
+          {DIFFICULTY_LABELS[level]}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+/** Default component. Paginated article list with filters. */
+function ArticleList(props: IProps) {
+  const {
+    initialCategory,
+    showCategoryFilter = true,
+    pageSize = 12,
+    className,
+  } = props
+
+  const [filter, setFilter] = useState<ArticleFilter>({
+    category: initialCategory,
+    page: 1,
+    pageSize,
+  })
+
+  const { data, isLoading, error, isFetching } = useArticles(filter)
+
+  const handleCategoryChange = (category: ArticleCategory | undefined) => {
+    setFilter((prev) => ({ ...prev, category, page: 1 }))
+  }
+
+  const handleDifficultyChange = (
+    difficultyLevel: DifficultyLevel | undefined,
+  ) => {
+    setFilter((prev) => ({ ...prev, difficultyLevel, page: 1 }))
+  }
+
+  const handlePageChange = (page: number) => {
+    setFilter((prev) => ({ ...prev, page }))
+  }
+
+  const totalPages = data ? Math.ceil(data.total / pageSize) : 0
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      {showCategoryFilter && (
+        <div className="space-y-3">
+          <CategoryFilterBar
+            selected={filter.category}
+            onChange={handleCategoryChange}
+          />
+          <DifficultyFilterBar
+            selected={filter.difficultyLevel}
+            onChange={handleDifficultyChange}
+          />
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center">
+          <p className="text-sm text-destructive">
+            Failed to load articles. Please try again.
+          </p>
+        </div>
+      )}
+
+      {isLoading && <ArticleListSkeleton count={pageSize} />}
+
+      {!isLoading &&
+        !error &&
+        data &&
+        (data.data.length === 0 ? (
+          <EmptyState category={filter.category} />
+        ) : (
+          <>
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Showing {data.data.length} of {data.total} articles
+                {isFetching && (
+                  <Loader2 className="ml-2 inline h-4 w-4 animate-spin" />
+                )}
+              </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {data.data.map((article) => (
+                <ArticleCard
+                  key={article.id}
+                  article={article}
+                  showCategory={!filter.category}
+                />
+              ))}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(filter.page! - 1)}
+                  disabled={filter.page === 1 || isFetching}
+                >
+                  Previous
+                </Button>
+                <span className="text-sm text-muted-foreground">
+                  Page {filter.page} of {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handlePageChange(filter.page! + 1)}
+                  disabled={filter.page === totalPages || isFetching}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        ))}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ArticleList }

--- a/frontend/src/components/Articles/ArticleSearch.tsx
+++ b/frontend/src/components/Articles/ArticleSearch.tsx
@@ -1,0 +1,132 @@
+/**
+ * Article Search Component
+ * Search interface for articles with debounced input
+ */
+
+import { Loader2, Search, X } from "lucide-react"
+import { useEffect, useState } from "react"
+
+import { cn } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useArticleSearch } from "@/hooks/queries"
+import { ArticleCard } from "./ArticleCard"
+
+interface IProps {
+  className?: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Article search interface with results. */
+function ArticleSearch(props: IProps) {
+  const { className } = props
+
+  const [query, setQuery] = useState("")
+  const [debouncedQuery, setDebouncedQuery] = useState("")
+
+  // Debounce search query
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(query)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [query])
+
+  const { data, isLoading, error } = useArticleSearch(debouncedQuery)
+
+  const handleClear = () => {
+    setQuery("")
+    setDebouncedQuery("")
+  }
+
+  const showResults = debouncedQuery.length >= 2
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="text"
+          placeholder="Search articles..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="pl-9 pr-9"
+        />
+        {query && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleClear}
+            className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      {query.length > 0 && query.length < 2 && (
+        <p className="text-sm text-muted-foreground">
+          Type at least 2 characters to search
+        </p>
+      )}
+
+      {showResults && (
+        <div className="space-y-4">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              <span className="ml-2 text-muted-foreground">Searching...</span>
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center">
+              <p className="text-sm text-destructive">
+                Failed to search. Please try again.
+              </p>
+            </div>
+          )}
+
+          {data && !isLoading && (
+            <>
+              <p className="text-sm text-muted-foreground">
+                {data.count === 0
+                  ? "No results found"
+                  : `Found ${data.count} article${data.count !== 1 ? "s" : ""}`}
+              </p>
+
+              {data.data.length > 0 && (
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {data.data.map((article) => (
+                    <ArticleCard key={article.id} article={article} />
+                  ))}
+                </div>
+              )}
+
+              {data.count === 0 && (
+                <div className="py-8 text-center">
+                  <p className="text-muted-foreground">
+                    No articles found for &quot;{debouncedQuery}&quot;
+                  </p>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Try different keywords or browse by category
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ArticleSearch }

--- a/frontend/src/components/Articles/index.ts
+++ b/frontend/src/components/Articles/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Article components index
+ */
+
+export { ArticleCard } from "./ArticleCard"
+export { ArticleDetail } from "./ArticleDetail"
+export { ArticleList } from "./ArticleList"
+export { ArticleSearch } from "./ArticleSearch"

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -1,4 +1,12 @@
-import { Calculator, Compass, FileText, Home, Scale, Users } from "lucide-react"
+import {
+  BookOpen,
+  Calculator,
+  Compass,
+  FileText,
+  Home,
+  Scale,
+  Users,
+} from "lucide-react"
 
 import { SidebarAppearance } from "@/components/Common/Appearance"
 import { Logo } from "@/components/Common/Logo"
@@ -18,6 +26,7 @@ const baseItems: Item[] = [
   { icon: FileText, title: "Documents", path: "/documents" },
   { icon: Scale, title: "Laws", path: "/laws" },
   { icon: Calculator, title: "Calculators", path: "/calculators" },
+  { icon: BookOpen, title: "Articles", path: "/articles" },
 ]
 
 export function AppSidebar() {

--- a/frontend/src/hooks/mutations/index.ts
+++ b/frontend/src/hooks/mutations/index.ts
@@ -2,6 +2,7 @@
  * Mutation hooks index
  */
 
+export * from "./useArticleMutations"
 export * from "./useCalculatorMutations"
 export * from "./useDocumentMutations"
 export * from "./useJourneyMutations"

--- a/frontend/src/hooks/mutations/useArticleMutations.ts
+++ b/frontend/src/hooks/mutations/useArticleMutations.ts
@@ -1,0 +1,25 @@
+/**
+ * Article Mutation Hooks
+ * React Query hooks for content library mutations
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { queryKeys } from "@/query/queryKeys"
+import { ArticleService } from "@/services/ArticleService"
+
+/**
+ * Rate an article as helpful or not helpful
+ */
+export function useRateArticle() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ slug, isHelpful }: { slug: string; isHelpful: boolean }) =>
+      ArticleService.rateArticle(slug, isHelpful),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.articles.detail(variables.slug),
+      })
+    },
+  })
+}

--- a/frontend/src/hooks/queries/index.ts
+++ b/frontend/src/hooks/queries/index.ts
@@ -2,6 +2,7 @@
  * Query hooks index
  */
 
+export * from "./useArticleQueries"
 export * from "./useCalculatorQueries"
 export * from "./useDashboardQueries"
 export * from "./useDocumentQueries"

--- a/frontend/src/hooks/queries/useArticleQueries.ts
+++ b/frontend/src/hooks/queries/useArticleQueries.ts
@@ -1,0 +1,54 @@
+/**
+ * Article Query Hooks
+ * React Query hooks for content library data fetching
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import type { ArticleFilter } from "@/models/article"
+import { queryKeys } from "@/query/queryKeys"
+import { ArticleService } from "@/services/ArticleService"
+
+/**
+ * Get paginated list of published articles
+ */
+export function useArticles(filters?: ArticleFilter) {
+  return useQuery({
+    queryKey: queryKeys.articles.list(
+      filters as Record<string, unknown> | undefined,
+    ),
+    queryFn: () => ArticleService.getArticles(filters),
+  })
+}
+
+/**
+ * Get article detail by slug
+ */
+export function useArticle(slug: string) {
+  return useQuery({
+    queryKey: queryKeys.articles.detail(slug),
+    queryFn: () => ArticleService.getArticle(slug),
+    enabled: !!slug,
+  })
+}
+
+/**
+ * Search articles by query
+ */
+export function useArticleSearch(query: string, limit = 20) {
+  return useQuery({
+    queryKey: queryKeys.articles.search(query),
+    queryFn: () => ArticleService.searchArticles(query, limit),
+    enabled: query.length >= 2,
+  })
+}
+
+/**
+ * Get article categories with counts
+ */
+export function useArticleCategories() {
+  return useQuery({
+    queryKey: queryKeys.articles.categories(),
+    queryFn: () => ArticleService.getCategories(),
+    staleTime: 30 * 60 * 1000,
+  })
+}

--- a/frontend/src/models/article.ts
+++ b/frontend/src/models/article.ts
@@ -1,0 +1,64 @@
+/**
+ * Article models for the Content Library
+ */
+
+export type ArticleCategory =
+  | "buying_process"
+  | "costs_and_taxes"
+  | "regulations"
+  | "common_pitfalls"
+
+export type DifficultyLevel = "beginner" | "intermediate" | "advanced"
+
+export type ArticleStatus = "draft" | "published" | "archived"
+
+export interface ArticleSummary {
+  id: string
+  slug: string
+  title: string
+  category: ArticleCategory
+  difficultyLevel: DifficultyLevel
+  excerpt: string
+  readingTimeMinutes: number
+  viewCount: number
+  authorName: string
+  createdAt: string
+}
+
+export interface ArticleDetail extends ArticleSummary {
+  metaDescription: string
+  status: ArticleStatus
+  content: string
+  keyTakeaways: string[]
+  relatedLawIds: string[]
+  relatedCalculatorTypes: string[]
+  updatedAt: string
+  helpfulCount: number
+  notHelpfulCount: number
+  userRating: boolean | null
+  relatedArticles: ArticleSummary[]
+}
+
+export interface ArticleSearchResult extends ArticleSummary {
+  relevanceScore: number
+}
+
+export interface ArticleCategoryInfo {
+  key: string
+  name: string
+  description: string
+  articleCount: number
+}
+
+export interface ArticleFilter {
+  category?: ArticleCategory
+  difficultyLevel?: DifficultyLevel
+  page?: number
+  pageSize?: number
+}
+
+export interface ArticleRating {
+  helpfulCount: number
+  notHelpfulCount: number
+  userRating: boolean | null
+}

--- a/frontend/src/models/index.ts
+++ b/frontend/src/models/index.ts
@@ -3,6 +3,7 @@
  * Re-export all domain models
  */
 
+export * from "./article"
 export * from "./calculator"
 export * from "./dashboard"
 export * from "./journey"

--- a/frontend/src/query/queryKeys.ts
+++ b/frontend/src/query/queryKeys.ts
@@ -102,6 +102,18 @@ export const queryKeys = {
     preferences: () => [...queryKeys.notifications.all, "preferences"] as const,
   },
 
+  // Article queries
+  articles: {
+    all: ["articles"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.articles.all, "list", filters] as const,
+    detail: (slug: string) =>
+      [...queryKeys.articles.all, "detail", slug] as const,
+    search: (query: string) =>
+      [...queryKeys.articles.all, "search", query] as const,
+    categories: () => [...queryKeys.articles.all, "categories"] as const,
+  },
+
   // Dashboard queries
   dashboard: {
     all: ["dashboard"] as const,

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -22,11 +22,13 @@ import { Route as LayoutAdminRouteImport } from './routes/_layout/admin'
 import { Route as LayoutLawsIndexRouteImport } from './routes/_layout/laws/index'
 import { Route as LayoutJourneysIndexRouteImport } from './routes/_layout/journeys/index'
 import { Route as LayoutDocumentsIndexRouteImport } from './routes/_layout/documents/index'
+import { Route as LayoutArticlesIndexRouteImport } from './routes/_layout/articles/index'
 import { Route as LayoutLawsBookmarksRouteImport } from './routes/_layout/laws/bookmarks'
 import { Route as LayoutLawsLawIdRouteImport } from './routes/_layout/laws/$lawId'
 import { Route as LayoutJourneysNewRouteImport } from './routes/_layout/journeys/new'
 import { Route as LayoutJourneysJourneyIdRouteImport } from './routes/_layout/journeys/$journeyId'
 import { Route as LayoutDocumentsDocumentIdRouteImport } from './routes/_layout/documents/$documentId'
+import { Route as LayoutArticlesSlugRouteImport } from './routes/_layout/articles/$slug'
 import { Route as LayoutJourneysJourneyIdIndexRouteImport } from './routes/_layout/journeys/$journeyId.index'
 import { Route as LayoutJourneysJourneyIdPropertyEvaluationRouteImport } from './routes/_layout/journeys/$journeyId.property-evaluation'
 
@@ -94,6 +96,11 @@ const LayoutDocumentsIndexRoute = LayoutDocumentsIndexRouteImport.update({
   path: '/documents/',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutArticlesIndexRoute = LayoutArticlesIndexRouteImport.update({
+  id: '/articles/',
+  path: '/articles/',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutLawsBookmarksRoute = LayoutLawsBookmarksRouteImport.update({
   id: '/laws/bookmarks',
   path: '/laws/bookmarks',
@@ -120,6 +127,11 @@ const LayoutDocumentsDocumentIdRoute =
     path: '/documents/$documentId',
     getParentRoute: () => LayoutRoute,
   } as any)
+const LayoutArticlesSlugRoute = LayoutArticlesSlugRouteImport.update({
+  id: '/articles/$slug',
+  path: '/articles/$slug',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutJourneysJourneyIdIndexRoute =
   LayoutJourneysJourneyIdIndexRouteImport.update({
     id: '/',
@@ -143,11 +155,13 @@ export interface FileRoutesByFullPath {
   '/calculators': typeof LayoutCalculatorsRoute
   '/items': typeof LayoutItemsRoute
   '/settings': typeof LayoutSettingsRoute
+  '/articles/$slug': typeof LayoutArticlesSlugRoute
   '/documents/$documentId': typeof LayoutDocumentsDocumentIdRoute
   '/journeys/$journeyId': typeof LayoutJourneysJourneyIdRouteWithChildren
   '/journeys/new': typeof LayoutJourneysNewRoute
   '/laws/$lawId': typeof LayoutLawsLawIdRoute
   '/laws/bookmarks': typeof LayoutLawsBookmarksRoute
+  '/articles/': typeof LayoutArticlesIndexRoute
   '/documents/': typeof LayoutDocumentsIndexRoute
   '/journeys/': typeof LayoutJourneysIndexRoute
   '/laws/': typeof LayoutLawsIndexRoute
@@ -164,10 +178,12 @@ export interface FileRoutesByTo {
   '/items': typeof LayoutItemsRoute
   '/settings': typeof LayoutSettingsRoute
   '/': typeof LayoutIndexRoute
+  '/articles/$slug': typeof LayoutArticlesSlugRoute
   '/documents/$documentId': typeof LayoutDocumentsDocumentIdRoute
   '/journeys/new': typeof LayoutJourneysNewRoute
   '/laws/$lawId': typeof LayoutLawsLawIdRoute
   '/laws/bookmarks': typeof LayoutLawsBookmarksRoute
+  '/articles': typeof LayoutArticlesIndexRoute
   '/documents': typeof LayoutDocumentsIndexRoute
   '/journeys': typeof LayoutJourneysIndexRoute
   '/laws': typeof LayoutLawsIndexRoute
@@ -186,11 +202,13 @@ export interface FileRoutesById {
   '/_layout/items': typeof LayoutItemsRoute
   '/_layout/settings': typeof LayoutSettingsRoute
   '/_layout/': typeof LayoutIndexRoute
+  '/_layout/articles/$slug': typeof LayoutArticlesSlugRoute
   '/_layout/documents/$documentId': typeof LayoutDocumentsDocumentIdRoute
   '/_layout/journeys/$journeyId': typeof LayoutJourneysJourneyIdRouteWithChildren
   '/_layout/journeys/new': typeof LayoutJourneysNewRoute
   '/_layout/laws/$lawId': typeof LayoutLawsLawIdRoute
   '/_layout/laws/bookmarks': typeof LayoutLawsBookmarksRoute
+  '/_layout/articles/': typeof LayoutArticlesIndexRoute
   '/_layout/documents/': typeof LayoutDocumentsIndexRoute
   '/_layout/journeys/': typeof LayoutJourneysIndexRoute
   '/_layout/laws/': typeof LayoutLawsIndexRoute
@@ -209,11 +227,13 @@ export interface FileRouteTypes {
     | '/calculators'
     | '/items'
     | '/settings'
+    | '/articles/$slug'
     | '/documents/$documentId'
     | '/journeys/$journeyId'
     | '/journeys/new'
     | '/laws/$lawId'
     | '/laws/bookmarks'
+    | '/articles/'
     | '/documents/'
     | '/journeys/'
     | '/laws/'
@@ -230,10 +250,12 @@ export interface FileRouteTypes {
     | '/items'
     | '/settings'
     | '/'
+    | '/articles/$slug'
     | '/documents/$documentId'
     | '/journeys/new'
     | '/laws/$lawId'
     | '/laws/bookmarks'
+    | '/articles'
     | '/documents'
     | '/journeys'
     | '/laws'
@@ -251,11 +273,13 @@ export interface FileRouteTypes {
     | '/_layout/items'
     | '/_layout/settings'
     | '/_layout/'
+    | '/_layout/articles/$slug'
     | '/_layout/documents/$documentId'
     | '/_layout/journeys/$journeyId'
     | '/_layout/journeys/new'
     | '/_layout/laws/$lawId'
     | '/_layout/laws/bookmarks'
+    | '/_layout/articles/'
     | '/_layout/documents/'
     | '/_layout/journeys/'
     | '/_layout/laws/'
@@ -364,6 +388,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutDocumentsIndexRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/articles/': {
+      id: '/_layout/articles/'
+      path: '/articles'
+      fullPath: '/articles/'
+      preLoaderRoute: typeof LayoutArticlesIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/laws/bookmarks': {
       id: '/_layout/laws/bookmarks'
       path: '/laws/bookmarks'
@@ -397,6 +428,13 @@ declare module '@tanstack/react-router' {
       path: '/documents/$documentId'
       fullPath: '/documents/$documentId'
       preLoaderRoute: typeof LayoutDocumentsDocumentIdRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/articles/$slug': {
+      id: '/_layout/articles/$slug'
+      path: '/articles/$slug'
+      fullPath: '/articles/$slug'
+      preLoaderRoute: typeof LayoutArticlesSlugRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/journeys/$journeyId/': {
@@ -439,11 +477,13 @@ interface LayoutRouteChildren {
   LayoutItemsRoute: typeof LayoutItemsRoute
   LayoutSettingsRoute: typeof LayoutSettingsRoute
   LayoutIndexRoute: typeof LayoutIndexRoute
+  LayoutArticlesSlugRoute: typeof LayoutArticlesSlugRoute
   LayoutDocumentsDocumentIdRoute: typeof LayoutDocumentsDocumentIdRoute
   LayoutJourneysJourneyIdRoute: typeof LayoutJourneysJourneyIdRouteWithChildren
   LayoutJourneysNewRoute: typeof LayoutJourneysNewRoute
   LayoutLawsLawIdRoute: typeof LayoutLawsLawIdRoute
   LayoutLawsBookmarksRoute: typeof LayoutLawsBookmarksRoute
+  LayoutArticlesIndexRoute: typeof LayoutArticlesIndexRoute
   LayoutDocumentsIndexRoute: typeof LayoutDocumentsIndexRoute
   LayoutJourneysIndexRoute: typeof LayoutJourneysIndexRoute
   LayoutLawsIndexRoute: typeof LayoutLawsIndexRoute
@@ -455,11 +495,13 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutItemsRoute: LayoutItemsRoute,
   LayoutSettingsRoute: LayoutSettingsRoute,
   LayoutIndexRoute: LayoutIndexRoute,
+  LayoutArticlesSlugRoute: LayoutArticlesSlugRoute,
   LayoutDocumentsDocumentIdRoute: LayoutDocumentsDocumentIdRoute,
   LayoutJourneysJourneyIdRoute: LayoutJourneysJourneyIdRouteWithChildren,
   LayoutJourneysNewRoute: LayoutJourneysNewRoute,
   LayoutLawsLawIdRoute: LayoutLawsLawIdRoute,
   LayoutLawsBookmarksRoute: LayoutLawsBookmarksRoute,
+  LayoutArticlesIndexRoute: LayoutArticlesIndexRoute,
   LayoutDocumentsIndexRoute: LayoutDocumentsIndexRoute,
   LayoutJourneysIndexRoute: LayoutJourneysIndexRoute,
   LayoutLawsIndexRoute: LayoutLawsIndexRoute,

--- a/frontend/src/routes/_layout/articles/$slug.tsx
+++ b/frontend/src/routes/_layout/articles/$slug.tsx
@@ -1,0 +1,59 @@
+/**
+ * Article Detail Page
+ * Displays full article with TOC, rating, and related content
+ */
+
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ArticleDetail } from "@/components/Articles"
+import { useArticle } from "@/hooks/queries"
+import type { ArticleDetail as ArticleDetailType } from "@/models/article"
+
+/******************************************************************************
+                              Route
+******************************************************************************/
+
+export const Route = createFileRoute("/_layout/articles/$slug")({
+  component: ArticleDetailPage,
+  head: () => ({
+    meta: [{ title: "Article - HeimPath" }],
+  }),
+})
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Article detail page. */
+function ArticleDetailPage() {
+  const { slug } = Route.useParams()
+
+  const { data: article, isLoading, error } = useArticle(slug)
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
+          <h2 className="text-lg font-semibold text-destructive">
+            Failed to load article
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            The article could not be found or there was an error loading it.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (isLoading || !article) {
+    return <ArticleDetail article={{} as ArticleDetailType} isLoading />
+  }
+
+  return <ArticleDetail article={article} />
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default ArticleDetailPage

--- a/frontend/src/routes/_layout/articles/index.tsx
+++ b/frontend/src/routes/_layout/articles/index.tsx
@@ -1,0 +1,73 @@
+/**
+ * Articles List Page
+ * Browse and search the content library
+ */
+
+import { createFileRoute } from "@tanstack/react-router"
+import { BookOpen, Search } from "lucide-react"
+import { useState } from "react"
+import { ArticleList, ArticleSearch } from "@/components/Articles"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+/******************************************************************************
+                              Route
+******************************************************************************/
+
+export const Route = createFileRoute("/_layout/articles/")({
+  component: ArticlesPage,
+  head: () => ({
+    meta: [{ title: "Content Library - HeimPath" }],
+  }),
+})
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Articles listing page. */
+function ArticlesPage() {
+  const [activeTab, setActiveTab] = useState<string>("browse")
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <BookOpen className="h-6 w-6" />
+          Content Library
+        </h1>
+        <p className="text-muted-foreground">
+          In-depth guides to buying property in Germany
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="browse" className="gap-2">
+            <BookOpen className="h-4 w-4" />
+            Browse
+          </TabsTrigger>
+          <TabsTrigger value="search" className="gap-2">
+            <Search className="h-4 w-4" />
+            Search
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="browse" className="mt-6">
+          <ArticleList showCategoryFilter pageSize={12} />
+        </TabsContent>
+
+        <TabsContent value="search" className="mt-6">
+          <ArticleSearch />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default ArticlesPage

--- a/frontend/src/services/ArticleService.ts
+++ b/frontend/src/services/ArticleService.ts
@@ -1,0 +1,138 @@
+/**
+ * Article Service
+ * Handles all API calls related to the content library
+ */
+
+import { OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+import type {
+  ArticleCategoryInfo,
+  ArticleDetail,
+  ArticleFilter,
+  ArticleRating,
+  ArticleSearchResult,
+  ArticleSummary,
+} from "@/models/article"
+import { PATHS } from "./common/Paths"
+
+interface ArticleListResponse {
+  data: ArticleSummary[]
+  total: number
+  page: number
+  pageSize: number
+  count: number
+}
+
+interface ArticleSearchResponse {
+  data: ArticleSearchResult[]
+  count: number
+  query: string
+}
+
+/******************************************************************************
+                              Functions
+******************************************************************************/
+
+/** Convert a snake_case string to camelCase. */
+function snakeToCamel(str: string): string {
+  return str.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase())
+}
+
+/** Recursively convert all object keys from snake_case to camelCase. */
+function transformKeys<T>(obj: unknown): T {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => transformKeys(item)) as T
+  }
+  if (obj !== null && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj as Record<string, unknown>).map(([key, value]) => [
+        snakeToCamel(key),
+        transformKeys(value),
+      ]),
+    ) as T
+  }
+  return obj as T
+}
+
+/******************************************************************************
+                              Service
+******************************************************************************/
+
+class ArticleServiceClass {
+  /**
+   * Get paginated list of published articles
+   */
+  async getArticles(
+    filters?: ArticleFilter,
+  ): Promise<{ data: ArticleSummary[]; total: number }> {
+    const params = new URLSearchParams()
+    if (filters?.category) params.append("category", filters.category)
+    if (filters?.difficultyLevel)
+      params.append("difficulty_level", filters.difficultyLevel)
+    params.append("page", String(filters?.page ?? 1))
+    params.append("page_size", String(filters?.pageSize ?? 20))
+
+    const url = `${PATHS.ARTICLES.LIST}?${params.toString()}`
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url,
+    })
+    const transformed = transformKeys<ArticleListResponse>(response)
+    return { data: transformed.data, total: transformed.total }
+  }
+
+  /**
+   * Get article detail by slug
+   */
+  async getArticle(slug: string): Promise<ArticleDetail> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url: PATHS.ARTICLES.DETAIL(slug),
+    })
+    return transformKeys<ArticleDetail>(response)
+  }
+
+  /**
+   * Search articles
+   */
+  async searchArticles(
+    query: string,
+    limit = 20,
+  ): Promise<ArticleSearchResponse> {
+    const params = new URLSearchParams({
+      q: query,
+      limit: String(limit),
+    })
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url: `${PATHS.ARTICLES.SEARCH}?${params.toString()}`,
+    })
+    return transformKeys<ArticleSearchResponse>(response)
+  }
+
+  /**
+   * Get article categories with counts
+   */
+  async getCategories(): Promise<ArticleCategoryInfo[]> {
+    const response = await request<unknown[]>(OpenAPI, {
+      method: "GET",
+      url: PATHS.ARTICLES.CATEGORIES,
+    })
+    return transformKeys<ArticleCategoryInfo[]>(response)
+  }
+
+  /**
+   * Rate an article as helpful or not
+   */
+  async rateArticle(slug: string, isHelpful: boolean): Promise<ArticleRating> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "POST",
+      url: PATHS.ARTICLES.RATE(slug),
+      body: { is_helpful: isHelpful },
+      mediaType: "application/json",
+    })
+    return transformKeys<ArticleRating>(response)
+  }
+}
+
+export const ArticleService = new ArticleServiceClass()

--- a/frontend/src/services/common/Paths.ts
+++ b/frontend/src/services/common/Paths.ts
@@ -96,6 +96,15 @@ export const PATHS = {
     DELETE: (id: string) => `${API_V1}/notifications/${id}`,
   },
 
+  // Articles (Content Library)
+  ARTICLES: {
+    LIST: `${API_V1}/articles`,
+    SEARCH: `${API_V1}/articles/search`,
+    DETAIL: (slug: string) => `${API_V1}/articles/${slug}`,
+    CATEGORIES: `${API_V1}/articles/categories`,
+    RATE: (slug: string) => `${API_V1}/articles/${slug}/rate`,
+  },
+
   // Dashboard
   DASHBOARD: {
     OVERVIEW: `${API_V1}/dashboard`,

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -2,6 +2,7 @@
  * Services index
  */
 
+export { ArticleService } from "./ArticleService"
 export { CalculatorService } from "./CalculatorService"
 export {
   clearAuthToken,


### PR DESCRIPTION
## Summary
- Add full content library with Article + ArticleRating models, PostgreSQL full-text search (TSVECTOR + GIN), 4 categories, 3 difficulty levels, reading time calculation, view tracking, and helpfulness ratings
- Backend: article service (CRUD + search), public/auth/admin API endpoints, `OptionalCurrentUser` dependency for public endpoints with optional auth, 12 seeded articles via Alembic migration
- Frontend: article list with category/difficulty filters, full-text search with debounce, article detail with markdown rendering (react-markdown), TOC, key takeaways, rating widget, social sharing, and related articles

## Test plan
- [x] 30/30 tests pass (16 API route + 14 service unit tests)
- [x] `ruff check` passes on all backend files
- [x] `bunx biome check` passes on all frontend files
- [x] `bunx tsc --noEmit` passes with 0 errors
- [x] Both Alembic migrations apply cleanly (schema + seed data)
- [ ] Verify `GET /api/v1/articles` returns 12 seeded articles
- [ ] Verify `GET /api/v1/articles/search?q=property` returns relevant results
- [ ] Verify `GET /api/v1/articles/{slug}` increments view count
- [ ] Verify rating and admin CRUD endpoints work end-to-end
- [ ] Verify frontend article pages render correctly