### PR TITLE
fix(calculators): fix save evaluation schema, notification urls, and error handling

### DIFF
--- a/backend/app/api/routes/calculators.py
+++ b/backend/app/api/routes/calculators.py
@@ -118,7 +118,7 @@ async def save_calculation(
         type=NotificationType.CALCULATION_SAVED,
         title="Calculation Saved",
         message=f"Your hidden cost calculation for {request.state_code} has been saved.",
-        action_url=f"/calculators/hidden-costs/{calculation.id}",
+        action_url="/calculators?tab=costs",
     )
 
     return HiddenCostCalculationResponse.model_validate(calculation)
@@ -236,7 +236,7 @@ async def save_roi_calculation(
         type=NotificationType.CALCULATION_SAVED,
         title="ROI Calculation Saved",
         message="Your ROI analysis has been saved.",
-        action_url=f"/calculators/roi/{calculation.id}",
+        action_url="/calculators?tab=roi",
     )
 
     return ROICalculationResponse.model_validate(calculation)
@@ -362,7 +362,7 @@ async def save_property_evaluation(
         type=NotificationType.CALCULATION_SAVED,
         title="Property Evaluation Saved",
         message="Your property evaluation has been saved.",
-        action_url=f"/calculators/property-evaluations/{evaluation.id}",
+        action_url="/calculators?tab=property-evaluation",
     )
 
     return PropertyEvaluationResponse.model_validate(evaluation)

--- a/backend/app/schemas/property_evaluation.py
+++ b/backend/app/schemas/property_evaluation.py
@@ -18,7 +18,7 @@ class PropertyEvaluationResponse(BaseModel):
     id: uuid.UUID
     name: str | None = None
     share_id: str | None = None
-    journey_step_id: str | None = None
+    journey_step_id: uuid.UUID | None = None
     purchase_price: float
     square_meters: float
     state_code: str | None = None

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3890,7 +3890,8 @@ export const PropertyEvaluationResponseSchema = {
         journey_step_id: {
             anyOf: [
                 {
-                    type: 'string'
+                    type: 'string',
+                    format: 'uuid'
                 },
                 {
                     type: 'null'

--- a/frontend/src/components/Calculators/FinancingWizard.tsx
+++ b/frontend/src/components/Calculators/FinancingWizard.tsx
@@ -50,6 +50,7 @@ import type {
   FinancingResidencyStatus,
   SchufaRating,
 } from "@/models/calculator"
+import { handleError } from "@/utils"
 
 interface IProps {
   className?: string
@@ -644,9 +645,7 @@ function FinancingWizard(props: IProps) {
           setShareUrl(url)
         }
       },
-      onError: () => {
-        showErrorToast("Failed to save financing assessment")
-      },
+      onError: handleError.bind(showErrorToast),
     })
   }
 

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/hooks/mutations/useCalculatorMutations"
 import { useUserPropertyEvaluations } from "@/hooks/queries/useCalculatorQueries"
 import type { PropertyEvaluationSummary } from "@/models/propertyEvaluation"
+import { handleError } from "@/utils"
 import {
   EvaluationSection,
   FinancingSection,
@@ -303,9 +304,7 @@ function PropertyEvaluationCalculator(
           setSaveName("")
           showSuccessToast("Property evaluation saved")
         },
-        onError: () => {
-          showErrorToast("Failed to save evaluation")
-        },
+        onError: handleError.bind(showErrorToast),
       },
     )
   }

--- a/frontend/src/components/Calculators/ROICalculator.tsx
+++ b/frontend/src/components/Calculators/ROICalculator.tsx
@@ -38,6 +38,7 @@ import type {
   ROICalculationInput,
   ROICalculationSummary,
 } from "@/models/calculator"
+import { handleError } from "@/utils"
 
 interface IProps {
   className?: string
@@ -559,9 +560,7 @@ function ROICalculator(props: IProps) {
           setShareUrl(url)
         }
       },
-      onError: () => {
-        showErrorToast("Failed to save ROI calculation")
-      },
+      onError: handleError.bind(showErrorToast),
     })
   }
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,24 +1,25 @@
 import { AxiosError } from "axios"
-import type { ApiError } from "./client"
+import { ApiError } from "./client/core/ApiError"
 
-function extractErrorMessage(err: ApiError): string {
+function extractErrorMessage(err: Error): string {
   if (err instanceof AxiosError) {
     return err.message
   }
 
-  const errDetail = (err.body as Record<string, unknown>)?.detail
-  if (Array.isArray(errDetail) && errDetail.length > 0) {
-    return errDetail[0].msg
+  if (err instanceof ApiError) {
+    const errDetail = (err.body as Record<string, unknown>)?.detail
+    if (Array.isArray(errDetail) && errDetail.length > 0) {
+      return errDetail[0].msg
+    }
+    if (typeof errDetail === "string" && errDetail) {
+      return errDetail
+    }
   }
-  return typeof errDetail === "string" && errDetail
-    ? errDetail
-    : "Something went wrong."
+
+  return err.message || "Something went wrong."
 }
 
-export const handleError = function (
-  this: (msg: string) => void,
-  err: ApiError,
-) {
+export const handleError = function (this: (msg: string) => void, err: Error) {
   const errorMessage = extractErrorMessage(err)
   this(errorMessage)
 }


### PR DESCRIPTION
## Summary
- **Schema type mismatch**: Changed `journey_step_id` from `str` to `uuid.UUID` in `PropertyEvaluationResponse` to match the DB model and create schema — this caused serialization errors on save
- **Broken notification URLs**: Fixed all 3 calculator notification `action_url` values to point to existing tab routes (`/calculators?tab=costs`, `?tab=roi`, `?tab=property-evaluation`) instead of non-existent detail pages that 404'd
- **Generic error handling**: Frontend `onError` now extracts `detail` from the API error body instead of always showing "Something went wrong"

## Test plan
- [x] `uv run pytest tests/services/test_property_evaluation_service.py -v` — 20/20 pass
- [x] `uv run pytest tests/services/test_roi_service.py -v` — all pass
- [x] Full test suite: 597 passed, 28 pre-existing failures (dashboard/journey migration issues, unrelated)
- [ ] Manual: save a property evaluation → confirm success toast with no error
- [ ] Manual: click notification link after saving → confirm it navigates to the correct calculator tab