### PR TITLE
feat(auth): email verification on registration

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -3,9 +3,10 @@ import { useNavigate } from "@tanstack/react-router"
 
 import {
   type Body_login_login_access_token as AccessToken,
+  AuthService,
   LoginService,
+  type RegisterRequest,
   type UserPublic,
-  type UserRegister,
   UsersService,
 } from "@/client"
 import { handleError } from "@/utils"
@@ -18,7 +19,7 @@ const isLoggedIn = () => {
 const useAuth = (redirectTo?: string) => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { showErrorToast, showSuccessToast } = useCustomToast()
+  const { showErrorToast } = useCustomToast()
 
   const { data: user } = useQuery<UserPublic | null, Error>({
     queryKey: ["currentUser"],
@@ -26,18 +27,12 @@ const useAuth = (redirectTo?: string) => {
     enabled: isLoggedIn(),
   })
 
+  // Uses /auth/register which sets email_verified=False and sends a
+  // verification email. onSuccess is omitted — SignUp renders a
+  // "check your email" confirmation when isSuccess is true.
   const signUpMutation = useMutation({
-    mutationFn: (data: UserRegister) =>
-      UsersService.registerUser({ requestBody: data }),
-    onSuccess: () => {
-      showSuccessToast(
-        "Account created! Please check your email to verify your account.",
-      )
-      navigate({
-        to: "/login",
-        search: redirectTo ? { redirect: redirectTo } : {},
-      })
-    },
+    mutationFn: (data: RegisterRequest) =>
+      AuthService.register({ requestBody: data }),
     onError: handleError.bind(showErrorToast),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] })

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 
 import {
@@ -18,7 +18,6 @@ const isLoggedIn = () => {
 
 const useAuth = (redirectTo?: string) => {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const { showErrorToast } = useCustomToast()
 
   const { data: user } = useQuery<UserPublic | null, Error>({
@@ -34,9 +33,6 @@ const useAuth = (redirectTo?: string) => {
     mutationFn: (data: RegisterRequest) =>
       AuthService.register({ requestBody: data }),
     onError: handleError.bind(showErrorToast),
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["users"] })
-    },
   })
 
   const login = async (data: AccessToken) => {

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as RecoverPasswordRouteImport } from './routes/recover-password'
@@ -33,6 +34,11 @@ import { Route as LayoutArticlesSlugRouteImport } from './routes/_layout/article
 import { Route as LayoutJourneysJourneyIdIndexRouteImport } from './routes/_layout/journeys/$journeyId.index'
 import { Route as LayoutJourneysJourneyIdPropertyEvaluationRouteImport } from './routes/_layout/journeys/$journeyId.property-evaluation'
 
+const VerifyEmailRoute = VerifyEmailRouteImport.update({
+  id: '/verify-email',
+  path: '/verify-email',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
@@ -157,6 +163,7 @@ export interface FileRoutesByFullPath {
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
   '/calculators': typeof LayoutCalculatorsRoute
   '/dashboard': typeof LayoutDashboardRoute
@@ -181,6 +188,7 @@ export interface FileRoutesByTo {
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
   '/calculators': typeof LayoutCalculatorsRoute
   '/dashboard': typeof LayoutDashboardRoute
@@ -206,6 +214,7 @@ export interface FileRoutesById {
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/_layout/admin': typeof LayoutAdminRoute
   '/_layout/calculators': typeof LayoutCalculatorsRoute
   '/_layout/dashboard': typeof LayoutDashboardRoute
@@ -232,6 +241,7 @@ export interface FileRouteTypes {
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/verify-email'
     | '/admin'
     | '/calculators'
     | '/dashboard'
@@ -256,6 +266,7 @@ export interface FileRouteTypes {
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/verify-email'
     | '/admin'
     | '/calculators'
     | '/dashboard'
@@ -280,6 +291,7 @@ export interface FileRouteTypes {
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/verify-email'
     | '/_layout/admin'
     | '/_layout/calculators'
     | '/_layout/dashboard'
@@ -306,10 +318,18 @@ export interface RootRouteChildren {
   RecoverPasswordRoute: typeof RecoverPasswordRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
+  VerifyEmailRoute: typeof VerifyEmailRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/verify-email': {
+      id: '/verify-email'
+      path: '/verify-email'
+      fullPath: '/verify-email'
+      preLoaderRoute: typeof VerifyEmailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/signup': {
       id: '/signup'
       path: '/signup'
@@ -537,6 +557,7 @@ const rootRouteChildren: RootRouteChildren = {
   RecoverPasswordRoute: RecoverPasswordRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,
+  VerifyEmailRoute: VerifyEmailRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/sidebar"
 import { isLoggedIn } from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
+import { handleError } from "@/utils"
 
 export const Route = createFileRoute("/_layout")({
   component: Layout,
@@ -44,8 +45,7 @@ function UnverifiedEmailBanner() {
       }),
     onSuccess: () =>
       showSuccessToast("Verification email sent — check your inbox."),
-    onError: () =>
-      showErrorToast("Could not send verification email. Try again later."),
+    onError: handleError.bind(showErrorToast),
   })
 
   if (dismissed || !user || user.email_verified !== false) return null
@@ -58,7 +58,7 @@ function UnverifiedEmailBanner() {
         <button
           type="button"
           onClick={() => resendMutation.mutate()}
-          disabled={resendMutation.isPending}
+          disabled={resendMutation.isPending || resendMutation.isSuccess}
           className="font-medium underline underline-offset-2 hover:text-amber-900 disabled:opacity-50 dark:hover:text-amber-100"
         >
           {resendMutation.isPending ? "Sending…" : "resend verification email"}

--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -1,5 +1,9 @@
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
+import { MailWarning, X } from "lucide-react"
+import { useState } from "react"
 
+import { AuthService, type UserPublic, UsersService } from "@/client"
 import { Footer } from "@/components/Common/Footer"
 import NotificationBell from "@/components/Notifications/NotificationBell"
 import AppSidebar from "@/components/Sidebar/AppSidebar"
@@ -9,6 +13,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar"
 import { isLoggedIn } from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
 
 export const Route = createFileRoute("/_layout")({
   component: Layout,
@@ -21,6 +26,57 @@ export const Route = createFileRoute("/_layout")({
   },
 })
 
+/** Banner shown when the logged-in user has not yet verified their email. */
+function UnverifiedEmailBanner() {
+  const [dismissed, setDismissed] = useState(false)
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  const { data: user } = useQuery<UserPublic | null, Error>({
+    queryKey: ["currentUser"],
+    queryFn: UsersService.readUserMe,
+    enabled: isLoggedIn(),
+  })
+
+  const resendMutation = useMutation({
+    mutationFn: () =>
+      AuthService.resendVerification({
+        requestBody: { email: user!.email },
+      }),
+    onSuccess: () =>
+      showSuccessToast("Verification email sent — check your inbox."),
+    onError: () =>
+      showErrorToast("Could not send verification email. Try again later."),
+  })
+
+  if (dismissed || !user || user.email_verified !== false) return null
+
+  return (
+    <div className="flex items-center gap-3 bg-amber-50 px-4 py-2 text-sm text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+      <MailWarning className="h-4 w-4 shrink-0" />
+      <span className="flex-1">
+        Your email address is not verified. Check your inbox or{" "}
+        <button
+          type="button"
+          onClick={() => resendMutation.mutate()}
+          disabled={resendMutation.isPending}
+          className="font-medium underline underline-offset-2 hover:text-amber-900 disabled:opacity-50 dark:hover:text-amber-100"
+        >
+          {resendMutation.isPending ? "Sending…" : "resend verification email"}
+        </button>
+        .
+      </span>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={() => setDismissed(true)}
+        className="shrink-0 rounded p-0.5 hover:bg-amber-100 dark:hover:bg-amber-800"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}
+
 function Layout() {
   return (
     <SidebarProvider>
@@ -32,6 +88,7 @@ function Layout() {
             <NotificationBell />
           </div>
         </header>
+        <UnverifiedEmailBanner />
         <main className="flex-1 p-6 md:p-8">
           <div className="mx-auto max-w-7xl">
             <Outlet />

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -4,6 +4,7 @@ import {
   Link as RouterLink,
   redirect,
 } from "@tanstack/react-router"
+import { CheckCircle } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { RESIDENCY_STATUS_OPTIONS } from "@/common/constants"
@@ -80,6 +81,31 @@ export const Route = createFileRoute("/signup")({
                               Components
 ******************************************************************************/
 
+/** Shown after successful registration. */
+function RegistrationSuccess({ email }: { email: string }) {
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 text-green-600 dark:bg-green-900/30">
+        <CheckCircle className="h-6 w-6" />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Check your email</h2>
+        <p className="text-sm text-muted-foreground">
+          We sent a verification link to{" "}
+          <span className="font-medium text-foreground">{email}</span>. Click
+          the link to activate your account.
+        </p>
+      </div>
+      <RouterLink
+        to="/login"
+        className="mt-2 inline-flex h-10 items-center justify-center rounded-md bg-blue-600 px-8 text-sm font-medium text-white hover:bg-blue-700"
+      >
+        Go to sign in
+      </RouterLink>
+    </div>
+  )
+}
+
 /** Default component. Sign up page. */
 function SignUp() {
   const { redirect: redirectTo } = Route.useSearch()
@@ -103,6 +129,14 @@ function SignUp() {
     // Exclude confirm_password from submission data
     const { confirm_password: _, ...submitData } = data
     signUpMutation.mutate(submitData)
+  }
+
+  if (signUpMutation.isSuccess) {
+    return (
+      <AuthLayout>
+        <RegistrationSuccess email={form.getValues("email")} />
+      </AuthLayout>
+    )
   }
 
   return (

--- a/frontend/src/routes/verify-email.tsx
+++ b/frontend/src/routes/verify-email.tsx
@@ -1,0 +1,120 @@
+import { useMutation } from "@tanstack/react-query"
+import {
+  createFileRoute,
+  Link as RouterLink,
+  redirect,
+} from "@tanstack/react-router"
+import { AlertCircle, CheckCircle, Loader2 } from "lucide-react"
+import { useEffect } from "react"
+import { z } from "zod"
+
+import { AuthService } from "@/client"
+import { AuthLayout } from "@/components/Common/AuthLayout"
+import { isLoggedIn } from "@/hooks/useAuth"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const searchSchema = z.object({
+  token: z.string().catch(""),
+})
+
+/******************************************************************************
+                              Route
+******************************************************************************/
+
+export const Route = createFileRoute("/verify-email")({
+  component: VerifyEmail,
+  validateSearch: searchSchema,
+  beforeLoad: async ({ search }) => {
+    if (isLoggedIn()) {
+      throw redirect({ to: "/dashboard" })
+    }
+    if (!search.token) {
+      throw redirect({ to: "/login" })
+    }
+  },
+  head: () => ({
+    meta: [{ title: "Verify Email - HeimPath" }],
+  }),
+})
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function VerifyEmail() {
+  const { token } = Route.useSearch()
+
+  const mutation = useMutation({
+    mutationFn: () => AuthService.verifyEmail({ requestBody: { token } }),
+  })
+
+  const { mutate } = mutation
+  useEffect(() => {
+    mutate()
+  }, [mutate])
+
+  return (
+    <AuthLayout>
+      <div className="flex flex-col items-center gap-4 text-center">
+        {mutation.isPending && (
+          <>
+            <Loader2 className="h-10 w-10 animate-spin text-blue-600" />
+            <p className="text-sm text-muted-foreground">
+              Verifying your email…
+            </p>
+          </>
+        )}
+
+        {mutation.isSuccess && (
+          <>
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 text-green-600 dark:bg-green-900/30">
+              <CheckCircle className="h-6 w-6" />
+            </div>
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold">Email verified!</h2>
+              <p className="text-sm text-muted-foreground">
+                Your account is now active. You can sign in.
+              </p>
+            </div>
+            <RouterLink
+              to="/login"
+              className="mt-2 inline-flex h-10 items-center justify-center rounded-md bg-blue-600 px-8 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              Sign in
+            </RouterLink>
+          </>
+        )}
+
+        {mutation.isError && (
+          <>
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-900/30">
+              <AlertCircle className="h-6 w-6" />
+            </div>
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold">Verification failed</h2>
+              <p className="text-sm text-muted-foreground">
+                This link is invalid or has expired. Request a new one from the
+                sign-in page.
+              </p>
+            </div>
+            <RouterLink
+              to="/login"
+              className="mt-2 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-8 text-sm font-medium hover:bg-accent"
+            >
+              Back to sign in
+            </RouterLink>
+          </>
+        )}
+      </div>
+    </AuthLayout>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default VerifyEmail

--- a/frontend/src/routes/verify-email.tsx
+++ b/frontend/src/routes/verify-email.tsx
@@ -10,7 +10,6 @@ import { z } from "zod"
 
 import { AuthService } from "@/client"
 import { AuthLayout } from "@/components/Common/AuthLayout"
-import { isLoggedIn } from "@/hooks/useAuth"
 
 /******************************************************************************
                               Constants
@@ -28,9 +27,6 @@ export const Route = createFileRoute("/verify-email")({
   component: VerifyEmail,
   validateSearch: searchSchema,
   beforeLoad: async ({ search }) => {
-    if (isLoggedIn()) {
-      throw redirect({ to: "/dashboard" })
-    }
     if (!search.token) {
       throw redirect({ to: "/login" })
     }


### PR DESCRIPTION
## Summary

- Switches signup flow to use the new `/auth/register` endpoint (which sets `email_verified=False` and sends a verification email via SMTP or logs the link in dev)
- After registration, `SignUp` shows a "Check your email" confirmation screen instead of immediately redirecting to login
- Adds a `/verify-email` page: reads the `token` query param, auto-calls `POST /auth/verify-email` on mount, and shows loading / success / failure states
- Adds an unverified-email banner in the authenticated layout (`_layout.tsx`) with a "Resend verification email" button; dismissible per-session

## Backend

The backend was already fully implemented (User.email_verified field, `/auth/register`, `/auth/verify-email`, `/auth/resend-verification` endpoints, SMTP email sending). No backend changes needed.

## Test plan

- [ ] Register a new account → "Check your email" screen appears with the registered address
- [ ] Click the verification link (or manually visit `/verify-email?token=...`) → "Email verified!" screen
- [ ] Visiting `/verify-email` with an invalid/expired token → "Verification failed" screen
- [ ] Log in with an unverified account → amber banner appears in the app layout
- [ ] Click "resend verification email" in the banner → success toast shown
- [ ] Dismiss the banner → banner disappears for the session
- [ ] Log in after verifying → no banner
- [ ] `tsc --noEmit` passes; `biome check` passes