### PR TITLE
feat(nav): add login/logout toggle and profile icon to nav bar

### DIFF
--- a/frontend/src/components/Common/NavUserMenu.tsx
+++ b/frontend/src/components/Common/NavUserMenu.tsx
@@ -11,24 +11,23 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import useAuth from "@/hooks/useAuth"
 import { getInitials } from "@/utils"
 
 /******************************************************************************
                               Components
 ******************************************************************************/
 
-/** Compact auth-aware user menu for navigation bars. Shows a login button when
- * logged out, and a profile avatar dropdown with logout when logged in. */
+/** Compact profile avatar dropdown for navigation bars. Renders the user's
+ * initials and a dropdown with User Settings and Log Out. Callers are
+ * responsible for only rendering this component when the user is authenticated. */
 function NavUserMenu() {
   const { user, logout } = useAuth()
 
-  if (!isLoggedIn()) {
-    return (
-      <Button variant="ghost" size="sm" asChild>
-        <Link to="/login">Log In</Link>
-      </Button>
-    )
+  // text-xs on the fallback is intentional: the compact nav avatar (size-8)
+  // reads better with smaller text than the default size used in the sidebar.
+  const handleLogout = async () => {
+    logout()
   }
 
   return (
@@ -65,7 +64,7 @@ function NavUserMenu() {
             User Settings
           </DropdownMenuItem>
         </Link>
-        <DropdownMenuItem onClick={logout}>
+        <DropdownMenuItem onClick={handleLogout}>
           <LogOut />
           Log Out
         </DropdownMenuItem>

--- a/frontend/src/components/Common/NavUserMenu.tsx
+++ b/frontend/src/components/Common/NavUserMenu.tsx
@@ -1,0 +1,81 @@
+import { Link } from "@tanstack/react-router"
+import { LogOut, Settings } from "lucide-react"
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import { getInitials } from "@/utils"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Compact auth-aware user menu for navigation bars. Shows a login button when
+ * logged out, and a profile avatar dropdown with logout when logged in. */
+function NavUserMenu() {
+  const { user, logout } = useAuth()
+
+  if (!isLoggedIn()) {
+    return (
+      <Button variant="ghost" size="sm" asChild>
+        <Link to="/login">Log In</Link>
+      </Button>
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="rounded-full"
+          data-testid="nav-user-menu"
+        >
+          <Avatar className="size-8">
+            <AvatarFallback className="bg-zinc-600 text-xs text-white">
+              {getInitials(user?.full_name || "User")}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm font-medium leading-none">
+              {user?.full_name}
+            </p>
+            <p className="text-muted-foreground text-xs leading-none">
+              {user?.email}
+            </p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <Link to="/settings">
+          <DropdownMenuItem>
+            <Settings />
+            User Settings
+          </DropdownMenuItem>
+        </Link>
+        <DropdownMenuItem onClick={logout}>
+          <LogOut />
+          Log Out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { NavUserMenu }

--- a/frontend/src/components/Landing/LandingHeader.tsx
+++ b/frontend/src/components/Landing/LandingHeader.tsx
@@ -2,7 +2,9 @@ import { Link } from "@tanstack/react-router"
 
 import { Appearance } from "@/components/Common/Appearance"
 import { Logo } from "@/components/Common/Logo"
+import { NavUserMenu } from "@/components/Common/NavUserMenu"
 import { Button } from "@/components/ui/button"
+import { isLoggedIn } from "@/hooks/useAuth"
 
 /******************************************************************************
                               Components
@@ -10,6 +12,8 @@ import { Button } from "@/components/ui/button"
 
 /** Default component. Sticky header for the landing page. */
 function LandingHeader() {
+  const authenticated = isLoggedIn()
+
   return (
     <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 md:px-6">
@@ -17,12 +21,18 @@ function LandingHeader() {
 
         <div className="flex items-center gap-2">
           <Appearance />
-          <Button variant="ghost" size="sm" asChild>
-            <Link to="/login">Log In</Link>
-          </Button>
-          <Button size="sm" asChild>
-            <Link to="/signup">Get Started</Link>
-          </Button>
+          {authenticated ? (
+            <NavUserMenu />
+          ) : (
+            <>
+              <Button variant="ghost" size="sm" asChild>
+                <Link to="/login">Log In</Link>
+              </Button>
+              <Button size="sm" asChild>
+                <Link to="/signup">Get Started</Link>
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 
 import { Footer } from "@/components/Common/Footer"
+import { NavUserMenu } from "@/components/Common/NavUserMenu"
 import NotificationBell from "@/components/Notifications/NotificationBell"
 import AppSidebar from "@/components/Sidebar/AppSidebar"
 import {
@@ -30,6 +31,7 @@ function Layout() {
           <SidebarTrigger className="-ml-1 text-muted-foreground" />
           <div className="ml-auto flex items-center gap-2">
             <NotificationBell />
+            <NavUserMenu />
           </div>
         </header>
         <main className="flex-1 p-6 md:p-8">


### PR DESCRIPTION
## Summary

- Adds a `NavUserMenu` component for navigation bars — shows a Login button when logged out, or a compact avatar dropdown (user initials) with Log Out when logged in
- Updates the landing page header (`LandingHeader`) to be auth-aware: authenticated visitors see the profile dropdown instead of Login/Get Started buttons
- Updates the authenticated app header (`_layout.tsx`) to show the profile dropdown next to the notification bell

## Test plan

- [ ] Visit landing page while logged out → see "Log In" and "Get Started" buttons
- [ ] Visit landing page while logged in → see avatar with initials; click to open dropdown showing name, email, "User Settings", and "Log Out"
- [ ] While logged in, click "Log Out" from the nav dropdown → redirects to /login and clears token
- [ ] While logged in, click "User Settings" from the nav dropdown → navigates to /settings
- [ ] In the authenticated app header, verify avatar with initials appears next to the notification bell
- [ ] Click the avatar in the app header → dropdown with "User Settings" and "Log Out"