### PR TITLE
feat(journey): pre-fill budget in property_goals from wizard questionnaire

### DIFF
--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -22,6 +22,10 @@ class PropertyGoals(BaseModel):
     # Property type preference (can differ from initial questionnaire)
     preferred_property_type: str | None = None
 
+    # Budget range (pre-filled from wizard questionnaire)
+    budget_min_euros: int | None = Field(default=None, ge=0)
+    budget_max_euros: int | None = Field(default=None, ge=0)
+
     # Room requirements
     min_rooms: int | None = Field(default=None, ge=1, le=10)
     min_bathrooms: int | None = Field(default=None, ge=1, le=5)
@@ -49,6 +53,8 @@ class PropertyGoalsUpdate(BaseModel):
     """Schema for updating property goals."""
 
     preferred_property_type: str | None = None
+    budget_min_euros: int | None = Field(default=None, ge=0)
+    budget_max_euros: int | None = Field(default=None, ge=0)
     min_rooms: int | None = Field(default=None, ge=1, le=10)
     min_bathrooms: int | None = Field(default=None, ge=1, le=5)
     preferred_floor: str | None = None
@@ -71,7 +77,8 @@ class QuestionnaireAnswers(BaseModel):
     financing_type: FinancingType
     is_first_time_buyer: bool = True
     has_german_residency: bool = False
-    budget_euros: int | None = Field(default=None, ge=0)
+    budget_euros: int | None = Field(default=None, ge=0)  # max budget
+    budget_min_euros: int | None = Field(default=None, ge=0)  # min budget
     target_purchase_date: datetime | None = None
 
 

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -423,7 +423,11 @@ def generate_journey(
         budget_euros=answers.budget_euros,
         target_purchase_date=answers.target_purchase_date,
         started_at=datetime.now(timezone.utc),
-        property_goals={"preferred_property_type": answers.property_type.value},
+        property_goals={
+            "preferred_property_type": answers.property_type.value,
+            "budget_min_euros": answers.budget_min_euros,
+            "budget_max_euros": answers.budget_euros,
+        },
     )
     session.add(journey)
     session.flush()  # Get journey ID

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -195,6 +195,65 @@ class TestGenerateJourney:
         assert journey.property_goals is not None
         assert journey.property_goals["preferred_property_type"] == "house"
 
+    def test_property_goals_budget_max_prefilled_from_budget_euros(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that property_goals.budget_max_euros is pre-filled from budget_euros."""
+        mock_session = MagicMock()
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(
+            session=mock_session,
+            user_id=user_id,
+            title="Test Journey",
+            answers=sample_answers,
+        )
+
+        assert journey.property_goals is not None
+        assert journey.property_goals["budget_max_euros"] == sample_answers.budget_euros
+
+    def test_property_goals_budget_min_prefilled_when_provided(
+        self,
+    ) -> None:
+        """Test that property_goals.budget_min_euros is pre-filled when provided."""
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="Berlin",
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=400000,
+            budget_min_euros=200000,
+        )
+        mock_session = MagicMock()
+
+        journey = generate_journey(
+            session=mock_session,
+            user_id=uuid.uuid4(),
+            title="Test Journey",
+            answers=answers,
+        )
+
+        assert journey.property_goals is not None
+        assert journey.property_goals["budget_min_euros"] == 200000
+        assert journey.property_goals["budget_max_euros"] == 400000
+
+    def test_property_goals_budget_min_none_when_not_provided(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that budget_min_euros is None in property_goals when not in questionnaire."""
+        mock_session = MagicMock()
+
+        journey = generate_journey(
+            session=mock_session,
+            user_id=uuid.uuid4(),
+            title="Test Journey",
+            answers=sample_answers,
+        )
+
+        assert journey.property_goals is not None
+        assert journey.property_goals["budget_min_euros"] is None
+
 
 class TestGetJourney:
     """Tests for getting journeys."""

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3919,6 +3919,30 @@ export const PropertyGoalsSchema = {
             ],
             title: 'Preferred Property Type'
         },
