### PR TITLE
feat: add delete journey frontend and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 HeimPath is a comprehensive platform helping foreign investors and immigrants navigate the German property buying process. The platform combines guided journeys, legal knowledge, document translation, and financial calculators to make property buying in Germany accessible and transparent.
 
+## Environments
+
+| Environment | URL | Deploys from |
+|-------------|-----|--------------|
+| Production | https://heimpath.com | Manual (`workflow_dispatch` with image tag) |
+| Staging | https://staging.heimpath.com | Automatic on push to `main` |
+| Local | http://localhost:5173 (frontend), http://localhost:8000 (backend) | `docker compose up` |
+
 ## Features
 
 ### Core Features
@@ -11,6 +19,7 @@ HeimPath is a comprehensive platform helping foreign investors and immigrants na
   - 15+ customizable steps based on user profile
   - Task tracking and progress monitoring
   - Personalization based on property type, financing, residency status
+  - Journey deletion with confirmation
 
 - **Legal Knowledge Base** - Comprehensive database of 50+ German real estate laws
   - Laws translated and explained in plain English
@@ -20,11 +29,19 @@ HeimPath is a comprehensive platform helping foreign investors and immigrants na
   - Bookmark functionality for quick reference
   - Laws automatically surfaced at relevant journey steps
 
-- **Document Translation** - AI-powered translation of German legal documents (Coming Soon)
+- **Financial Calculators**
+  - Property Evaluation calculator with investment analysis
+  - Hidden costs calculator
+  - ROI calculator
+  - Financing eligibility checker
+
+- **Document Translation** - AI-powered translation of German legal documents
   - Risk warnings for legal/financial terms
   - Confidence scores for translations
 
-- **Financial Calculators** - Hidden costs calculator, ROI calculator, financing eligibility (Coming Soon)
+- **Dashboard** - Overview of active journeys, recent activity, and recommendations
+
+- **Notification System** - In-app notifications with read/unread tracking and preferences
 
 ### Technical Features
 
@@ -46,22 +63,27 @@ HeimPath is a comprehensive platform helping foreign investors and immigrants na
 - **SQLModel/SQLAlchemy** - Python ORM
 - **Pydantic** - Data validation and settings management
 - **Alembic** - Database migrations
-- **Pytest** - Testing framework (271+ tests)
+- **Pytest** - Testing framework
 
 ### Frontend
 - **React** - Frontend library
 - **TypeScript** - Type-safe JavaScript
+- **TanStack Router** - Type-safe routing
+- **TanStack Query** - Server state management
 - **Tailwind CSS** - Utility-first CSS framework
 - **Vite** - Fast build tool
 
 ### Infrastructure
-- **Docker Compose** - Container orchestration
+- **Azure Container Apps** - Cloud hosting (staging and production)
+- **Docker Compose** - Local development and container orchestration
 - **Traefik** - Reverse proxy with automatic HTTPS
+- **GHCR** - Container image registry
 - **GitHub Actions** - CI/CD pipelines
+- **Sentry** - Error monitoring (optional)
 
 ### Integrations
 - **Stripe** - Payment processing
-- **DeepL** - Document translation (planned)
+- **Azure Translator** - Document translation
 
 ## Getting Started
 
