### PR TITLE
chore(journey): add due diligence tasks to step 10

### DIFF
--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -250,6 +250,10 @@ STEP_TEMPLATES: list[StepTemplate] = [
         prerequisites=[3],
         tasks=[
             {
+                "title": "Request property exposé from agent",
+                "is_required": True,
+            },
+            {
                 "title": "Request Grundbuchauszug (land registry extract)",
                 "is_required": True,
             },
@@ -260,6 +264,10 @@ STEP_TEMPLATES: list[StepTemplate] = [
             {"title": "Check for encumbrances or easements", "is_required": True},
             {"title": "Verify building permits and compliance", "is_required": True},
             {"title": "Consider hiring a property surveyor", "is_required": False},
+            {
+                "title": "Review HOA documents (Teilungserklärung)",
+                "is_required": False,
+            },
         ],
         related_laws=["GBO (Grundbuchordnung)", "EnEV (Energieeinsparverordnung)"],
     ),

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -470,6 +470,15 @@ class TestStepTemplates:
         assert len(required) == 4
         assert len(optional) == 1
 
+    def test_step_10_due_diligence_tasks(self) -> None:
+        """Test that step 10 (due_diligence) has 7 tasks: 5 required, 2 optional."""
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "due_diligence")
+        assert len(template.tasks) == 7
+        required = [t for t in template.tasks if t["is_required"]]
+        optional = [t for t in template.tasks if not t["is_required"]]
+        assert len(required) == 5
+        assert len(optional) == 2
+
     def test_research_phase_steps_order(self) -> None:
         """Test that steps 1-5 are RESEARCH phase with correct content_keys."""
         expected = [

--- a/frontend/tests/user-settings.spec.ts
+++ b/frontend/tests/user-settings.spec.ts
@@ -232,6 +232,9 @@ test("Selected mode is preserved across sessions", async ({ page }) => {
   await page.getByTestId("light-mode").click()
   await expect(page.locator("html")).toHaveClass(/light/)
 
+  // Wait for dropdown to fully close before reopening
+  await expect(page.getByTestId("light-mode")).not.toBeVisible()
+
   // Now switch to dark mode
   await page.getByTestId("theme-button").click()
   await expect(page.getByTestId("dark-mode")).toBeVisible()


### PR DESCRIPTION
## Summary
- Add "Request property exposé from agent" (required) to Property Due Diligence step
- Add "Review HOA documents (Teilungserklärung)" (optional) to Property Due Diligence step
- Step 10 goes from 5 → 7 tasks (5 required, 2 optional)

## Test plan
- [x] Unit test `test_step_10_due_diligence_tasks` asserts 7 total tasks (5 required, 2 optional)
- [x] All 36 journey service tests pass