### PR TITLE
feat(journey): step capsule not started/in progress/completed transitions

### DIFF
--- a/backend/app/alembic/versions/f6a7b8c9d0e1_add_market_insights_to_journey.py
+++ b/backend/app/alembic/versions/f6a7b8c9d0e1_add_market_insights_to_journey.py
@@ -1,0 +1,32 @@
+"""Add market_insights to journey
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-05 10:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "f6a7b8c9d0e1"
+down_revision = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add market_insights JSONB column to journey table
+    op.add_column(
+        "journey",
+        sa.Column(
+            "market_insights",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("journey", "market_insights")

--- a/backend/app/alembic/versions/o6k7l8m9n0p1_add_market_insights_to_journey.py
+++ b/backend/app/alembic/versions/o6k7l8m9n0p1_add_market_insights_to_journey.py
@@ -1,7 +1,7 @@
 """Add market_insights to journey
 
-Revision ID: f6a7b8c9d0e1
-Revises: e5f6a7b8c9d0
+Revision ID: o6k7l8m9n0p1
+Revises: n5j6k7l8m9o1
 Create Date: 2026-04-05 10:00:00.000000
 
 """
@@ -10,8 +10,8 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "f6a7b8c9d0e1"
-down_revision = "e5f6a7b8c9d0"
+revision = "o6k7l8m9n0p1"
+down_revision = "n5j6k7l8m9o1"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/routes/journeys.py
+++ b/backend/app/api/routes/journeys.py
@@ -30,13 +30,13 @@ from app.schemas.journey import (
 )
 from app.services import journey_service as svc
 from app.services import notification_service
-from app.services.market_data import compute_market_insights
 from app.services.journey_service import (
     InvalidStepTransitionError,
     JourneyError,
     JourneyNotFoundError,
     StepNotFoundError,
 )
+from app.services.market_data import compute_market_insights
 
 router = APIRouter(prefix="/journeys", tags=["journeys"])
 

--- a/backend/app/api/routes/journeys.py
+++ b/backend/app/api/routes/journeys.py
@@ -23,12 +23,14 @@ from app.schemas.journey import (
     JourneyTaskResponse,
     JourneyTaskUpdate,
     JourneyUpdate,
+    MarketInsightsData,
     NextStepResponse,
     PropertyGoals,
     PropertyGoalsUpdate,
 )
 from app.services import journey_service as svc
 from app.services import notification_service
+from app.services.market_data import compute_market_insights
 from app.services.journey_service import (
     InvalidStepTransitionError,
     JourneyError,
@@ -99,6 +101,9 @@ def _build_journey_response(journey: Journey) -> JourneyResponse:
         target_purchase_date=journey.target_purchase_date,
         property_goals=PropertyGoals(**journey.property_goals)
         if journey.property_goals
+        else None,
+        market_insights=MarketInsightsData(**journey.market_insights)
+        if journey.market_insights
         else None,
         started_at=journey.started_at,
         completed_at=journey.completed_at,
@@ -192,6 +197,9 @@ async def get_journey(
         target_purchase_date=journey.target_purchase_date,
         property_goals=PropertyGoals(**journey.property_goals)
         if journey.property_goals
+        else None,
+        market_insights=MarketInsightsData(**journey.market_insights)
+        if journey.market_insights
         else None,
         started_at=journey.started_at,
         completed_at=journey.completed_at,
@@ -490,6 +498,18 @@ async def update_property_goals(
         existing_goals[field] = value
 
     journey.property_goals = existing_goals
+
+    # Auto-generate market insights when Step 1 is completed for the first time.
+    # Insights are only computed once; re-saving an already-completed form does
+    # not overwrite previously generated insights.
+    if existing_goals.get("is_completed") and journey.market_insights is None:
+        journey.market_insights = compute_market_insights(
+            property_location=journey.property_location,
+            property_type=journey.property_type,
+            budget_euros=journey.budget_euros,
+            property_goals=existing_goals,
+        )
+
     session.add(journey)
     session.commit()
     session.refresh(journey)

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -118,6 +118,9 @@ class Journey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # Property goals (Step 1 user input)
     property_goals = Column(JSONB, nullable=True)
 
+    # Market insights (generated after Step 1 completion)
+    market_insights = Column(JSONB, nullable=True)
+
     # Progress tracking
     started_at = Column(DateTime(timezone=True), nullable=True)
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -25,7 +25,7 @@ class MarketInsightsData(BaseModel):
     price_range_min: float
     price_range_max: float
     agent_fee_percent: float
-    trend: str  # "rising" | "stable" | "falling"
+    trend: Literal["rising", "stable", "falling"]
     hotspots: list[str]
     transfer_tax_rate: float
     property_type: str

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -13,6 +13,30 @@ from app.models.journey import (
     StepStatus,
 )
 
+# Market Insights schema (generated after Step 1 completion)
+
+
+class MarketInsightsData(BaseModel):
+    """Computed market insights stored on the journey after Step 1 completion."""
+
+    state_code: str
+    state_name: str
+    avg_price_per_sqm: float
+    price_range_min: float
+    price_range_max: float
+    agent_fee_percent: float
+    trend: str  # "rising" | "stable" | "falling"
+    hotspots: list[str]
+    transfer_tax_rate: float
+    property_type: str
+    type_multiplier: float
+    adjusted_avg_price_per_sqm: float
+    adjusted_min_price_per_sqm: float
+    adjusted_max_price_per_sqm: float
+    estimated_size_sqm: int | None = None
+    generated_at: str
+
+
 # Property Goals schemas (Step 1)
 
 
@@ -209,6 +233,7 @@ class JourneyResponse(BaseModel):
     budget_euros: int | None = None
     target_purchase_date: datetime | None = None
     property_goals: PropertyGoals | None = None
+    market_insights: MarketInsightsData | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
     is_active: bool

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -742,6 +742,12 @@ def _sync_step_status_from_tasks(
             journey.completed_at = None
             session.add(journey)
 
+    elif not any_complete and step.status == StepStatus.IN_PROGRESS:
+        # All tasks unchecked on an in_progress step → revert to not_started
+        step.status = StepStatus.NOT_STARTED
+        step.started_at = None
+        session.add(step)
+
     elif any_complete and step.status == StepStatus.NOT_STARTED:
         # First task checked → move to in_progress
         step.status = StepStatus.IN_PROGRESS

--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -1,0 +1,218 @@
+"""Market data constants and computation for Step 2: Market Insights.
+
+This module provides static German real estate market data and a function to
+compute personalised market insights for a journey based on location, property
+type, and budget.  The data mirrors the constants used in the frontend
+(frontend/src/common/constants/propertyGoals.ts and index.ts) so that the
+backend and frontend are always in sync.
+"""
+
+from datetime import datetime, timezone
+
+# ---------------------------------------------------------------------------
+# Static data: German states
+# ---------------------------------------------------------------------------
+
+GERMAN_STATES: dict[str, dict] = {
+    "BW": {"name": "Baden-Württemberg", "transfer_tax_rate": 5.0},
+    "BY": {"name": "Bayern", "transfer_tax_rate": 3.5},
+    "BE": {"name": "Berlin", "transfer_tax_rate": 6.0},
+    "BB": {"name": "Brandenburg", "transfer_tax_rate": 6.5},
+    "HB": {"name": "Bremen", "transfer_tax_rate": 5.0},
+    "HH": {"name": "Hamburg", "transfer_tax_rate": 5.5},
+    "HE": {"name": "Hessen", "transfer_tax_rate": 6.0},
+    "MV": {"name": "Mecklenburg-Vorpommern", "transfer_tax_rate": 6.0},
+    "NI": {"name": "Niedersachsen", "transfer_tax_rate": 5.0},
+    "NW": {"name": "Nordrhein-Westfalen", "transfer_tax_rate": 6.5},
+    "RP": {"name": "Rheinland-Pfalz", "transfer_tax_rate": 5.0},
+    "SL": {"name": "Saarland", "transfer_tax_rate": 6.5},
+    "SN": {"name": "Sachsen", "transfer_tax_rate": 5.5},
+    "ST": {"name": "Sachsen-Anhalt", "transfer_tax_rate": 5.0},
+    "SH": {"name": "Schleswig-Holstein", "transfer_tax_rate": 6.5},
+    "TH": {"name": "Thüringen", "transfer_tax_rate": 6.5},
+}
+
+# Average prices per sqm by German state (2024 estimates) — mirrors frontend
+MARKET_DATA_BY_STATE: dict[str, dict] = {
+    "BW": {
+        "avg_price_per_sqm": 3800,
+        "price_range": {"min": 2500, "max": 6000},
+        "agent_fee_percent": 3.57,
+        "trend": "stable",
+        "hotspots": ["Stuttgart", "Freiburg", "Karlsruhe"],
+    },
+    "BY": {
+        "avg_price_per_sqm": 4500,
+        "price_range": {"min": 2800, "max": 9000},
+        "agent_fee_percent": 3.57,
+        "trend": "stable",
+        "hotspots": ["Munich", "Nuremberg", "Augsburg"],
+    },
+    "BE": {
+        "avg_price_per_sqm": 5200,
+        "price_range": {"min": 3500, "max": 8000},
+        "agent_fee_percent": 3.57,
+        "trend": "rising",
+        "hotspots": ["Mitte", "Prenzlauer Berg", "Kreuzberg"],
+    },
+    "BB": {
+        "avg_price_per_sqm": 2800,
+        "price_range": {"min": 1800, "max": 4500},
+        "agent_fee_percent": 3.57,
+        "trend": "rising",
+        "hotspots": ["Potsdam", "Cottbus", "Brandenburg an der Havel"],
+    },
+    "HB": {
+        "avg_price_per_sqm": 2900,
+        "price_range": {"min": 2000, "max": 4500},
+        "agent_fee_percent": 2.98,
+        "trend": "stable",
+        "hotspots": ["Bremen-Mitte", "Schwachhausen", "Horn-Lehe"],
+    },
+    "HH": {
+        "avg_price_per_sqm": 5800,
+        "price_range": {"min": 4000, "max": 10000},
+        "agent_fee_percent": 3.12,
+        "trend": "stable",
+        "hotspots": ["Eppendorf", "Winterhude", "Eimsbüttel"],
+    },
+    "HE": {
+        "avg_price_per_sqm": 3600,
+        "price_range": {"min": 2200, "max": 7000},
+        "agent_fee_percent": 2.98,
+        "trend": "stable",
+        "hotspots": ["Frankfurt", "Wiesbaden", "Darmstadt"],
+    },
+    "MV": {
+        "avg_price_per_sqm": 2200,
+        "price_range": {"min": 1400, "max": 4000},
+        "agent_fee_percent": 2.98,
+        "trend": "rising",
+        "hotspots": ["Rostock", "Schwerin", "Greifswald"],
+    },
+    "NI": {
+        "avg_price_per_sqm": 2600,
+        "price_range": {"min": 1800, "max": 4500},
+        "agent_fee_percent": 2.98,
+        "trend": "stable",
+        "hotspots": ["Hannover", "Braunschweig", "Oldenburg"],
+    },
+    "NW": {
+        "avg_price_per_sqm": 3200,
+        "price_range": {"min": 2000, "max": 6000},
+        "agent_fee_percent": 3.57,
+        "trend": "stable",
+        "hotspots": ["Düsseldorf", "Cologne", "Münster"],
+    },
+    "RP": {
+        "avg_price_per_sqm": 2400,
+        "price_range": {"min": 1600, "max": 4000},
+        "agent_fee_percent": 2.98,
+        "trend": "stable",
+        "hotspots": ["Mainz", "Koblenz", "Trier"],
+    },
+    "SL": {
+        "avg_price_per_sqm": 2000,
+        "price_range": {"min": 1400, "max": 3200},
+        "agent_fee_percent": 3.57,
+        "trend": "stable",
+        "hotspots": ["Saarbrücken", "Neunkirchen", "Homburg"],
+    },
+    "SN": {
+        "avg_price_per_sqm": 2400,
+        "price_range": {"min": 1600, "max": 4000},
+        "agent_fee_percent": 2.98,
+        "trend": "rising",
+        "hotspots": ["Leipzig", "Dresden", "Chemnitz"],
+    },
+    "ST": {
+        "avg_price_per_sqm": 1800,
+        "price_range": {"min": 1200, "max": 3000},
+        "agent_fee_percent": 2.98,
+        "trend": "stable",
+        "hotspots": ["Magdeburg", "Halle", "Dessau"],
+    },
+    "SH": {
+        "avg_price_per_sqm": 3000,
+        "price_range": {"min": 2000, "max": 5500},
+        "agent_fee_percent": 3.57,
+        "trend": "stable",
+        "hotspots": ["Kiel", "Lübeck", "Flensburg"],
+    },
+    "TH": {
+        "avg_price_per_sqm": 1900,
+        "price_range": {"min": 1300, "max": 3200},
+        "agent_fee_percent": 2.98,
+        "trend": "stable",
+        "hotspots": ["Erfurt", "Jena", "Weimar"],
+    },
+}
+
+# Price multipliers relative to apartment prices — mirrors frontend
+PROPERTY_TYPE_MULTIPLIERS: dict[str, float] = {
+    "apartment": 1.0,
+    "house": 1.3,
+    "multi_family": 1.5,
+    "commercial": 1.4,
+    "land": 0.4,
+}
+
+
+def compute_market_insights(
+    property_location: str | None,
+    property_type: str | None,
+    budget_euros: int | None,
+    property_goals: dict | None,
+) -> dict | None:
+    """Compute market insights from static data.
+
+    Returns a dict suitable for storing in Journey.market_insights, or None
+    when the location is unrecognised (e.g. a free-text city name that is not
+    a two-letter state code).
+
+    The computation mirrors the logic in the frontend MarketInsights component
+    so both surfaces show identical numbers.
+    """
+    if not property_location:
+        return None
+
+    state_data = MARKET_DATA_BY_STATE.get(property_location)
+    state_info = GERMAN_STATES.get(property_location)
+    if not state_data or not state_info:
+        return None
+
+    # Prefer the property type from goals (user may have refined it in Step 1)
+    goals = property_goals or {}
+    effective_type = (
+        goals.get("preferred_property_type") or property_type or "apartment"
+    )
+
+    multiplier = PROPERTY_TYPE_MULTIPLIERS.get(effective_type, 1.0)
+
+    avg_price = state_data["avg_price_per_sqm"]
+    adjusted_avg = round(avg_price * multiplier)
+    adjusted_min = round(state_data["price_range"]["min"] * multiplier)
+    adjusted_max = round(state_data["price_range"]["max"] * multiplier)
+
+    estimated_sqm: int | None = None
+    if budget_euros and adjusted_avg > 0:
+        estimated_sqm = round(budget_euros / adjusted_avg)
+
+    return {
+        "state_code": property_location,
+        "state_name": state_info["name"],
+        "avg_price_per_sqm": avg_price,
+        "price_range_min": state_data["price_range"]["min"],
+        "price_range_max": state_data["price_range"]["max"],
+        "agent_fee_percent": state_data["agent_fee_percent"],
+        "trend": state_data["trend"],
+        "hotspots": state_data["hotspots"],
+        "transfer_tax_rate": state_info["transfer_tax_rate"],
+        "property_type": effective_type,
+        "type_multiplier": multiplier,
+        "adjusted_avg_price_per_sqm": adjusted_avg,
+        "adjusted_min_price_per_sqm": adjusted_min,
+        "adjusted_max_price_per_sqm": adjusted_max,
+        "estimated_size_sqm": estimated_sqm,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -8,6 +8,7 @@ backend and frontend are always in sync.
 """
 
 from datetime import datetime, timezone
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Static data: German states
@@ -162,8 +163,8 @@ def compute_market_insights(
     property_location: str | None,
     property_type: str | None,
     budget_euros: int | None,
-    property_goals: dict | None,
-) -> dict | None:
+    property_goals: dict[str, Any] | None,
+) -> dict[str, Any] | None:
     """Compute market insights from static data.
 
     Returns a dict suitable for storing in Journey.market_insights, or None

--- a/backend/tests/api/routes/test_journeys.py
+++ b/backend/tests/api/routes/test_journeys.py
@@ -478,3 +478,160 @@ def test_update_property_goals_second_save_persists(
     journey_goals = r.json()["property_goals"]
     assert journey_goals is not None
     assert journey_goals["preferred_property_type"] == "house"
+
+
+def create_journey_with_state_location(
+    client: TestClient, headers: dict[str, str]
+) -> dict:
+    """Helper to create a journey with a valid German state code as location.
+
+    Uses "BE" (Berlin) so that market insight generation can look up static data.
+    """
+    journey_data = {
+        "title": "Berlin Property Journey",
+        "questionnaire": {
+            "property_type": "apartment",
+            "property_location": "BE",
+            "financing_type": "mortgage",
+            "is_first_time_buyer": True,
+            "has_german_residency": True,
+            "budget_euros": 400000,
+        },
+    }
+    r = client.post(
+        f"{settings.API_V1_STR}/journeys/",
+        headers=headers,
+        json=journey_data,
+    )
+    return r.json()
+
+
+def test_completing_property_goals_generates_market_insights(
+    client: TestClient, db: Session
+) -> None:
+    """Market insights are generated when property goals are completed for the first time."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)
+    journey_id = journey["id"]
+
+    # Confirm no insights exist yet
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    assert r.json()["market_insights"] is None
+
+    # Complete Step 1 property goals
+    r = client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "apartment",
+            "min_rooms": 2,
+            "is_completed": True,
+        },
+    )
+    assert r.status_code == 200
+
+    # Verify insights were generated and attached to journey
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    assert r.status_code == 200
+    data = r.json()
+    insights = data["market_insights"]
+    assert insights is not None
+    assert insights["state_code"] == "BE"
+    assert insights["state_name"] == "Berlin"
+    assert insights["property_type"] == "apartment"
+    assert insights["trend"] == "rising"
+    assert "generated_at" in insights
+    assert insights["estimated_size_sqm"] is not None  # budget was provided
+
+
+def test_market_insights_not_regenerated_if_already_exists(
+    client: TestClient, db: Session
+) -> None:
+    """Re-saving property goals does not overwrite previously generated insights."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)
+    journey_id = journey["id"]
+
+    # First completion: generates insights
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={"preferred_property_type": "apartment", "is_completed": True},
+    )
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    first_generated_at = r.json()["market_insights"]["generated_at"]
+
+    # Second completion: insights must NOT be overwritten
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={"preferred_property_type": "house", "is_completed": True},
+    )
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    second_generated_at = r.json()["market_insights"]["generated_at"]
+
+    assert first_generated_at == second_generated_at, (
+        "market_insights was regenerated on a second save; it should be preserved"
+    )
+
+
+def test_incomplete_goals_do_not_generate_insights(
+    client: TestClient, db: Session
+) -> None:
+    """Saving property goals without is_completed=True must not generate insights."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)
+    journey_id = journey["id"]
+
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={"preferred_property_type": "apartment", "is_completed": False},
+    )
+
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    assert r.json()["market_insights"] is None
+
+
+def test_goals_property_type_used_in_insights(
+    client: TestClient, db: Session
+) -> None:
+    """Insights use the property type set in goals, not the journey-level type."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)
+    journey_id = journey["id"]
+
+    # Journey property_type is "apartment"; override in goals with "house"
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "house",
+            "is_completed": True,
+        },
+    )
+
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    insights = r.json()["market_insights"]
+    assert insights["property_type"] == "house"
+    assert insights["type_multiplier"] == 1.3
+
+
+def test_unknown_location_skips_insight_generation(
+    client: TestClient, db: Session
+) -> None:
+    """When property_location is a city name (not a state code), no insights are set."""
+    headers, _ = get_auth_headers(client, db)
+    # Use the default create_journey helper which sends "Berlin" (city, not state code)
+    journey = create_journey(client, headers)
+    journey_id = journey["id"]
+
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={"preferred_property_type": "apartment", "is_completed": True},
+    )
+
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    # "Berlin" is not a recognised state code → insights should remain None
+    assert r.json()["market_insights"] is None

--- a/backend/tests/api/routes/test_journeys.py
+++ b/backend/tests/api/routes/test_journeys.py
@@ -593,9 +593,7 @@ def test_incomplete_goals_do_not_generate_insights(
     assert r.json()["market_insights"] is None
 
 
-def test_goals_property_type_used_in_insights(
-    client: TestClient, db: Session
-) -> None:
+def test_goals_property_type_used_in_insights(client: TestClient, db: Session) -> None:
     """Insights use the property type set in goals, not the journey-level type."""
     headers, _ = get_auth_headers(client, db)
     journey = create_journey_with_state_location(client, headers)

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -594,6 +594,40 @@ class TestUpdateTaskStatusSyncsStepStatus:
         assert mock_step.completed_at is None
         assert mock_journey.current_step_number == 2
 
+    def test_all_tasks_unchecked_reverts_in_progress_step_to_not_started(
+        self,
+    ) -> None:
+        """All tasks unchecked on an in_progress step reverts it to not_started."""
+        step_id = uuid.uuid4()
+        task1 = _make_task(step_id, is_completed=False)
+        task2 = _make_task(step_id, is_completed=True)  # Will be unchecked
+
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = task2
+        mock_session.exec.return_value.all.return_value = [task1, task2]
+
+        mock_step = MagicMock(spec=JourneyStep)
+        mock_step.id = step_id
+        mock_step.status = StepStatus.IN_PROGRESS
+        mock_step.started_at = datetime.now(timezone.utc)
+        mock_step.step_number = 1
+
+        mock_journey = MagicMock(spec=Journey)
+        mock_journey.id = uuid.uuid4()
+        mock_journey.current_step_number = 1
+
+        update_task_status(
+            session=mock_session,
+            step=mock_step,
+            task_id=task2.id,
+            is_completed=False,
+            journey=mock_journey,
+        )
+
+        assert task2.is_completed is False
+        assert mock_step.status == StepStatus.NOT_STARTED
+        assert mock_step.started_at is None
+
     def test_partial_completion_keeps_step_in_progress(self) -> None:
         """Test that completing some but not all tasks keeps step in_progress."""
         step_id = uuid.uuid4()

--- a/backend/tests/services/test_market_data.py
+++ b/backend/tests/services/test_market_data.py
@@ -1,0 +1,159 @@
+"""Tests for market data computation."""
+
+import pytest
+
+from app.services.market_data import (
+    GERMAN_STATES,
+    MARKET_DATA_BY_STATE,
+    PROPERTY_TYPE_MULTIPLIERS,
+    compute_market_insights,
+)
+
+
+class TestComputeMarketInsights:
+    """Tests for the compute_market_insights function."""
+
+    def test_returns_none_for_none_location(self) -> None:
+        result = compute_market_insights(
+            property_location=None,
+            property_type="apartment",
+            budget_euros=300000,
+            property_goals=None,
+        )
+        assert result is None
+
+    def test_returns_none_for_unknown_location(self) -> None:
+        result = compute_market_insights(
+            property_location="Berlin",  # city name, not a state code
+            property_type="apartment",
+            budget_euros=300000,
+            property_goals=None,
+        )
+        assert result is None
+
+    def test_valid_state_code_returns_insights(self) -> None:
+        result = compute_market_insights(
+            property_location="BE",
+            property_type="apartment",
+            budget_euros=400000,
+            property_goals=None,
+        )
+        assert result is not None
+        assert result["state_code"] == "BE"
+        assert result["state_name"] == "Berlin"
+        assert result["trend"] == "rising"
+        assert result["property_type"] == "apartment"
+        assert result["type_multiplier"] == 1.0
+        assert isinstance(result["generated_at"], str)
+        assert len(result["hotspots"]) > 0
+
+    def test_apartment_multiplier_applied_correctly(self) -> None:
+        result = compute_market_insights(
+            property_location="BY",
+            property_type="apartment",
+            budget_euros=None,
+            property_goals=None,
+        )
+        assert result is not None
+        expected_avg = round(MARKET_DATA_BY_STATE["BY"]["avg_price_per_sqm"] * 1.0)
+        assert result["adjusted_avg_price_per_sqm"] == expected_avg
+
+    def test_house_multiplier_applied_correctly(self) -> None:
+        result = compute_market_insights(
+            property_location="BY",
+            property_type="house",
+            budget_euros=None,
+            property_goals=None,
+        )
+        assert result is not None
+        multiplier = PROPERTY_TYPE_MULTIPLIERS["house"]
+        expected_avg = round(
+            MARKET_DATA_BY_STATE["BY"]["avg_price_per_sqm"] * multiplier
+        )
+        assert result["adjusted_avg_price_per_sqm"] == expected_avg
+        assert result["type_multiplier"] == multiplier
+
+    def test_goals_property_type_takes_precedence_over_journey_type(self) -> None:
+        """Property type in goals overrides the journey-level property type."""
+        result = compute_market_insights(
+            property_location="BE",
+            property_type="apartment",
+            budget_euros=None,
+            property_goals={"preferred_property_type": "house"},
+        )
+        assert result is not None
+        assert result["property_type"] == "house"
+        assert result["type_multiplier"] == PROPERTY_TYPE_MULTIPLIERS["house"]
+
+    def test_estimated_size_computed_from_budget(self) -> None:
+        location = "BE"
+        budget = 520000
+        result = compute_market_insights(
+            property_location=location,
+            property_type="apartment",
+            budget_euros=budget,
+            property_goals=None,
+        )
+        assert result is not None
+        avg = MARKET_DATA_BY_STATE[location]["avg_price_per_sqm"]  # apartment multiplier = 1.0
+        expected_sqm = round(budget / avg)
+        assert result["estimated_size_sqm"] == expected_sqm
+
+    def test_estimated_size_is_none_when_no_budget(self) -> None:
+        result = compute_market_insights(
+            property_location="BE",
+            property_type="apartment",
+            budget_euros=None,
+            property_goals=None,
+        )
+        assert result is not None
+        assert result["estimated_size_sqm"] is None
+
+    def test_transfer_tax_rate_matches_state(self) -> None:
+        result = compute_market_insights(
+            property_location="BY",
+            property_type="apartment",
+            budget_euros=None,
+            property_goals=None,
+        )
+        assert result is not None
+        assert result["transfer_tax_rate"] == GERMAN_STATES["BY"]["transfer_tax_rate"]
+
+    def test_all_required_fields_present(self) -> None:
+        result = compute_market_insights(
+            property_location="HH",
+            property_type="apartment",
+            budget_euros=600000,
+            property_goals=None,
+        )
+        required = [
+            "state_code",
+            "state_name",
+            "avg_price_per_sqm",
+            "price_range_min",
+            "price_range_max",
+            "agent_fee_percent",
+            "trend",
+            "hotspots",
+            "transfer_tax_rate",
+            "property_type",
+            "type_multiplier",
+            "adjusted_avg_price_per_sqm",
+            "adjusted_min_price_per_sqm",
+            "adjusted_max_price_per_sqm",
+            "generated_at",
+        ]
+        assert result is not None
+        for field in required:
+            assert field in result, f"Missing field: {field}"
+
+    @pytest.mark.parametrize("state_code", list(MARKET_DATA_BY_STATE.keys()))
+    def test_all_states_return_valid_insights(self, state_code: str) -> None:
+        result = compute_market_insights(
+            property_location=state_code,
+            property_type="apartment",
+            budget_euros=300000,
+            property_goals=None,
+        )
+        assert result is not None
+        assert result["state_code"] == state_code

--- a/backend/tests/services/test_market_data.py
+++ b/backend/tests/services/test_market_data.py
@@ -95,7 +95,9 @@ class TestComputeMarketInsights:
             property_goals=None,
         )
         assert result is not None
-        avg = MARKET_DATA_BY_STATE[location]["avg_price_per_sqm"]  # apartment multiplier = 1.0
+        avg = MARKET_DATA_BY_STATE[location][
+            "avg_price_per_sqm"
+        ]  # apartment multiplier = 1.0
         expected_sqm = round(budget / avg)
         assert result["estimated_size_sqm"] == expected_sqm
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -716,7 +716,7 @@ export const Body_documents_upload_documentSchema = {
     properties: {
         file: {
             type: 'string',
-            contentMediaType: 'application/octet-stream',
+            format: 'binary',
             title: 'File'
         }
     },

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2249,6 +2249,18 @@ export const JourneyDetailResponseSchema = {
                 }
             ]
         },
+        market_insights: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/MarketInsightsData'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            default: null,
+            title: 'Market Insights'
+        },
         started_at: {
             anyOf: [
                 {
@@ -2541,6 +2553,18 @@ export const JourneyResponseSchema = {
                     type: 'null'
                 }
             ]
+        },
+        market_insights: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/MarketInsightsData'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            default: null,
+            title: 'Market Insights'
         },
         started_at: {
             anyOf: [
@@ -3919,30 +3943,6 @@ export const PropertyGoalsSchema = {
             ],
             title: 'Preferred Property Type'
         },
-        budget_min_euros: {
-            anyOf: [
-                {
-                    type: 'integer',
-                    minimum: 0
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Budget Min Euros'
-        },
-        budget_max_euros: {
-            anyOf: [
-                {
-                    type: 'integer',
-                    minimum: 0
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Budget Max Euros'
-        },
         min_rooms: {
             anyOf: [
                 {
@@ -4051,30 +4051,6 @@ export const PropertyGoalsUpdateSchema = {
                 }
             ],
             title: 'Preferred Property Type'
-        },
-        budget_min_euros: {
-            anyOf: [
-                {
-                    type: 'integer',
-                    minimum: 0
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Budget Min Euros'
-        },
-        budget_max_euros: {
-            anyOf: [
-                {
-                    type: 'integer',
-                    minimum: 0
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Budget Max Euros'
         },
         min_rooms: {
             anyOf: [
@@ -4239,18 +4215,6 @@ export const QuestionnaireAnswersSchema = {
                 }
             ],
             title: 'Budget Euros'
-        },
-        budget_min_euros: {
-            anyOf: [
-                {
-                    type: 'integer',
-                    minimum: 0
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            title: 'Budget Min Euros'
         },
         target_purchase_date: {
             anyOf: [
@@ -5795,4 +5759,88 @@ export const WebhookResponseSchema = {
     required: ['received'],
     title: 'WebhookResponse',
     description: 'Webhook processing response.'
+} as const;
+
+export const MarketInsightsDataSchema = {
+    properties: {
+        state_code: {
+            title: 'State Code',
+            type: 'string'
+        },
+        state_name: {
+            title: 'State Name',
+            type: 'string'
+        },
+        avg_price_per_sqm: {
+            title: 'Avg Price Per Sqm',
+            type: 'number'
+        },
+        price_range_min: {
+            title: 'Price Range Min',
+            type: 'number'
+        },
+        price_range_max: {
+            title: 'Price Range Max',
+            type: 'number'
+        },
+        agent_fee_percent: {
+            title: 'Agent Fee Percent',
+            type: 'number'
+        },
+        trend: {
+            enum: ['rising', 'stable', 'falling'],
+            title: 'Trend',
+            type: 'string'
+        },
+        hotspots: {
+            items: {
+                type: 'string'
+            },
+            title: 'Hotspots',
+            type: 'array'
+        },
+        transfer_tax_rate: {
+            title: 'Transfer Tax Rate',
+            type: 'number'
+        },
+        property_type: {
+            title: 'Property Type',
+            type: 'string'
+        },
+        type_multiplier: {
+            title: 'Type Multiplier',
+            type: 'number'
+        },
+        adjusted_avg_price_per_sqm: {
+            title: 'Adjusted Avg Price Per Sqm',
+            type: 'number'
+        },
+        adjusted_min_price_per_sqm: {
+            title: 'Adjusted Min Price Per Sqm',
+            type: 'number'
+        },
+        adjusted_max_price_per_sqm: {
+            title: 'Adjusted Max Price Per Sqm',
+            type: 'number'
+        },
+        estimated_size_sqm: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            default: null,
+            title: 'Estimated Size Sqm'
+        },
+        generated_at: {
+            title: 'Generated At',
+            type: 'string'
+        }
+    },
+    required: ['state_code', 'state_name', 'avg_price_per_sqm', 'price_range_min', 'price_range_max', 'agent_fee_percent', 'trend', 'hotspots', 'transfer_tax_rate', 'property_type', 'type_multiplier', 'adjusted_avg_price_per_sqm', 'adjusted_min_price_per_sqm', 'adjusted_max_price_per_sqm', 'generated_at'],
+    title: 'MarketInsightsData',
+    type: 'object'
 } as const;

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -716,7 +716,7 @@ export const Body_documents_upload_documentSchema = {
     properties: {
         file: {
             type: 'string',
-            format: 'binary',
+            contentMediaType: 'application/octet-stream',
             title: 'File'
         }
     },
@@ -2257,9 +2257,7 @@ export const JourneyDetailResponseSchema = {
                 {
                     type: 'null'
                 }
-            ],
-            default: null,
-            title: 'Market Insights'
+            ]
         },
         started_at: {
             anyOf: [
@@ -2562,9 +2560,7 @@ export const JourneyResponseSchema = {
                 {
                     type: 'null'
                 }
-            ],
-            default: null,
-            title: 'Market Insights'
+            ]
         },
         started_at: {
             anyOf: [
@@ -3426,6 +3422,90 @@ export const LogoutRequestSchema = {
     description: 'Schema for logout request.'
 } as const;
 
+export const MarketInsightsDataSchema = {
+    properties: {
+        state_code: {
+            type: 'string',
+            title: 'State Code'
+        },
+        state_name: {
+            type: 'string',
+            title: 'State Name'
+        },
+        avg_price_per_sqm: {
+            type: 'number',
+            title: 'Avg Price Per Sqm'
+        },
+        price_range_min: {
+            type: 'number',
+            title: 'Price Range Min'
+        },
+        price_range_max: {
+            type: 'number',
+            title: 'Price Range Max'
+        },
+        agent_fee_percent: {
+            type: 'number',
+            title: 'Agent Fee Percent'
+        },
+        trend: {
+            type: 'string',
+            enum: ['rising', 'stable', 'falling'],
+            title: 'Trend'
+        },
+        hotspots: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Hotspots'
+        },
+        transfer_tax_rate: {
+            type: 'number',
+            title: 'Transfer Tax Rate'
+        },
+        property_type: {
+            type: 'string',
+            title: 'Property Type'
+        },
+        type_multiplier: {
+            type: 'number',
+            title: 'Type Multiplier'
+        },
+        adjusted_avg_price_per_sqm: {
+            type: 'number',
+            title: 'Adjusted Avg Price Per Sqm'
+        },
+        adjusted_min_price_per_sqm: {
+            type: 'number',
+            title: 'Adjusted Min Price Per Sqm'
+        },
+        adjusted_max_price_per_sqm: {
+            type: 'number',
+            title: 'Adjusted Max Price Per Sqm'
+        },
+        estimated_size_sqm: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Estimated Size Sqm'
+        },
+        generated_at: {
+            type: 'string',
+            title: 'Generated At'
+        }
+    },
+    type: 'object',
+    required: ['state_code', 'state_name', 'avg_price_per_sqm', 'price_range_min', 'price_range_max', 'agent_fee_percent', 'trend', 'hotspots', 'transfer_tax_rate', 'property_type', 'type_multiplier', 'adjusted_avg_price_per_sqm', 'adjusted_min_price_per_sqm', 'adjusted_max_price_per_sqm', 'generated_at'],
+    title: 'MarketInsightsData',
+    description: 'Computed market insights stored on the journey after Step 1 completion.'
+} as const;
+
 export const MessageSchema = {
     properties: {
         message: {
@@ -3943,6 +4023,30 @@ export const PropertyGoalsSchema = {
             ],
             title: 'Preferred Property Type'
         },
+        budget_min_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Min Euros'
+        },
+        budget_max_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Max Euros'
+        },
         min_rooms: {
             anyOf: [
                 {
@@ -4051,6 +4155,30 @@ export const PropertyGoalsUpdateSchema = {
                 }
             ],
             title: 'Preferred Property Type'
+        },
+        budget_min_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Min Euros'
+        },
+        budget_max_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Max Euros'
         },
         min_rooms: {
             anyOf: [
@@ -4215,6 +4343,18 @@ export const QuestionnaireAnswersSchema = {
                 }
             ],
             title: 'Budget Euros'
+        },
+        budget_min_euros: {
+            anyOf: [
+                {
+                    type: 'integer',
+                    minimum: 0
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Min Euros'
         },
         target_purchase_date: {
             anyOf: [
@@ -5759,88 +5899,4 @@ export const WebhookResponseSchema = {
     required: ['received'],
     title: 'WebhookResponse',
     description: 'Webhook processing response.'
-} as const;
-
-export const MarketInsightsDataSchema = {
-    properties: {
-        state_code: {
-            title: 'State Code',
-            type: 'string'
-        },
-        state_name: {
-            title: 'State Name',
-            type: 'string'
-        },
-        avg_price_per_sqm: {
-            title: 'Avg Price Per Sqm',
-            type: 'number'
-        },
-        price_range_min: {
-            title: 'Price Range Min',
-            type: 'number'
-        },
-        price_range_max: {
-            title: 'Price Range Max',
-            type: 'number'
-        },
-        agent_fee_percent: {
-            title: 'Agent Fee Percent',
-            type: 'number'
-        },
-        trend: {
-            enum: ['rising', 'stable', 'falling'],
-            title: 'Trend',
-            type: 'string'
-        },
-        hotspots: {
-            items: {
-                type: 'string'
-            },
-            title: 'Hotspots',
-            type: 'array'
-        },
-        transfer_tax_rate: {
-            title: 'Transfer Tax Rate',
-            type: 'number'
-        },
-        property_type: {
-            title: 'Property Type',
-            type: 'string'
-        },
-        type_multiplier: {
-            title: 'Type Multiplier',
-            type: 'number'
-        },
-        adjusted_avg_price_per_sqm: {
-            title: 'Adjusted Avg Price Per Sqm',
-            type: 'number'
-        },
-        adjusted_min_price_per_sqm: {
-            title: 'Adjusted Min Price Per Sqm',
-            type: 'number'
-        },
-        adjusted_max_price_per_sqm: {
-            title: 'Adjusted Max Price Per Sqm',
-            type: 'number'
-        },
-        estimated_size_sqm: {
-            anyOf: [
-                {
-                    type: 'integer'
-                },
-                {
-                    type: 'null'
-                }
-            ],
-            default: null,
-            title: 'Estimated Size Sqm'
-        },
-        generated_at: {
-            title: 'Generated At',
-            type: 'string'
-        }
-    },
-    required: ['state_code', 'state_name', 'avg_price_per_sqm', 'price_range_min', 'price_range_max', 'agent_fee_percent', 'trend', 'hotspots', 'transfer_tax_rate', 'property_type', 'type_multiplier', 'adjusted_avg_price_per_sqm', 'adjusted_min_price_per_sqm', 'adjusted_max_price_per_sqm', 'generated_at'],
-    title: 'MarketInsightsData',
-    type: 'object'
 } as const;

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -218,7 +218,7 @@ export type BatchTranslationResponse = {
 };
 
 export type Body_documents_upload_document = {
-    file: (Blob | File);
+    file: string;
 };
 
 export type Body_login_login_access_token = {
@@ -1011,6 +1011,9 @@ export type LogoutRequest = {
     refresh_token: string;
 };
 
+/**
+ * Computed market insights stored on the journey after Step 1 completion.
+ */
 export type MarketInsightsData = {
     state_code: string;
     state_name: string;
@@ -1190,6 +1193,8 @@ export type PropertyEvaluationSummary = {
  */
 export type PropertyGoals = {
     preferred_property_type?: (string | null);
+    budget_min_euros?: (number | null);
+    budget_max_euros?: (number | null);
     min_rooms?: (number | null);
     min_bathrooms?: (number | null);
     preferred_floor?: (string | null);
@@ -1206,6 +1211,8 @@ export type PropertyGoals = {
  */
 export type PropertyGoalsUpdate = {
     preferred_property_type?: (string | null);
+    budget_min_euros?: (number | null);
+    budget_max_euros?: (number | null);
     min_rooms?: (number | null);
     min_bathrooms?: (number | null);
     preferred_floor?: (string | null);
@@ -1237,6 +1244,7 @@ export type QuestionnaireAnswers = {
     is_first_time_buyer?: boolean;
     has_german_residency?: boolean;
     budget_euros?: (number | null);
+    budget_min_euros?: (number | null);
     target_purchase_date?: (string | null);
 };
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -218,7 +218,7 @@ export type BatchTranslationResponse = {
 };
 
 export type Body_documents_upload_document = {
-    file: string;
+    file: (Blob | File);
 };
 
 export type Body_login_login_access_token = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -692,6 +692,7 @@ export type JourneyDetailResponse = {
     budget_euros?: (number | null);
     target_purchase_date?: (string | null);
     property_goals?: (PropertyGoals | null);
+    market_insights?: (MarketInsightsData | null);
     started_at?: (string | null);
     completed_at?: (string | null);
     is_active: boolean;
@@ -760,6 +761,7 @@ export type JourneyResponse = {
     budget_euros?: (number | null);
     target_purchase_date?: (string | null);
     property_goals?: (PropertyGoals | null);
+    market_insights?: (MarketInsightsData | null);
     started_at?: (string | null);
     completed_at?: (string | null);
     is_active: boolean;
@@ -1009,6 +1011,27 @@ export type LogoutRequest = {
     refresh_token: string;
 };
 
+export type MarketInsightsData = {
+    state_code: string;
+    state_name: string;
+    avg_price_per_sqm: number;
+    price_range_min: number;
+    price_range_max: number;
+    agent_fee_percent: number;
+    trend: 'rising' | 'stable' | 'falling';
+    hotspots: Array<(string)>;
+    transfer_tax_rate: number;
+    property_type: string;
+    type_multiplier: number;
+    adjusted_avg_price_per_sqm: number;
+    adjusted_min_price_per_sqm: number;
+    adjusted_max_price_per_sqm: number;
+    estimated_size_sqm?: (number | null);
+    generated_at: string;
+};
+
+export type trend = 'rising' | 'stable' | 'falling';
+
 export type Message = {
     message: string;
 };
@@ -1167,8 +1190,6 @@ export type PropertyEvaluationSummary = {
  */
 export type PropertyGoals = {
     preferred_property_type?: (string | null);
-    budget_min_euros?: (number | null);
-    budget_max_euros?: (number | null);
     min_rooms?: (number | null);
     min_bathrooms?: (number | null);
     preferred_floor?: (string | null);
@@ -1185,8 +1206,6 @@ export type PropertyGoals = {
  */
 export type PropertyGoalsUpdate = {
     preferred_property_type?: (string | null);
-    budget_min_euros?: (number | null);
-    budget_max_euros?: (number | null);
     min_rooms?: (number | null);
     min_bathrooms?: (number | null);
     preferred_floor?: (string | null);
@@ -1218,7 +1237,6 @@ export type QuestionnaireAnswers = {
     is_first_time_buyer?: boolean;
     has_german_residency?: boolean;
     budget_euros?: (number | null);
-    budget_min_euros?: (number | null);
     target_purchase_date?: (string | null);
 };
 

--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -27,6 +27,7 @@ interface IProps {
   journey?: JourneyPublic
   progress?: JourneyProgress
   onTaskToggle: (stepId: string, taskId: string, isCompleted: boolean) => void
+  onStepOpen?: (stepId: string) => void
   onDelete?: () => void
   isLoading?: boolean
   className?: string
@@ -164,6 +165,7 @@ function JourneyDetail(props: IProps) {
     journey,
     progress,
     onTaskToggle,
+    onStepOpen,
     onDelete,
     isLoading = false,
     className,
@@ -243,6 +245,7 @@ function JourneyDetail(props: IProps) {
                 step={step}
                 isActive={step.step_number === journey.current_step_number}
                 onTaskToggle={onTaskToggle}
+                onStepOpen={onStepOpen}
               />
             ))}
           </div>

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -223,18 +223,10 @@ function JourneyWizard(props: IProps) {
     switch (currentStep) {
       case 1:
         return (
-          <div className="space-y-8">
-            <PropertyTypeSelector
-              value={state.propertyType}
-              onChange={(v) => updateState({ propertyType: v })}
-            />
-            <BudgetInput
-              budgetMin={state.budgetMin}
-              budgetMax={state.budgetMax}
-              onBudgetMinChange={(v) => updateState({ budgetMin: v })}
-              onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
-            />
-          </div>
+          <PropertyTypeSelector
+            value={state.propertyType}
+            onChange={(v) => updateState({ propertyType: v })}
+          />
         )
       case 2:
         return (

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -20,6 +20,7 @@ import {
 import type {
   JourneyStep,
   JourneyTask,
+  MarketInsightsData,
   PropertyGoals,
   StepStatus,
 } from "@/models/journey"
@@ -78,6 +79,7 @@ interface IStepContentProps {
   propertyType?: string
   budgetEuros?: number
   propertyGoals?: PropertyGoals
+  marketInsights?: MarketInsightsData
 }
 
 const STEP_CONTENT_REGISTRY: Record<
@@ -93,6 +95,7 @@ const STEP_CONTENT_REGISTRY: Record<
       propertyType={p.propertyType}
       budgetEuros={p.budgetEuros}
       propertyGoals={p.propertyGoals}
+      marketInsights={p.marketInsights}
     />
   ),
   property_evaluation: (p) => (
@@ -229,6 +232,7 @@ function StepCard(props: IProps) {
                 propertyType: journey.property_type,
                 budgetEuros: journey.budget_euros,
                 propertyGoals: journey.property_goals,
+                marketInsights: journey.market_insights,
               })}
             </div>
           )}

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -35,6 +35,7 @@ interface IProps {
   step: JourneyStep
   isActive?: boolean
   onTaskToggle?: (stepId: string, taskId: string, isCompleted: boolean) => void
+  onStepOpen?: (stepId: string) => void
   className?: string
 }
 
@@ -167,7 +168,7 @@ function StepTasks(props: {
 
 /** Default component. Collapsible step card. */
 function StepCard(props: IProps) {
-  const { step, isActive = false, onTaskToggle, className } = props
+  const { step, isActive = false, onTaskToggle, onStepOpen, className } = props
   const { journey } = useJourneyContext()
 
   const [isExpanded, setIsExpanded] = useState(isActive)
@@ -180,6 +181,15 @@ function StepCard(props: IProps) {
   const hasBody =
     !!contentRenderer || hasTasks || !!step.estimated_duration_days
 
+  const handleToggleExpanded = () => {
+    if (!hasBody) return
+    const opening = !isExpanded
+    setIsExpanded(opening)
+    if (opening && step.status === "not_started") {
+      onStepOpen?.(step.id)
+    }
+  }
+
   return (
     <Card
       className={cn(
@@ -191,7 +201,7 @@ function StepCard(props: IProps) {
     >
       <CardHeader
         className={cn("pb-3", hasBody && "cursor-pointer select-none")}
-        onClick={() => hasBody && setIsExpanded((prev) => !prev)}
+        onClick={handleToggleExpanded}
       >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
           <div className="flex-1 space-y-1">

--- a/frontend/src/components/Journey/StepContent/MarketInsights.tsx
+++ b/frontend/src/components/Journey/StepContent/MarketInsights.tsx
@@ -298,33 +298,41 @@ function MarketInsights(props: IProps) {
         </div>
 
         {/* Key Stats Grid */}
-        <div className="grid gap-4 sm:grid-cols-2">
-          <StatCard
-            label="Average Price per m²"
-            value={CURRENCY_FORMATTER.format(adjustedAvgPrice)}
-            sublabel={`For ${propertyTypeLabel.toLowerCase()}s`}
-            icon={Euro}
-            highlight
-          />
-          <StatCard
-            label="Price Range"
-            value={`${CURRENCY_FORMATTER.format(adjustedMinPrice)} - ${CURRENCY_FORMATTER.format(adjustedMaxPrice)}`}
-            sublabel="Per m²"
-            icon={BarChart3}
-          />
-          <StatCard
-            label="Agent Fee (Makler)"
-            value={`${marketData.agentFeePercent}%`}
-            sublabel="Buyer's share after Bestellerprinzip"
-            icon={Users}
-          />
-          <StatCard
-            label="Transfer Tax"
-            value={`${stateInfo.transferTaxRate}%`}
-            sublabel="Grunderwerbsteuer"
-            icon={Euro}
-          />
-        </div>
+        {(() => {
+          const agentFee =
+            marketInsights?.agent_fee_percent ?? marketData.agentFeePercent
+          const transferTax =
+            marketInsights?.transfer_tax_rate ?? stateInfo.transferTaxRate
+          return (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <StatCard
+                label="Average Price per m²"
+                value={CURRENCY_FORMATTER.format(adjustedAvgPrice)}
+                sublabel={`For ${propertyTypeLabel.toLowerCase()}s`}
+                icon={Euro}
+                highlight
+              />
+              <StatCard
+                label="Price Range"
+                value={`${CURRENCY_FORMATTER.format(adjustedMinPrice)} - ${CURRENCY_FORMATTER.format(adjustedMaxPrice)}`}
+                sublabel="Per m²"
+                icon={BarChart3}
+              />
+              <StatCard
+                label="Agent Fee (Makler)"
+                value={`${agentFee}%`}
+                sublabel="Buyer's share after Bestellerprinzip"
+                icon={Users}
+              />
+              <StatCard
+                label="Transfer Tax"
+                value={`${transferTax}%`}
+                sublabel="Grunderwerbsteuer"
+                icon={Euro}
+              />
+            </div>
+          )
+        })()}
 
         {/* Budget Analysis */}
         {budgetEuros && budgetEuros > 0 && (
@@ -336,38 +344,43 @@ function MarketInsights(props: IProps) {
                 Based on Your Budget
               </h4>
               <div className="rounded-lg bg-muted/50 p-4 space-y-2">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Your Budget</span>
-                  <span className="font-medium">
-                    {CURRENCY_FORMATTER.format(budgetEuros)}
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">
-                    Estimated Property Size
-                  </span>
-                  <span className="font-medium">{estimatedSqm} m²</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">
-                    Total Additional Costs (~
-                    {(
-                      marketData.agentFeePercent +
-                      stateInfo.transferTaxRate +
-                      2
-                    ).toFixed(1)}
-                    %)
-                  </span>
-                  <span className="font-medium">
-                    {CURRENCY_FORMATTER.format(
-                      (budgetEuros *
-                        (marketData.agentFeePercent +
-                          stateInfo.transferTaxRate +
-                          2)) /
-                        100,
-                    )}
-                  </span>
-                </div>
+                {(() => {
+                  const agentFee =
+                    marketInsights?.agent_fee_percent ??
+                    marketData.agentFeePercent
+                  const transferTax =
+                    marketInsights?.transfer_tax_rate ?? stateInfo.transferTaxRate
+                  const additionalCostPct = agentFee + transferTax + 2
+                  return (
+                    <>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">
+                          Your Budget
+                        </span>
+                        <span className="font-medium">
+                          {CURRENCY_FORMATTER.format(budgetEuros)}
+                        </span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">
+                          Estimated Property Size
+                        </span>
+                        <span className="font-medium">{estimatedSqm} m²</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">
+                          Total Additional Costs (~
+                          {additionalCostPct.toFixed(1)}%)
+                        </span>
+                        <span className="font-medium">
+                          {CURRENCY_FORMATTER.format(
+                            (budgetEuros * additionalCostPct) / 100,
+                          )}
+                        </span>
+                      </div>
+                    </>
+                  )
+                })()}
               </div>
             </div>
           </>
@@ -430,26 +443,34 @@ function MarketInsights(props: IProps) {
         </div>
 
         {/* Tips */}
-        <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:bg-blue-950/30">
-          <h4 className="font-medium text-blue-800 dark:text-blue-400 mb-2">
-            Tips for {stateInfo.name}
-          </h4>
-          <ul className="text-sm text-blue-700 dark:text-blue-300 space-y-1">
-            <li>
-              • Agent fees are typically split 50/50 between buyer and seller
-            </li>
-            <li>
-              • Budget an additional 10-15% for transaction costs (notary,
-              taxes, etc.)
-            </li>
-            {marketData.trend === "rising" && (
-              <li>• Market is competitive - be prepared to move quickly</li>
-            )}
-            {marketData.trend === "stable" && (
-              <li>• Take your time to find the right property</li>
-            )}
-          </ul>
-        </div>
+        {(() => {
+          const effectiveTrend = marketInsights?.trend ?? marketData.trend
+          return (
+            <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:bg-blue-950/30">
+              <h4 className="font-medium text-blue-800 dark:text-blue-400 mb-2">
+                Tips for {stateInfo.name}
+              </h4>
+              <ul className="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+                <li>
+                  • Agent fees are typically split 50/50 between buyer and
+                  seller
+                </li>
+                <li>
+                  • Budget an additional 10-15% for transaction costs (notary,
+                  taxes, etc.)
+                </li>
+                {effectiveTrend === "rising" && (
+                  <li>
+                    • Market is competitive - be prepared to move quickly
+                  </li>
+                )}
+                {effectiveTrend === "stable" && (
+                  <li>• Take your time to find the right property</li>
+                )}
+              </ul>
+            </div>
+          )
+        })()}
       </CardContent>
     </Card>
   )

--- a/frontend/src/components/Journey/StepContent/MarketInsights.tsx
+++ b/frontend/src/components/Journey/StepContent/MarketInsights.tsx
@@ -349,7 +349,8 @@ function MarketInsights(props: IProps) {
                     marketInsights?.agent_fee_percent ??
                     marketData.agentFeePercent
                   const transferTax =
-                    marketInsights?.transfer_tax_rate ?? stateInfo.transferTaxRate
+                    marketInsights?.transfer_tax_rate ??
+                    stateInfo.transferTaxRate
                   const additionalCostPct = agentFee + transferTax + 2
                   return (
                     <>
@@ -460,9 +461,7 @@ function MarketInsights(props: IProps) {
                   taxes, etc.)
                 </li>
                 {effectiveTrend === "rising" && (
-                  <li>
-                    • Market is competitive - be prepared to move quickly
-                  </li>
+                  <li>• Market is competitive - be prepared to move quickly</li>
                 )}
                 {effectiveTrend === "stable" && (
                   <li>• Take your time to find the right property</li>

--- a/frontend/src/components/Journey/StepContent/MarketInsights.tsx
+++ b/frontend/src/components/Journey/StepContent/MarketInsights.tsx
@@ -8,6 +8,7 @@ import {
   BarChart3,
   Euro,
   Info,
+  Loader2,
   MapPin,
   Minus,
   TrendingDown,
@@ -30,13 +31,15 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-import type { PropertyGoals } from "@/models/journey"
+import { Skeleton } from "@/components/ui/skeleton"
+import type { MarketInsightsData, PropertyGoals } from "@/models/journey"
 
 interface IProps {
   propertyLocation?: string
   propertyType?: string
   budgetEuros?: number
   propertyGoals?: PropertyGoals
+  marketInsights?: MarketInsightsData
   className?: string
 }
 
@@ -103,6 +106,49 @@ function StatCard(props: {
   )
 }
 
+/** Skeleton stat card shown while insights are generating. */
+function StatCardSkeleton() {
+  return (
+    <div className="rounded-lg border p-4 space-y-2">
+      <Skeleton className="h-4 w-2/3" />
+      <Skeleton className="h-7 w-1/2" />
+      <Skeleton className="h-3 w-3/4" />
+    </div>
+  )
+}
+
+/** Loading state shown while market insights are being generated. */
+function GeneratingInsights(props: { className?: string }) {
+  return (
+    <Card className={cn("overflow-hidden", props.className)}>
+      <CardHeader className="bg-green-50 dark:bg-green-950/30">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <BarChart3 className="h-4 w-4" />
+          Market Insights
+          <Loader2 className="ml-auto h-4 w-4 animate-spin text-muted-foreground" />
+        </CardTitle>
+        <CardDescription>Generating personalised insights…</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6 pt-6">
+        <div className="flex items-center gap-3 rounded-lg border p-4">
+          <Skeleton className="h-6 w-6 rounded" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-1/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <Skeleton className="h-6 w-16 rounded-full" />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+          <StatCardSkeleton />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 /** No goals warning. */
 function NoGoalsWarning() {
   return (
@@ -127,8 +173,15 @@ function MarketInsights(props: IProps) {
     propertyType,
     budgetEuros,
     propertyGoals,
+    marketInsights,
     className,
   } = props
+
+  // Show loading skeleton when Step 1 is done but insights haven't arrived yet
+  const isGenerating = propertyGoals?.is_completed && !marketInsights
+  if (isGenerating) {
+    return <GeneratingInsights className={className} />
+  }
 
   // Get state info
   const stateInfo = GERMAN_STATES.find((s) => s.code === propertyLocation)
@@ -144,23 +197,38 @@ function MarketInsights(props: IProps) {
       " ",
     )[0] || "Property"
 
-  // Calculate adjusted price based on property type
-  const typeMultiplier = PROPERTY_TYPE_MULTIPLIERS[effectivePropertyType] || 1
-  const adjustedAvgPrice = marketData
-    ? Math.round(marketData.avgPricePerSqm * typeMultiplier)
-    : 0
-  const adjustedMinPrice = marketData
-    ? Math.round(marketData.priceRange.min * typeMultiplier)
-    : 0
-  const adjustedMaxPrice = marketData
-    ? Math.round(marketData.priceRange.max * typeMultiplier)
-    : 0
+  // Use backend-computed prices when available, fall back to local computation
+  const adjustedAvgPrice =
+    marketInsights?.adjusted_avg_price_per_sqm ??
+    (marketData
+      ? Math.round(
+          marketData.avgPricePerSqm *
+            (PROPERTY_TYPE_MULTIPLIERS[effectivePropertyType] || 1),
+        )
+      : 0)
+  const adjustedMinPrice =
+    marketInsights?.adjusted_min_price_per_sqm ??
+    (marketData
+      ? Math.round(
+          marketData.priceRange.min *
+            (PROPERTY_TYPE_MULTIPLIERS[effectivePropertyType] || 1),
+        )
+      : 0)
+  const adjustedMaxPrice =
+    marketInsights?.adjusted_max_price_per_sqm ??
+    (marketData
+      ? Math.round(
+          marketData.priceRange.max *
+            (PROPERTY_TYPE_MULTIPLIERS[effectivePropertyType] || 1),
+        )
+      : 0)
 
-  // Calculate estimated size based on budget
+  // Calculate estimated size based on budget (prefer backend value)
   const estimatedSqm =
-    budgetEuros && adjustedAvgPrice > 0
+    marketInsights?.estimated_size_sqm ??
+    (budgetEuros && adjustedAvgPrice > 0
       ? Math.round(budgetEuros / adjustedAvgPrice)
-      : 0
+      : 0)
 
   // Check if property goals are set
   const hasGoals = propertyGoals?.is_completed

--- a/frontend/src/hooks/mutations/useJourneyMutations.ts
+++ b/frontend/src/hooks/mutations/useJourneyMutations.ts
@@ -119,12 +119,15 @@ export function useUpdateTask(journeyId: string) {
             const anyDone = updatedTasks.some((t) => t.is_completed)
 
             let newStatus: StepStatus = step.status
-            if (allDone && step.status !== "completed") {
-              newStatus = "completed"
-            } else if (!allDone && step.status === "completed") {
-              newStatus = "in_progress"
-            } else if (anyDone && step.status === "not_started") {
-              newStatus = "in_progress"
+            if (step.status !== "skipped") {
+              if (allDone) {
+                newStatus = "completed"
+              } else if (anyDone) {
+                newStatus = "in_progress"
+              } else {
+                // All tasks unchecked → revert to not_started
+                newStatus = "not_started"
+              }
             }
 
             return { ...step, tasks: updatedTasks, status: newStatus }
@@ -137,12 +140,15 @@ export function useUpdateTask(journeyId: string) {
 
           const targetStep = updatedSteps.find((s) => s.id === stepId)
           if (targetStep) {
+            const previousStatus = journey.steps.find(
+              (s) => s.id === stepId,
+            )?.status
             const justCompleted =
               targetStep.status === "completed" &&
-              journey.steps.find((s) => s.id === stepId)?.status !== "completed"
+              previousStatus !== "completed"
             const justReverted =
-              targetStep.status === "in_progress" &&
-              journey.steps.find((s) => s.id === stepId)?.status === "completed"
+              previousStatus === "completed" &&
+              targetStep.status !== "completed"
 
             if (justCompleted) {
               const nextIncomplete = updatedSteps.find(

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -64,6 +64,7 @@ export interface JourneyPublic {
   budget_euros?: number
   target_purchase_date?: string
   property_goals?: PropertyGoals
+  market_insights?: MarketInsightsData
   started_at?: string
   completed_at?: string
   is_active: boolean
@@ -123,6 +124,26 @@ export interface NextStepRecommendation {
   has_next: boolean
   step?: JourneyStep
   message?: string
+}
+
+/** Computed market insights stored after Step 1 completion */
+export interface MarketInsightsData {
+  state_code: string
+  state_name: string
+  avg_price_per_sqm: number
+  price_range_min: number
+  price_range_max: number
+  agent_fee_percent: number
+  trend: "rising" | "stable" | "falling"
+  hotspots: string[]
+  transfer_tax_rate: number
+  property_type: string
+  type_multiplier: number
+  adjusted_avg_price_per_sqm: number
+  adjusted_min_price_per_sqm: number
+  adjusted_max_price_per_sqm: number
+  estimated_size_sqm?: number
+  generated_at: string
 }
 
 /** Property goals from Step 1 */

--- a/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
+++ b/frontend/src/routes/_layout/journeys/$journeyId.index.tsx
@@ -9,6 +9,7 @@ import { useState } from "react"
 import { DeleteJourneyDialog, JourneyDetail } from "@/components/Journey"
 import {
   useDeleteJourney,
+  useUpdateStep,
   useUpdateTask,
 } from "@/hooks/mutations/useJourneyMutations"
 import { useJourney, useJourneyProgress } from "@/hooks/queries"
@@ -42,6 +43,7 @@ function JourneyDetailPage() {
 
   const { data: progress } = useJourneyProgress(journeyId)
   const updateTask = useUpdateTask(journeyId)
+  const updateStep = useUpdateStep(journeyId)
   const deleteJourney = useDeleteJourney()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
@@ -52,6 +54,10 @@ function JourneyDetailPage() {
     isCompleted: boolean,
   ) => {
     updateTask.mutate({ stepId, taskId, data: { is_completed: isCompleted } })
+  }
+
+  const handleStepOpen = (stepId: string) => {
+    updateStep.mutate({ stepId, data: { status: "in_progress" } })
   }
 
   const handleDeleteConfirm = () => {
@@ -91,6 +97,7 @@ function JourneyDetailPage() {
         journey={journey}
         progress={progress}
         onTaskToggle={handleTaskToggle}
+        onStepOpen={handleStepOpen}
         onDelete={() => setShowDeleteDialog(true)}
       />
       <DeleteJourneyDialog


### PR DESCRIPTION
## Summary

- **Backend**: adds the missing `not_started` reversion in `_sync_step_status_from_tasks` — when all tasks are unchecked on an `in_progress` step, the step reverts to `not_started` (clears `started_at`)
- **Frontend optimistic update**: replaces the partial `if/else` chain with a clean three-branch logic covering all task completion states, including the previously missing `in_progress → not_started` case
- **Frontend visited trigger**: when a user opens (expands) a step that is `not_started`, the step is immediately set to `in_progress` via `PATCH /api/v1/journeys/{id}/steps/{stepId}`; the `onStepOpen` callback is threaded from `StepCard` → `JourneyDetail` → the route page

## Test plan

- [ ] Start a journey with all tasks unchecked — all steps show **Not Started**
- [ ] Expand (open) a step — status badge flips to **In Progress** immediately
- [ ] Check one task — badge remains **In Progress**
- [ ] Check all tasks — badge flips to **Completed**; journey advances to next step
- [ ] Uncheck one task on a completed step — badge reverts to **In Progress**
- [ ] Uncheck all tasks — badge reverts to **Not Started**
- [ ] Reload page — statuses are persisted correctly via backend