+        budget_min_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Min Euros'
+        },
+        budget_max_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Max Euros'
+        },
         min_rooms: {
             anyOf: [
                 {
@@ -4027,6 +4051,30 @@ export const PropertyGoalsUpdateSchema = {
                 }
             ],
             title: 'Preferred Property Type'
+        },
+        budget_min_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Min Euros'
+        },
+        budget_max_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Max Euros'
         },
         min_rooms: {
             anyOf: [
@@ -4191,6 +4239,18 @@ export const QuestionnaireAnswersSchema = {
                 }
             ],
             title: 'Budget Euros'
+        },
+        budget_min_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Min Euros'
         },
         target_purchase_date: {
             anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1167,6 +1167,8 @@ export type PropertyEvaluationSummary = {
  */
 export type PropertyGoals = {
     preferred_property_type?: (string | null);
+    budget_min_euros?: (number | null);
+    budget_max_euros?: (number | null);
     min_rooms?: (number | null);
     min_bathrooms?: (number | null);
     preferred_floor?: (string | null);
@@ -1183,6 +1185,8 @@ export type PropertyGoals = {
  */
 export type PropertyGoalsUpdate = {
     preferred_property_type?: (string | null);
+    budget_min_euros?: (number | null);
+    budget_max_euros?: (number | null);
     min_rooms?: (number | null);
     min_bathrooms?: (number | null);
     preferred_floor?: (string | null);
@@ -1214,6 +1218,7 @@ export type QuestionnaireAnswers = {
     is_first_time_buyer?: boolean;
     has_german_residency?: boolean;
     budget_euros?: (number | null);
+    budget_min_euros?: (number | null);
     target_purchase_date?: (string | null);
 };
 

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -183,6 +183,7 @@ function JourneyWizard(props: IProps) {
         is_first_time_buyer: true, // Default value, can be added to wizard later
         has_german_residency: hasGermanResidency,
         budget_euros: state.budgetMax || state.budgetMin,
+        budget_min_euros: state.budgetMin,
         target_purchase_date: state.targetDate,
       },
     }

--- a/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
+++ b/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
@@ -35,6 +35,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { useUpdatePropertyGoals } from "@/hooks/mutations/useJourneyMutations"
 import type { PropertyGoals } from "@/models/journey"
+import { BudgetInput } from "../BudgetInput"
 
 interface IProps {
   journeyId: string
@@ -133,6 +134,8 @@ function PropertyGoalsForm(props: IProps) {
 
   const [goals, setGoals] = useState<PropertyGoals>({
     preferred_property_type: initialGoals?.preferred_property_type || "",
+    budget_min_euros: initialGoals?.budget_min_euros,
+    budget_max_euros: initialGoals?.budget_max_euros,
     min_rooms: initialGoals?.min_rooms || undefined,
     min_bathrooms: initialGoals?.min_bathrooms || undefined,
     preferred_floor: initialGoals?.preferred_floor || "",
@@ -149,6 +152,8 @@ function PropertyGoalsForm(props: IProps) {
     if (initialGoals) {
       setGoals({
         preferred_property_type: initialGoals.preferred_property_type || "",
+        budget_min_euros: initialGoals.budget_min_euros,
+        budget_max_euros: initialGoals.budget_max_euros,
         min_rooms: initialGoals.min_rooms,
         min_bathrooms: initialGoals.min_bathrooms,
         preferred_floor: initialGoals.preferred_floor || "",
@@ -218,6 +223,18 @@ function PropertyGoalsForm(props: IProps) {
             ))}
           </div>
         </div>
+
+        {/* Budget */}
+        <BudgetInput
+          budgetMin={goals.budget_min_euros}
+          budgetMax={goals.budget_max_euros}
+          onBudgetMinChange={(v) =>
+            setGoals((prev) => ({ ...prev, budget_min_euros: v }))
+          }
+          onBudgetMaxChange={(v) =>
+            setGoals((prev) => ({ ...prev, budget_max_euros: v }))
+          }
+        />
 
         {/* Number of Rooms */}
         <div className="space-y-3">

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -90,6 +90,7 @@ export interface QuestionnaireAnswers {
   is_first_time_buyer: boolean
   has_german_residency: boolean
   budget_euros?: number
+  budget_min_euros?: number
   target_purchase_date?: string
 }
 
@@ -127,6 +128,8 @@ export interface NextStepRecommendation {
 /** Property goals from Step 1 */
 export interface PropertyGoals {
   preferred_property_type?: string
+  budget_min_euros?: number
+  budget_max_euros?: number
   min_rooms?: number
   min_bathrooms?: number
   preferred_floor?: string
@@ -141,6 +144,8 @@ export interface PropertyGoals {
 /** Property goals update request */
 export interface PropertyGoalsUpdate {
   preferred_property_type?: string
+  budget_min_euros?: number
+  budget_max_euros?: number
   min_rooms?: number
   min_bathrooms?: number
   preferred_floor?: string


### PR DESCRIPTION
## Summary
- Extends the property_goals pre-fill from PR #47 to also include budget: when a journey is created, `property_goals.budget_min_euros` and `property_goals.budget_max_euros` are now seeded from the wizard's min/max budget inputs
- Adds `budget_min_euros` + `budget_max_euros` to `PropertyGoals` and `PropertyGoalsUpdate` backend schemas (stored in existing JSONB column — no DB migration needed)
- Adds `budget_min_euros` to `QuestionnaireAnswers` so the wizard can pass both min and max to the backend
- Adds budget inputs to the "Define Your Property Goals" Research Step 1 form using the existing `BudgetInput` component

## Data flow
```
Wizard (budgetMin/budgetMax)
  → POST /api/v1/journeys { questionnaire: { budget_euros: max, budget_min_euros: min } }
  → generate_journey() seeds property_goals = { ..., budget_min_euros, budget_max_euros }
  → GET /api/v1/journeys/:id → journey.property_goals
  → PropertyGoalsForm(initialGoals=journey.property_goals) → pre-filled inputs
```

## Test Plan
- [x] `test_property_goals_budget_max_prefilled_from_budget_euros` — max value seeded from budget_euros
- [x] `test_property_goals_budget_min_prefilled_when_provided` — min+max both seeded
- [x] `test_property_goals_budget_min_none_when_not_provided` — min is None when wizard had none
- [x] All 7 TestGenerateJourney tests pass
- [x] `npm run build` passes with no TypeScript errors