@@ -75,7 +97,7 @@ HeimPath is a comprehensive platform helping foreign investors and immigrants na
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/your-org/heimpath.git
+git clone https://github.com/Sojisoyoye/heimpath.git
 cd heimpath
 ```
 
@@ -101,12 +123,41 @@ Key environment variables to configure:
 
 | Variable | Description |
 |----------|-------------|
+| `DOMAIN` | Domain for Traefik routing (default: `localhost`) |
+| `FRONTEND_HOST` | Frontend URL for email links |
+| `ENVIRONMENT` | `local`, `staging`, or `production` |
 | `SECRET_KEY` | JWT secret key |
 | `POSTGRES_PASSWORD` | Database password |
 | `FIRST_SUPERUSER` | Admin email |
 | `FIRST_SUPERUSER_PASSWORD` | Admin password |
 | `STRIPE_SECRET_KEY` | Stripe API key (optional) |
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook secret (optional) |
+| `SENTRY_DSN` | Sentry DSN for error tracking (optional) |
+| `AZURE_TRANSLATOR_KEY` | Azure Translator API key (optional) |
+| `AZURE_TRANSLATOR_REGION` | Azure Translator region (optional) |
+
+See `.env.example` for the full list.
+
+## CI/CD
+
+### Pipelines
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| **Test Backend** | Push to `main`, PRs | Runs backend test suite |
+| **Pre-commit** | PRs | Linting and formatting checks |
+| **Playwright** | PRs | End-to-end tests |
+| **Security Scan** | PRs | Dependency vulnerability scanning |
+| **Deploy Staging** | Push to `main` | Builds images, runs migrations, deploys to staging |
+| **Deploy Production** | Manual trigger | Deploys a staging-tested image tag to production |
+
+### Deployment Flow
+
+1. Push to `main` triggers staging deployment automatically
+2. Images are built and pushed to GHCR with tag `staging-<commit-sha>`
+3. Database migrations run via Azure Container Apps job
+4. Backend and frontend containers are updated on Azure Container Apps
+5. After verifying staging, manually trigger production deployment with the tested image tag
 
 ## API Overview
 
@@ -125,9 +176,11 @@ Key environment variables to configure:
 - `POST /api/v1/journeys/` - Create new journey
 - `GET /api/v1/journeys/` - List user journeys
 - `GET /api/v1/journeys/{id}` - Get journey details
+- `DELETE /api/v1/journeys/{id}` - Delete a journey (soft delete)
 - `GET /api/v1/journeys/{id}/progress` - Get journey progress
 - `GET /api/v1/journeys/{id}/next-step` - Get next recommended step
 - `PATCH /api/v1/journeys/{id}/steps/{step_id}` - Update step status
+- `PATCH /api/v1/journeys/{id}/steps/{step_id}/tasks/{task_id}` - Toggle task completion
 
 ### Legal Knowledge Base
 - `GET /api/v1/laws/` - List laws with filtering
@@ -136,6 +189,16 @@ Key environment variables to configure:
 - `GET /api/v1/laws/categories` - List law categories
 - `POST /api/v1/laws/{id}/bookmark` - Bookmark a law
 - `GET /api/v1/laws/bookmarks` - Get user bookmarks
+
+### Calculators
+- `POST /api/v1/calculators/hidden-costs` - Calculate hidden costs
+- `POST /api/v1/calculators/roi` - Calculate ROI
+- `POST /api/v1/calculators/property-evaluations` - Evaluate property
+
+### Dashboard
+- `GET /api/v1/dashboard` - Dashboard overview
+- `GET /api/v1/dashboard/activity` - Recent activity
+- `GET /api/v1/dashboard/recommendations` - Personalized recommendations
 
 ### Subscriptions
 - `GET /api/v1/subscriptions/current` - Get current subscription
@@ -146,23 +209,29 @@ Key environment variables to configure:
 
 ```
 heimpath/
+├── .github/workflows/      # CI/CD pipelines
 ├── backend/
 │   ├── app/
-│   │   ├── api/           # API routes
-│   │   ├── models/        # Database models
-│   │   ├── schemas/       # Pydantic schemas
-│   │   ├── services/      # Business logic
-│   │   ├── repository/    # Data access layer
-│   │   └── core/          # Configuration
-│   ├── tests/             # Test suite
-│   └── alembic/           # Database migrations
+│   │   ├── api/             # API routes
+│   │   ├── models/          # Database models
+│   │   ├── schemas/         # Pydantic schemas
+│   │   ├── services/        # Business logic
+│   │   ├── repository/      # Data access layer
+│   │   └── core/            # Configuration
+│   ├── tests/               # Test suite
+│   └── alembic/             # Database migrations
 ├── frontend/
 │   ├── src/
