### PR TITLE
feat(journey): add post-wizard confirmation and generation screen

### DIFF
--- a/frontend/src/components/Common/NavUserMenu.tsx
+++ b/frontend/src/components/Common/NavUserMenu.tsx
@@ -26,7 +26,7 @@ function NavUserMenu() {
 
   // text-xs on the fallback is intentional: the compact nav avatar (size-8)
   // reads better with smaller text than the default size used in the sidebar.
-  const handleLogout = async () => {
+  const handleLogout = () => {
     logout()
   }
 

--- a/frontend/src/components/Journey/JourneyGenerating.tsx
+++ b/frontend/src/components/Journey/JourneyGenerating.tsx
@@ -1,0 +1,141 @@
+/**
+ * Journey Generating Component
+ * Post-wizard screen showing generation animation and completion summary
+ */
+
+import { CheckCircle2, Sparkles } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { cn } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import type { JourneyPhase, JourneyPublic } from "@/models/journey"
+import { ProgressBar } from "./ProgressBar"
+
+interface IProps {
+  journey: JourneyPublic
+  phase: "generating" | "complete"
+  onViewJourney: () => void
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const SUBTITLE_MESSAGES = [
+  "Analyzing your profile...",
+  "Personalizing steps...",
+  "Preparing your journey...",
+]
+
+const SUBTITLE_INTERVAL_MS = 700
+
+const PHASE_LABELS: Record<JourneyPhase, string> = {
+  research: "Research",
+  preparation: "Preparation",
+  buying: "Buying",
+  closing: "Closing",
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Post-wizard generation and completion screen. */
+function JourneyGenerating(props: IProps) {
+  const { journey, phase, onViewJourney } = props
+  const [subtitleIndex, setSubtitleIndex] = useState(0)
+  const [progress, setProgress] = useState(0)
+
+  // Cycle subtitle messages during generating phase
+  useEffect(() => {
+    if (phase !== "generating") return
+    const interval = setInterval(() => {
+      setSubtitleIndex((prev) => (prev + 1) % SUBTITLE_MESSAGES.length)
+    }, SUBTITLE_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [phase])
+
+  // Animate progress bar during generating phase
+  useEffect(() => {
+    if (phase !== "generating") {
+      setProgress(100)
+      return
+    }
+    const interval = setInterval(() => {
+      setProgress((prev) => Math.min(prev + 5, 90))
+    }, 100)
+    return () => clearInterval(interval)
+  }, [phase])
+
+  // Count steps per phase
+  const phaseCounts = useMemo(() => {
+    const counts: Record<JourneyPhase, number> = {
+      research: 0,
+      preparation: 0,
+      buying: 0,
+      closing: 0,
+    }
+    for (const step of journey.steps) {
+      counts[step.phase]++
+    }
+    return counts
+  }, [journey.steps])
+
+  if (phase === "generating") {
+    return (
+      <div className="flex flex-col items-center justify-center space-y-6 py-16">
+        <Sparkles className="h-12 w-12 text-blue-500 animate-pulse" />
+        <div className="space-y-2 text-center">
+          <h2 className="text-2xl font-bold">
+            Generating your personalized journey...
+          </h2>
+          <p className="text-muted-foreground">
+            {SUBTITLE_MESSAGES[subtitleIndex]}
+          </p>
+        </div>
+        <ProgressBar value={progress} size="sm" className="max-w-xs" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center space-y-6 py-16">
+      <CheckCircle2 className="h-12 w-12 text-green-500" />
+      <div className="space-y-2 text-center">
+        <h2 className="text-2xl font-bold">Your journey is ready!</h2>
+        <p className="text-muted-foreground">
+          {journey.steps.length}-step guide tailored to your profile
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {(Object.entries(PHASE_LABELS) as [JourneyPhase, string][]).map(
+          ([phaseKey, label]) => (
+            <Card
+              key={phaseKey}
+              className={cn(
+                "text-center",
+                phaseCounts[phaseKey] === 0 && "opacity-50",
+              )}
+            >
+              <CardContent className="p-4">
+                <p className="text-2xl font-bold">{phaseCounts[phaseKey]}</p>
+                <p className="text-xs text-muted-foreground">{label}</p>
+              </CardContent>
+            </Card>
+          ),
+        )}
+      </div>
+
+      <Button size="lg" onClick={onViewJourney}>
+        View My Journey
+      </Button>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { JourneyGenerating }

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -14,11 +14,13 @@ import { useCreateJourney } from "@/hooks/mutations"
 import type {
   FinancingType,
   JourneyCreate,
+  JourneyPublic,
   PropertyType,
   ResidencyStatus,
 } from "@/models/journey"
 import { BudgetInput } from "./BudgetInput"
 import { FinancingSelector } from "./FinancingSelector"
+import { JourneyGenerating } from "./JourneyGenerating"
 import { JourneySummary } from "./JourneySummary"
 import { LocationSelector } from "./LocationSelector"
 import { PropertyTypeSelector } from "./PropertyTypeSelector"
@@ -87,6 +89,12 @@ function JourneyWizard(props: IProps) {
     }
   })
   const [showSummary, setShowSummary] = useState(false)
+  const [wizardPhase, setWizardPhase] = useState<
+    "input" | "generating" | "complete"
+  >("input")
+  const [createdJourney, setCreatedJourney] = useState<JourneyPublic | null>(
+    null,
+  )
 
   // Persist selections to sessionStorage so Back navigation restores them
   useEffect(() => {
@@ -191,10 +199,8 @@ function JourneyWizard(props: IProps) {
     try {
       const newJourney = await createJourneyMutation.mutateAsync(journeyData)
       clearWizardStorage()
-      navigate({
-        to: "/journeys/$journeyId",
-        params: { journeyId: newJourney.id },
-      })
+      setCreatedJourney(newJourney)
+      setWizardPhase("generating")
     } catch {
       // Error is handled by React Query
     }
@@ -212,6 +218,21 @@ function JourneyWizard(props: IProps) {
     if (state.residencyStatus) done.add(6)
     return done
   }, [state, currentStep])
+
+  // Transition from generating animation to complete after 2 seconds
+  useEffect(() => {
+    if (wizardPhase !== "generating") return
+    const timer = setTimeout(() => setWizardPhase("complete"), 2000)
+    return () => clearTimeout(timer)
+  }, [wizardPhase])
+
+  const handleViewJourney = () => {
+    if (!createdJourney) return
+    navigate({
+      to: "/journeys/$journeyId",
+      params: { journeyId: createdJourney.id },
+    })
+  }
 
   const selectedState = GERMAN_STATES.find((s) => s.code === state.targetState)
 
@@ -270,6 +291,17 @@ function JourneyWizard(props: IProps) {
       default:
         return null
     }
+  }
+
+  // Show generating/complete screen after successful submission
+  if (wizardPhase !== "input" && createdJourney) {
+    return (
+      <JourneyGenerating
+        journey={createdJourney}
+        phase={wizardPhase as "generating" | "complete"}
+        onViewJourney={handleViewJourney}
+      />
+    )
   }
 
   const isLastStep = currentStep === WIZARD_STEPS.length && !showSummary

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -298,7 +298,7 @@ function JourneyWizard(props: IProps) {
     return (
       <JourneyGenerating
         journey={createdJourney}
-        phase={wizardPhase as "generating" | "complete"}
+        phase={wizardPhase}
         onViewJourney={handleViewJourney}
       />
     )

--- a/frontend/src/components/Journey/index.ts
+++ b/frontend/src/components/Journey/index.ts
@@ -8,6 +8,7 @@ export { FinancingSelector } from "./FinancingSelector"
 // Dashboard components
 export { JourneyCard } from "./JourneyCard"
 export { JourneyDetail } from "./JourneyDetail"
+export { JourneyGenerating } from "./JourneyGenerating"
 export { JourneyList } from "./JourneyList"
 export { JourneySummary } from "./JourneySummary"
 // Wizard components


### PR DESCRIPTION
## Summary

- Adds a new `JourneyGenerating` component with two phases: a "generating" animation (pulsing sparkles icon, cycling subtitles, cosmetic progress bar) and a "complete" screen (green checkmark, step count, phase summary grid, "View My Journey" CTA)
- Modifies `JourneyWizard` to show the generating/complete screen after successful journey creation instead of immediately navigating to the detail page
- Error flow unchanged — API failures keep the wizard on the summary step with the existing error message

## Test plan

- [ ] Complete the 6-step wizard and click "Create My Journey" — verify the generating animation appears (~2s) then transitions to the completion screen
- [ ] Verify the completion screen shows correct total step count and per-phase breakdown
- [ ] Click "View My Journey" — verify navigation to `/journeys/$journeyId`
- [ ] Simulate API failure — verify wizard stays on summary with error message (no generating screen shown)
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] Pre-commit hooks (biome lint/format) pass