### PR TITLE
refactor: frontend component standards (task 11)

### DIFF
--- a/frontend/src/components/Admin/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser.tsx
@@ -52,7 +52,7 @@ const formSchema = z
 
 type FormData = z.infer<typeof formSchema>
 
-const AddUser = () => {
+function AddUser() {
   const [isOpen, setIsOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()

--- a/frontend/src/components/Admin/DeleteUser.tsx
+++ b/frontend/src/components/Admin/DeleteUser.tsx
@@ -93,4 +93,3 @@ function DeleteUser({ id, onSuccess }: DeleteUserProps) {
 }
 
 export default DeleteUser
-

--- a/frontend/src/components/Admin/DeleteUser.tsx
+++ b/frontend/src/components/Admin/DeleteUser.tsx
@@ -24,7 +24,7 @@ interface DeleteUserProps {
   onSuccess: () => void
 }
 
-const DeleteUser = ({ id, onSuccess }: DeleteUserProps) => {
+function DeleteUser({ id, onSuccess }: DeleteUserProps) {
   const [isOpen, setIsOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
@@ -93,3 +93,4 @@ const DeleteUser = ({ id, onSuccess }: DeleteUserProps) => {
 }
 
 export default DeleteUser
+

--- a/frontend/src/components/Admin/EditUser.tsx
+++ b/frontend/src/components/Admin/EditUser.tsx
@@ -56,7 +56,7 @@ interface EditUserProps {
   onSuccess: () => void
 }
 
-const EditUser = ({ user, onSuccess }: EditUserProps) => {
+function EditUser({ user, onSuccess }: EditUserProps) {
   const [isOpen, setIsOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()

--- a/frontend/src/components/Admin/UserActionsMenu.tsx
+++ b/frontend/src/components/Admin/UserActionsMenu.tsx
@@ -16,7 +16,7 @@ interface UserActionsMenuProps {
   user: UserPublic
 }
 
-export const UserActionsMenu = ({ user }: UserActionsMenuProps) => {
+export function UserActionsMenu({ user }: UserActionsMenuProps) {
   const [open, setOpen] = useState(false)
   const { user: currentUser } = useAuth()
 

--- a/frontend/src/components/Common/Appearance.tsx
+++ b/frontend/src/components/Common/Appearance.tsx
@@ -14,7 +14,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar"
 
-type LucideIcon = React.FC<React.SVGProps<SVGSVGElement>>
+type LucideIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>
 
 const ICON_MAP: Record<Theme, LucideIcon> = {
   system: Monitor,
@@ -22,7 +22,7 @@ const ICON_MAP: Record<Theme, LucideIcon> = {
   dark: Moon,
 }
 
-export const SidebarAppearance = () => {
+export function SidebarAppearance() {
   const { isMobile } = useSidebar()
   const { setTheme, theme } = useTheme()
   const Icon = ICON_MAP[theme]
@@ -66,7 +66,7 @@ export const SidebarAppearance = () => {
   )
 }
 
-export const Appearance = () => {
+export function Appearance() {
   const { setTheme } = useTheme()
 
   return (

--- a/frontend/src/components/Common/ErrorComponent.tsx
+++ b/frontend/src/components/Common/ErrorComponent.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 
-const ErrorComponent = () => {
+function ErrorComponent() {
   return (
     <div
       className="flex min-h-screen items-center justify-center flex-col p-4"

--- a/frontend/src/components/Common/NotFound.tsx
+++ b/frontend/src/components/Common/NotFound.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 
-const NotFound = () => {
+function NotFound() {
   return (
     <div
       className="flex min-h-screen items-center justify-center flex-col p-4"

--- a/frontend/src/components/Documents/DocumentCard.tsx
+++ b/frontend/src/components/Documents/DocumentCard.tsx
@@ -148,4 +148,4 @@ function DocumentCard(props: IProps) {
                               Export
 ******************************************************************************/
 
-export { DocumentCard, DOCUMENT_TYPE_LABELS, STATUS_CONFIG }
+export { DOCUMENT_TYPE_LABELS, DocumentCard, STATUS_CONFIG }

--- a/frontend/src/components/Items/AddItem.tsx
+++ b/frontend/src/components/Items/AddItem.tsx
@@ -37,7 +37,7 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>
 
-const AddItem = () => {
+function AddItem() {
   const [isOpen, setIsOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()

--- a/frontend/src/components/Items/DeleteItem.tsx
+++ b/frontend/src/components/Items/DeleteItem.tsx
@@ -24,7 +24,7 @@ interface DeleteItemProps {
   onSuccess: () => void
 }
 
-const DeleteItem = ({ id, onSuccess }: DeleteItemProps) => {
+function DeleteItem({ id, onSuccess }: DeleteItemProps) {
   const [isOpen, setIsOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()

--- a/frontend/src/components/Items/EditItem.tsx
+++ b/frontend/src/components/Items/EditItem.tsx
@@ -42,7 +42,7 @@ interface EditItemProps {
   onSuccess: () => void
 }
 
-const EditItem = ({ item, onSuccess }: EditItemProps) => {
+function EditItem({ item, onSuccess }: EditItemProps) {
   const [isOpen, setIsOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()

--- a/frontend/src/components/Items/ItemActionsMenu.tsx
+++ b/frontend/src/components/Items/ItemActionsMenu.tsx
@@ -15,7 +15,7 @@ interface ItemActionsMenuProps {
   item: ItemPublic
 }
 
-export const ItemActionsMenu = ({ item }: ItemActionsMenuProps) => {
+export function ItemActionsMenu({ item }: ItemActionsMenuProps) {
   const [open, setOpen] = useState(false)
 
   return (

--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -24,7 +24,7 @@ import { ProgressBar } from "./ProgressBar"
 import { StepCard } from "./StepCard"
 
 interface IProps {
-  journey: JourneyPublic
+  journey?: JourneyPublic
   progress?: JourneyProgress
   onTaskToggle: (stepId: string, taskId: string, isCompleted: boolean) => void
   onDelete?: () => void
@@ -169,7 +169,7 @@ function JourneyDetail(props: IProps) {
     className,
   } = props
 
-  if (isLoading) {
+  if (isLoading || !journey) {
     return <JourneyDetailSkeleton />
   }
 

--- a/frontend/src/components/Pending/PendingItems.tsx
+++ b/frontend/src/components/Pending/PendingItems.tsx
@@ -10,38 +10,38 @@ import {
 
 function PendingItems() {
   return (
-  <Table>
-    <TableHeader>
-      <TableRow>
-        <TableHead>ID</TableHead>
-        <TableHead>Title</TableHead>
-        <TableHead>Description</TableHead>
-        <TableHead>
-          <span className="sr-only">Actions</span>
-        </TableHead>
-      </TableRow>
-    </TableHeader>
-    <TableBody>
-      {Array.from({ length: 5 }).map((_, index) => (
-        <TableRow key={index}>
-          <TableCell>
-            <Skeleton className="h-4 w-64 font-mono" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-4 w-32" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-4 w-48" />
-          </TableCell>
-          <TableCell>
-            <div className="flex justify-end">
-              <Skeleton className="size-8 rounded-md" />
-            </div>
-          </TableCell>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>ID</TableHead>
+          <TableHead>Title</TableHead>
+          <TableHead>Description</TableHead>
+          <TableHead>
+            <span className="sr-only">Actions</span>
+          </TableHead>
         </TableRow>
-      ))}
-    </TableBody>
-  </Table>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <TableRow key={index}>
+            <TableCell>
+              <Skeleton className="h-4 w-64 font-mono" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-32" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-48" />
+            </TableCell>
+            <TableCell>
+              <div className="flex justify-end">
+                <Skeleton className="size-8 rounded-md" />
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   )
 }
 

--- a/frontend/src/components/Pending/PendingItems.tsx
+++ b/frontend/src/components/Pending/PendingItems.tsx
@@ -8,7 +8,8 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
-const PendingItems = () => (
+function PendingItems() {
+  return (
   <Table>
     <TableHeader>
       <TableRow>
@@ -41,6 +42,7 @@ const PendingItems = () => (
       ))}
     </TableBody>
   </Table>
-)
+  )
+}
 
 export default PendingItems

--- a/frontend/src/components/Pending/PendingUsers.tsx
+++ b/frontend/src/components/Pending/PendingUsers.tsx
@@ -10,45 +10,45 @@ import {
 
 function PendingUsers() {
   return (
-  <Table>
-    <TableHeader>
-      <TableRow>
-        <TableHead>Full Name</TableHead>
-        <TableHead>Email</TableHead>
-        <TableHead>Role</TableHead>
-        <TableHead>Status</TableHead>
-        <TableHead>
-          <span className="sr-only">Actions</span>
-        </TableHead>
-      </TableRow>
-    </TableHeader>
-    <TableBody>
-      {Array.from({ length: 5 }).map((_, index) => (
-        <TableRow key={index}>
-          <TableCell>
-            <Skeleton className="h-4 w-32" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-4 w-40" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-5 w-20 rounded-full" />
-          </TableCell>
-          <TableCell>
-            <div className="flex items-center gap-2">
-              <Skeleton className="size-2 rounded-full" />
-              <Skeleton className="h-4 w-12" />
-            </div>
-          </TableCell>
-          <TableCell>
-            <div className="flex justify-end">
-              <Skeleton className="size-8 rounded-md" />
-            </div>
-          </TableCell>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Full Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>
+            <span className="sr-only">Actions</span>
+          </TableHead>
         </TableRow>
-      ))}
-    </TableBody>
-  </Table>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <TableRow key={index}>
+            <TableCell>
+              <Skeleton className="h-4 w-32" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-40" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </TableCell>
+            <TableCell>
+              <div className="flex items-center gap-2">
+                <Skeleton className="size-2 rounded-full" />
+                <Skeleton className="h-4 w-12" />
+              </div>
+            </TableCell>
+            <TableCell>
+              <div className="flex justify-end">
+                <Skeleton className="size-8 rounded-md" />
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   )
 }
 

--- a/frontend/src/components/Pending/PendingUsers.tsx
+++ b/frontend/src/components/Pending/PendingUsers.tsx
@@ -8,7 +8,8 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
-const PendingUsers = () => (
+function PendingUsers() {
+  return (
   <Table>
     <TableHeader>
       <TableRow>
@@ -48,6 +49,7 @@ const PendingUsers = () => (
       ))}
     </TableBody>
   </Table>
-)
+  )
+}
 
 export default PendingUsers

--- a/frontend/src/components/Sidebar/User.tsx
+++ b/frontend/src/components/Sidebar/User.tsx
@@ -1,6 +1,7 @@
 import { Link as RouterLink } from "@tanstack/react-router"
 import { ChevronsUpDown, LogOut, Settings } from "lucide-react"
 
+import type { UserPublic } from "@/client"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -18,6 +19,10 @@ import {
 } from "@/components/ui/sidebar"
 import useAuth from "@/hooks/useAuth"
 import { getInitials } from "@/utils"
+
+interface IProps {
+  user: UserPublic | null | undefined
+}
 
 interface UserInfoProps {
   fullName?: string
@@ -40,7 +45,7 @@ function UserInfo({ fullName, email }: UserInfoProps) {
   )
 }
 
-export function User({ user }: { user: any }) {
+export function User({ user }: IProps) {
   const { logout } = useAuth()
   const { isMobile, setOpenMobile } = useSidebar()
 

--- a/frontend/src/components/Sidebar/User.tsx
+++ b/frontend/src/components/Sidebar/User.tsx
@@ -25,8 +25,8 @@ interface IProps {
 }
 
 interface UserInfoProps {
-  fullName?: string
-  email?: string
+  fullName?: string | null
+  email?: string | null
 }
 
 function UserInfo({ fullName, email }: UserInfoProps) {

--- a/frontend/src/components/UserSettings/ChangePassword.tsx
+++ b/frontend/src/components/UserSettings/ChangePassword.tsx
@@ -38,7 +38,7 @@ const formSchema = z
 
 type FormData = z.infer<typeof formSchema>
 
-const ChangePassword = () => {
+function ChangePassword() {
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),

--- a/frontend/src/components/UserSettings/DeleteAccount.tsx
+++ b/frontend/src/components/UserSettings/DeleteAccount.tsx
@@ -1,6 +1,6 @@
 import DeleteConfirmation from "./DeleteConfirmation"
 
-const DeleteAccount = () => {
+function DeleteAccount() {
   return (
     <div className="max-w-md mt-4 rounded-lg border border-destructive/50 p-4">
       <h3 className="font-semibold text-destructive">Delete Account</h3>

--- a/frontend/src/components/UserSettings/DeleteConfirmation.tsx
+++ b/frontend/src/components/UserSettings/DeleteConfirmation.tsx
@@ -18,7 +18,7 @@ import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import { handleError } from "@/utils"
 
-const DeleteConfirmation = () => {
+function DeleteConfirmation() {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { handleSubmit } = useForm()

--- a/frontend/src/components/UserSettings/UserInformation.tsx
+++ b/frontend/src/components/UserSettings/UserInformation.tsx
@@ -28,7 +28,7 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>
 
-const UserInformation = () => {
+function UserInformation() {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [editMode, setEditMode] = useState(false)

--- a/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
+++ b/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
@@ -82,9 +82,7 @@ function JourneyDetailPage() {
   }
 
   if (isLoadingJourney || !journey) {
-    return (
-      <JourneyDetail onTaskToggle={() => {}} isLoading />
-    )
+    return <JourneyDetail onTaskToggle={() => {}} isLoading />
   }
 
   return (

--- a/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
+++ b/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
@@ -83,7 +83,7 @@ function JourneyDetailPage() {
 
   if (isLoadingJourney || !journey) {
     return (
-      <JourneyDetail journey={{} as any} onTaskToggle={() => {}} isLoading />
+      <JourneyDetail onTaskToggle={() => {}} isLoading />
     )
   }
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -6,7 +6,7 @@ function extractErrorMessage(err: ApiError): string {
     return err.message
   }
 
-  const errDetail = (err.body as any)?.detail
+  const errDetail = (err.body as Record<string, unknown>)?.detail
   if (Array.isArray(errDetail) && errDetail.length > 0) {
     return errDetail[0].msg
   }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -10,7 +10,9 @@ function extractErrorMessage(err: ApiError): string {
   if (Array.isArray(errDetail) && errDetail.length > 0) {
     return errDetail[0].msg
   }
-  return errDetail || "Something went wrong."
+  return typeof errDetail === "string" && errDetail
+    ? errDetail
+    : "Something went wrong."
 }
 
 export const handleError = function (


### PR DESCRIPTION
## Summary

- Convert 16 arrow function components to `function` declarations across Admin, Common, Items, UserSettings, and Pending component directories
- Replace `React.FC` type alias with `React.ComponentType` in `Appearance.tsx`
- Remove `as any` casts: use `Record<string, unknown>` in `utils.ts` and make `JourneyDetail.journey` optional to eliminate `{} as any` in the journey route
- Make `JourneyDetail` guard `isLoading || !journey` so the skeleton renders correctly when journey data is absent

## Files changed (20)

| Area | Files |
|------|-------|
| Admin | `AddUser`, `DeleteUser`, `EditUser`, `UserActionsMenu` |
| Common | `Appearance`, `ErrorComponent`, `NotFound` |
| Items | `AddItem`, `DeleteItem`, `EditItem`, `ItemActionsMenu` |
| UserSettings | `ChangePassword`, `DeleteAccount`, `DeleteConfirmation`, `UserInformation` |
| Pending | `PendingItems`, `PendingUsers` |
| Journey | `JourneyDetail` (optional journey prop) |
| Route | `journeys/$journeyId.index.tsx` (remove `as any`) |
| Utils | `utils.ts` (remove `as any`) |

## Test plan

- [ ] Verify all converted components render correctly
- [ ] Confirm journey detail loading skeleton still displays when data is loading
- [ ] Confirm error toast still triggers on API errors (utils.ts change)
- [ ] Run pre-commit hooks (biome/ruff)