### PR TITLE
fix(notifications): review and fix task 10 — notifications and reminders

### DIFF
--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -19,9 +19,9 @@ router = APIRouter(prefix="/notifications", tags=["notifications"])
 
 
 @router.get("/", response_model=NotificationListResponse)
-def list_notifications(
+async def list_notifications(
+    current_user: CurrentUser,
     session: Session = Depends(get_db),
-    current_user: CurrentUser = None,
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
     unread_only: bool = Query(False),
@@ -37,9 +37,9 @@ def list_notifications(
 
 
 @router.put("/mark-all-read", response_model=Message)
-def mark_all_notifications_read(
+async def mark_all_notifications_read(
+    current_user: CurrentUser,
     session: Session = Depends(get_db),
-    current_user: CurrentUser = None,
 ) -> Message:
     """Mark all unread notifications as read."""
     count = notification_service.mark_all_read(session, current_user.id)
@@ -47,19 +47,19 @@ def mark_all_notifications_read(
 
 
 @router.get("/preferences", response_model=NotificationPreferencesResponse)
-def get_notification_preferences(
+async def get_notification_preferences(
+    current_user: CurrentUser,
     session: Session = Depends(get_db),
-    current_user: CurrentUser = None,
 ) -> NotificationPreferencesResponse:
     """Get notification preferences for the current user."""
     return notification_service.get_preferences(session, current_user.id)
 
 
 @router.put("/preferences", response_model=NotificationPreferencesResponse)
-def update_notification_preferences(
+async def update_notification_preferences(
     request: NotificationPreferencesUpdate,
+    current_user: CurrentUser,
     session: Session = Depends(get_db),
-    current_user: CurrentUser = None,
 ) -> NotificationPreferencesResponse:
     """Update notification preferences for the current user."""
     return notification_service.update_preferences(
@@ -68,10 +68,10 @@ def update_notification_preferences(
 
 
 @router.put("/{notification_id}/read", response_model=NotificationResponse)
-def mark_notification_read(
+async def mark_notification_read(
     notification_id: uuid.UUID,
+    current_user: CurrentUser,
     session: Session = Depends(get_db),
-    current_user: CurrentUser = None,
 ) -> NotificationResponse:
     """Mark a single notification as read."""
     notification = notification_service.mark_as_read(
@@ -97,10 +97,10 @@ def mark_notification_read(
     "/{notification_id}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-def delete_notification(
+async def delete_notification(
     notification_id: uuid.UUID,
+    current_user: CurrentUser,
     session: Session = Depends(get_db),
-    current_user: CurrentUser = None,
 ) -> None:
     """Delete a notification."""
     deleted = notification_service.delete_notification(


### PR DESCRIPTION
## Summary

- Make all 6 route handlers `async def` (were `sync def`)
- Remove `= None` default from `CurrentUser` on all handlers — prevents auth bypass on user-scoped endpoints
- Reorder parameters: `current_user: CurrentUser` before `session: Session = Depends(get_db)` per project convention

Affected handlers: `list_notifications`, `mark_all_notifications_read`, `get_notification_preferences`, `update_notification_preferences`, `mark_notification_read`, `delete_notification`

## Test plan

- [ ] All 579 existing unit tests pass (`pytest tests/ -k "not api"`)
- [ ] Unauthenticated requests return 401 on all notification endpoints
- [ ] CI: `test-backend`, `commitlint`, `pre-commit` pass