-│   │   ├── components/    # React components
-│   │   ├── services/      # API client
-│   │   └── hooks/         # Custom hooks
-│   └── tests/             # Frontend tests
-└── docker-compose.yml
+│   │   ├── components/      # React components
+│   │   ├── hooks/           # Custom hooks (queries + mutations)
+│   │   ├── models/          # TypeScript models
+│   │   ├── routes/          # TanStack Router pages
+│   │   ├── services/        # API service layer
+│   │   └── query/           # Query key factory
+│   └── tests/               # E2E tests (Playwright)
+├── compose.yml              # Docker Compose (local + deployment)
+├── compose.override.yml     # Local development overrides
+└── compose.traefik.yml      # Traefik reverse proxy config
 ```
 
 ## Development
@@ -173,8 +242,8 @@ heimpath/
 # Backend tests
 docker compose exec backend pytest -v
 
-# Frontend tests
-cd frontend && npm test
+# Frontend E2E tests
+cd frontend && bunx playwright test
 ```
 
 ### Database Migrations
@@ -187,25 +256,22 @@ docker compose exec backend alembic revision --autogenerate -m "Description"
 docker compose exec backend alembic upgrade head
 ```
 
+### Generate Frontend API Client
+
+```bash
+# Automatic (requires backend venv active)
+bash ./scripts/generate-client.sh
+
+# Manual
+cd frontend && bun run generate-client
+```
+
 ### Code Quality
 
-The project follows strict coding standards:
-- Python: PEP 8, type hints required
-- TypeScript: Strict mode enabled
-- Tests required for all new features
-
-## Roadmap
-
-- [x] User authentication and authorization
-- [x] Guided property journeys
-- [x] Legal knowledge base with search
-- [x] Stripe subscription integration
-- [ ] Document translation with DeepL
-- [ ] Hidden costs calculator
-- [ ] ROI calculator
-- [ ] Financing eligibility checker
-- [ ] User dashboard
-- [ ] Notification system
+The project uses pre-commit hooks and CI checks:
+- **Python**: Ruff (linting + formatting), type hints required
+- **TypeScript**: Biome (linting + formatting), strict mode enabled
+- **Commit messages**: Conventional commits enforced via commitlint
 
 ## License
 

--- a/frontend/src/components/Journey/DeleteJourneyDialog.tsx
+++ b/frontend/src/components/Journey/DeleteJourneyDialog.tsx
@@ -1,0 +1,66 @@
+/**
+ * Delete Journey Confirmation Dialog
+ * Reusable dialog for confirming journey deletion
+ */
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface IProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  isPending?: boolean
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Confirmation dialog for journey deletion. */
+function DeleteJourneyDialog(props: IProps) {
+  const { open, onOpenChange, onConfirm, isPending = false } = props
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete Journey</DialogTitle>
+          <DialogDescription>
+            This will permanently remove the journey and all its progress. Are
+            you sure? You will not be able to undo this action.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="mt-4">
+          <DialogClose asChild>
+            <Button variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { DeleteJourneyDialog }

--- a/frontend/src/components/Journey/JourneyCard.tsx
+++ b/frontend/src/components/Journey/JourneyCard.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Link } from "@tanstack/react-router"
-import { ArrowRight, Calendar, Home, MapPin } from "lucide-react"
+import { ArrowRight, Calendar, Home, MapPin, Trash2 } from "lucide-react"
 import { GERMAN_STATES, PHASE_COLORS, PROPERTY_TYPES } from "@/common/constants"
 import { cn, formatDate, formatEur } from "@/common/utils"
 import { Badge } from "@/components/ui/badge"
@@ -23,6 +23,7 @@ import { ProgressBar } from "./ProgressBar"
 interface IProps {
   journey: JourneyPublic
   progress?: JourneyProgress
+  onDelete?: (id: string) => void
   className?: string
 }
 
@@ -36,7 +37,7 @@ interface IProps {
 
 /** Default component. Journey summary card. */
 function JourneyCard(props: IProps) {
-  const { journey, progress, className } = props
+  const { journey, progress, onDelete, className } = props
 
   const stateName =
     GERMAN_STATES.find((s) => s.code === journey.property_location)?.name ||
@@ -71,14 +72,30 @@ function JourneyCard(props: IProps) {
               </span>
             </CardDescription>
           </div>
-          <Badge
-            variant="secondary"
-            className={cn("shrink-0", PHASE_COLORS[journey.current_phase])}
-          >
-            {journey.current_phase.charAt(0).toUpperCase() +
-              journey.current_phase.slice(1)}{" "}
-            Phase
-          </Badge>
+          <div className="flex shrink-0 items-center gap-1">
+            {onDelete && (
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Delete journey"
+                className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                onClick={(e) => {
+                  e.preventDefault()
+                  onDelete(journey.id)
+                }}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+            <Badge
+              variant="secondary"
+              className={cn("shrink-0", PHASE_COLORS[journey.current_phase])}
+            >
+              {journey.current_phase.charAt(0).toUpperCase() +
+                journey.current_phase.slice(1)}{" "}
+              Phase
+            </Badge>
+          </div>
         </div>
       </CardHeader>
 

--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Link } from "@tanstack/react-router"
-import { ArrowLeft, Calendar, Home, MapPin, Wallet } from "lucide-react"
+import { ArrowLeft, Calendar, Home, MapPin, Trash2, Wallet } from "lucide-react"
 import {
   FINANCING_TYPES,
   GERMAN_STATES,
@@ -27,6 +27,7 @@ interface IProps {
   journey: JourneyPublic
   progress?: JourneyProgress
   onTaskToggle: (stepId: string, taskId: string, isCompleted: boolean) => void
+  onDelete?: () => void
   isLoading?: boolean
   className?: string
 }
@@ -163,6 +164,7 @@ function JourneyDetail(props: IProps) {
     journey,
     progress,
     onTaskToggle,
+    onDelete,
     isLoading = false,
     className,
   } = props
@@ -193,17 +195,30 @@ function JourneyDetail(props: IProps) {
             <h1 className="text-xl font-bold sm:text-2xl">
               {propertyLabel} in {stateName}
             </h1>
-            <Badge
-              variant="secondary"
-              className={cn(
-                "shrink-0 text-sm",
-                PHASE_COLORS[journey.current_phase],
+            <div className="flex shrink-0 items-center gap-1">
+              {onDelete && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Delete journey"
+                  className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                  onClick={onDelete}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
               )}
-            >
-              {journey.current_phase.charAt(0).toUpperCase() +
-                journey.current_phase.slice(1)}{" "}
-              Phase
-            </Badge>
+              <Badge
+                variant="secondary"
+                className={cn(
+                  "shrink-0 text-sm",
+                  PHASE_COLORS[journey.current_phase],
+                )}
+              >
+                {journey.current_phase.charAt(0).toUpperCase() +
+                  journey.current_phase.slice(1)}{" "}
+                Phase
+              </Badge>
+            </div>
           </div>
           <p className="text-sm text-muted-foreground sm:text-base">
             Your personalized property buying journey

--- a/frontend/src/components/Journey/JourneyList.tsx
+++ b/frontend/src/components/Journey/JourneyList.tsx
@@ -15,6 +15,7 @@ import { JourneyCard } from "./JourneyCard"
 interface IProps {
   journeys: JourneyPublic[]
   isLoading?: boolean
+  onDelete?: (id: string) => void
   className?: string
 }
 
@@ -69,7 +70,7 @@ function JourneyCardSkeleton() {
 
 /** Default component. List of journey cards. */
 function JourneyList(props: IProps) {
-  const { journeys, isLoading = false, className } = props
+  const { journeys, isLoading = false, onDelete, className } = props
 
   if (isLoading) {
     return (
@@ -90,7 +91,7 @@ function JourneyList(props: IProps) {
   return (
     <div className={cn("grid gap-6 md:grid-cols-2 lg:grid-cols-3", className)}>
       {journeys.map((journey) => (
-        <JourneyCard key={journey.id} journey={journey} />
+        <JourneyCard key={journey.id} journey={journey} onDelete={onDelete} />
       ))}
     </div>
   )

--- a/frontend/src/components/Journey/index.ts
+++ b/frontend/src/components/Journey/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { BudgetInput } from "./BudgetInput"
+export { DeleteJourneyDialog } from "./DeleteJourneyDialog"
 export { FinancingSelector } from "./FinancingSelector"
 // Dashboard components
 export { JourneyCard } from "./JourneyCard"

--- a/frontend/src/hooks/mutations/useJourneyMutations.ts
+++ b/frontend/src/hooks/mutations/useJourneyMutations.ts
@@ -30,6 +30,23 @@ export function useCreateJourney() {
 }
 
 /**
+ * Delete a journey
+ */
+export function useDeleteJourney() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (journeyId: string) => JourneyService.deleteJourney(journeyId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.journeys.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.dashboard.overview(),
+      })
+    },
+  })
+}
+
+/**
  * Update a journey step status
  */
 export function useUpdateStep(journeyId: string) {

--- a/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
+++ b/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
@@ -3,11 +3,16 @@
  * Displays a single journey with all steps
  */
 
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
 
-import { JourneyDetail } from "@/components/Journey"
-import { useUpdateTask } from "@/hooks/mutations/useJourneyMutations"
+import { DeleteJourneyDialog, JourneyDetail } from "@/components/Journey"
+import {
+  useDeleteJourney,
+  useUpdateTask,
+} from "@/hooks/mutations/useJourneyMutations"
 import { useJourney, useJourneyProgress } from "@/hooks/queries"
+import useCustomToast from "@/hooks/useCustomToast"
 
 /******************************************************************************
                               Route
@@ -27,6 +32,7 @@ export const Route = createFileRoute("/_layout/journeys/$journeyId/")({
 /** Default component. Journey detail page. */
 function JourneyDetailPage() {
   const { journeyId } = Route.useParams()
+  const navigate = useNavigate()
 
   const {
     data: journey,
@@ -36,6 +42,9 @@ function JourneyDetailPage() {
 
   const { data: progress } = useJourneyProgress(journeyId)
   const updateTask = useUpdateTask(journeyId)
+  const deleteJourney = useDeleteJourney()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
   const handleTaskToggle = (
     stepId: string,
@@ -43,6 +52,18 @@ function JourneyDetailPage() {
     isCompleted: boolean,
   ) => {
     updateTask.mutate({ stepId, taskId, data: { is_completed: isCompleted } })
+  }
+
+  const handleDeleteConfirm = () => {
+    deleteJourney.mutate(journeyId, {
+      onSuccess: () => {
+        showSuccessToast("Journey deleted successfully")
+        navigate({ to: "/journeys" })
+      },
+      onError: () => {
+        showErrorToast("Failed to delete journey. Please try again.")
+      },
+    })
   }
 
   if (journeyError) {
@@ -67,11 +88,20 @@ function JourneyDetailPage() {
   }
 
   return (
-    <JourneyDetail
-      journey={journey}
-      progress={progress}
-      onTaskToggle={handleTaskToggle}
-    />
+    <>
+      <JourneyDetail
+        journey={journey}
+        progress={progress}
+        onTaskToggle={handleTaskToggle}
+        onDelete={() => setShowDeleteDialog(true)}
+      />
+      <DeleteJourneyDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        onConfirm={handleDeleteConfirm}
+        isPending={deleteJourney.isPending}
+      />
+    </>
   )
 }
 

--- a/frontend/src/routes/_layout/journeys/index.tsx
+++ b/frontend/src/routes/_layout/journeys/index.tsx
@@ -5,9 +5,12 @@
 
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { Plus } from "lucide-react"
-import { JourneyList } from "@/components/Journey"
+import { useState } from "react"
+import { DeleteJourneyDialog, JourneyList } from "@/components/Journey"
 import { Button } from "@/components/ui/button"
+import { useDeleteJourney } from "@/hooks/mutations/useJourneyMutations"
 import { useJourneys } from "@/hooks/queries"
+import useCustomToast from "@/hooks/useCustomToast"
 
 /******************************************************************************
                               Route
@@ -27,6 +30,22 @@ export const Route = createFileRoute("/_layout/journeys/")({
 /** Default component. Journeys list page. */
 function JourneysPage() {
   const { data: journeys = [], isLoading, error } = useJourneys()
+  const deleteJourney = useDeleteJourney()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [deleteId, setDeleteId] = useState<string | null>(null)
+
+  const handleDeleteConfirm = () => {
+    if (!deleteId) return
+    deleteJourney.mutate(deleteId, {
+      onSuccess: () => {
+        showSuccessToast("Journey deleted successfully")
+        setDeleteId(null)
+      },
+      onError: () => {
+        showErrorToast("Failed to delete journey. Please try again.")
+      },
+    })
+  }
 
   return (
     <div className="space-y-6">
@@ -52,8 +71,21 @@ function JourneysPage() {
           </p>
         </div>
       ) : (
-        <JourneyList journeys={journeys} isLoading={isLoading} />
+        <JourneyList
+          journeys={journeys}
+          isLoading={isLoading}
+          onDelete={setDeleteId}
+        />
       )}
+
+      <DeleteJourneyDialog
+        open={deleteId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteId(null)
+        }}
+        onConfirm={handleDeleteConfirm}
+        isPending={deleteJourney.isPending}
+      />
     </div>
   )
 }

--- a/frontend/src/services/JourneyService.ts
+++ b/frontend/src/services/JourneyService.ts
@@ -123,6 +123,16 @@ class JourneyServiceClass {
   }
 
   /**
+   * Delete a journey
+   */
+  async deleteJourney(journeyId: string): Promise<void> {
+    await request<void>(OpenAPI, {
+      method: "DELETE",
+      url: PATHS.JOURNEYS.DETAIL(journeyId),
+    })
+  }
+
+  /**
    * Update property goals for a journey (Step 1)
    */
   async updatePropertyGoals(


### PR DESCRIPTION
## Summary

- Wire up the existing `DELETE /api/v1/journeys/{id}` backend endpoint on the frontend
- Add trash icon button to journey cards (list view) and journey detail page header
- Confirmation dialog before deletion with loading state
- Success toast + query invalidation (journeys list + dashboard) on delete
- Update root README with staging/production URLs, deployment flow, CI/CD docs, and current feature set

## Changes

| File | Change |
|------|--------|
| `Paths.ts` | Add `DELETE` path to `JOURNEYS` |
| `JourneyService.ts` | Add `deleteJourney()` method |
| `useJourneyMutations.ts` | Add `useDeleteJourney` hook |
| `DeleteJourneyDialog.tsx` | New reusable confirmation dialog |
| `JourneyCard.tsx` | Add optional `onDelete` prop + trash icon |
| `JourneyDetail.tsx` | Add optional `onDelete` prop + trash icon |
| `JourneyList.tsx` | Pass through `onDelete` to cards |
| `journeys/index.tsx` (route) | Wire delete with dialog + toast |
| `$journeyId.index.tsx` (route) | Wire delete with dialog + navigate + toast |
| `README.md` | Environments, CI/CD, deployment flow, features |

## Test plan

- [ ] Journey list: click trash icon on card → confirmation dialog → confirm → card disappears, success toast
- [ ] Journey list: click trash icon → cancel → nothing happens
- [ ] Journey detail: click trash icon in header → confirm → redirect to `/journeys`, success toast
- [ ] Dashboard overview updates after deletion
- [ ] Error case: API failure shows error toast, dialog stays open