### PR TITLE
chore(ci): add workflow_dispatch to deploy-staging workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -222,10 +222,18 @@ function JourneyWizard(props: IProps) {
     switch (currentStep) {
       case 1:
         return (
-          <PropertyTypeSelector
-            value={state.propertyType}
-            onChange={(v) => updateState({ propertyType: v })}
-          />
+          <div className="space-y-8">
+            <PropertyTypeSelector
+              value={state.propertyType}
+              onChange={(v) => updateState({ propertyType: v })}
+            />
+            <BudgetInput
+              budgetMin={state.budgetMin}
+              budgetMax={state.budgetMax}
+              onBudgetMinChange={(v) => updateState({ budgetMin: v })}
+              onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
+            />
+          </div>
         )
       case 2:
         return (


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `deploy-staging.yml` so the staging deploy can be triggered manually from the Actions tab
- Merging this PR also serves as the push event to deploy the current `main` (including PR #45 wizard budget field change, which did not trigger a deploy when merged)

## Test plan
- [ ] Merging this PR triggers a staging deploy via the push event
- [ ] After merge, the "Run workflow" button appears on the Deploy to Staging workflow page