### PR TITLE
fix(wizard): remove budget input from step 1

### DIFF
--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -223,18 +223,10 @@ function JourneyWizard(props: IProps) {
     switch (currentStep) {
       case 1:
         return (
-          <div className="space-y-8">
-            <PropertyTypeSelector
-              value={state.propertyType}
-              onChange={(v) => updateState({ propertyType: v })}
-            />
-            <BudgetInput
-              budgetMin={state.budgetMin}
-              budgetMax={state.budgetMax}
-              onBudgetMinChange={(v) => updateState({ budgetMin: v })}
-              onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
-            />
-          </div>
+          <PropertyTypeSelector
+            value={state.propertyType}
+            onChange={(v) => updateState({ propertyType: v })}
+          />
         )
       case 2:
         return (


### PR DESCRIPTION
## Summary
- Removes `BudgetInput` from wizard Step 1, where it was duplicating the dedicated Step 4 (Budget)
- Step 1 now renders only `PropertyTypeSelector`
- Budget state (`budgetMin`/`budgetMax`) is unchanged and still collected in Step 4

## Test plan
- [ ] Navigate to Create Journey — verify Step 1 shows only the property type selector
- [ ] Complete wizard through Step 4 — verify budget fields appear correctly with cost breakdown
- [ ] Submit wizard — verify `budget_euros` is still sent to the backend from Step 4 values
- [ ] Verify build passes (`bun run build`)