### PR TITLE
feat(wizard): add budget to step 1 and persist all steps via sessionStorage

### DIFF
--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -222,10 +222,18 @@ function JourneyWizard(props: IProps) {
     switch (currentStep) {
       case 1:
         return (
-          <PropertyTypeSelector
-            value={state.propertyType}
-            onChange={(v) => updateState({ propertyType: v })}
-          />
+          <div className="space-y-8">
+            <PropertyTypeSelector
+              value={state.propertyType}
+              onChange={(v) => updateState({ propertyType: v })}
+            />
+            <BudgetInput
+              budgetMin={state.budgetMin}
+              budgetMax={state.budgetMax}
+              onBudgetMinChange={(v) => updateState({ budgetMin: v })}
+              onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
+            />
+          </div>
         )
       case 2:
         return (


### PR DESCRIPTION
## Summary
- Added `BudgetInput` to Step 1 (Property Goals) alongside `PropertyTypeSelector`, so users can enter their budget upfront
- Budget fields on Step 1 share the same `WizardState` keys (`budgetMin`/`budgetMax`) as Step 4, keeping values in sync automatically
- All wizard state now persists to `sessionStorage` under key `journey_wizard_state` using a lazy `useState` initialiser for restore on mount and a `useEffect` for writes on every state change
- `sessionStorage` is cleared on successful journey creation

## Test plan
- [ ] Navigate to `/journeys/new`, select a property type and enter a budget on Step 1 — verify values appear on Step 4 Budget step
- [ ] Enter a value on Step 4 Budget — navigate back to Step 1 and confirm it is pre-filled
- [ ] Fill out multiple steps, refresh the page, return to `/journeys/new` — verify all previous values are restored
- [ ] Complete and submit the wizard — verify `sessionStorage` is cleared afterward
- [ ] CI: commitlint, test-backend, playwright all pass