### PR TITLE
feat(documents): add share, delete, filter, and usage display

### DIFF
--- a/backend/app/alembic/versions/p7l8m9n0o1q2_add_share_id_to_document.py
+++ b/backend/app/alembic/versions/p7l8m9n0o1q2_add_share_id_to_document.py
@@ -1,0 +1,39 @@
+"""Add share_id to document
+
+Revision ID: p7l8m9n0o1q2
+Revises: o6k7l8m9n0p1
+Create Date: 2026-04-10 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "p7l8m9n0o1q2"
+down_revision = "o6k7l8m9n0p1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document",
+        sa.Column("share_id", sa.String(12), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_document_share_id",
+        "document",
+        ["share_id"],
+    )
+    op.create_index(
+        "ix_document_share_id",
+        "document",
+        ["share_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_share_id", table_name="document")
+    op.drop_constraint("uq_document_share_id", table_name="document")
+    op.drop_column("document", "share_id")

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -17,15 +17,19 @@ from fastapi import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import CurrentUser
+from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.models import SubscriptionTier
+from app.models.document import Document, DocumentStatus, DocumentType
 from app.schemas.document import (
     DocumentDetailResponse,
     DocumentListResponse,
+    DocumentShareResponse,
     DocumentStatusResponse,
     DocumentSummary,
     DocumentTranslationResponse,
     DocumentUploadResponse,
+    DocumentUsageResponse,
 )
 from app.services import document_service
 
@@ -39,6 +43,37 @@ async def get_async_session() -> AsyncSession:  # type: ignore[misc]
             yield session  # type: ignore[misc]
         finally:
             await session.close()
+
+
+def _build_detail_response(document: Document) -> DocumentDetailResponse:
+    """Build DocumentDetailResponse from a Document model instance."""
+    translation_response = None
+    if document.translation:
+        t = document.translation
+        translation_response = DocumentTranslationResponse(
+            id=str(t.id),
+            document_id=str(t.document_id),
+            source_language=t.source_language,
+            target_language=t.target_language,
+            translated_pages=t.translated_pages or [],
+            clauses_detected=t.clauses_detected or [],
+            risk_warnings=t.risk_warnings or [],
+            processing_started_at=t.processing_started_at,
+            processing_completed_at=t.processing_completed_at,
+        )
+
+    return DocumentDetailResponse(
+        id=str(document.id),
+        original_filename=document.original_filename,
+        file_size_bytes=document.file_size_bytes,
+        page_count=document.page_count,
+        document_type=document.document_type,
+        status=document.status,
+        error_message=document.error_message,
+        share_id=document.share_id,
+        created_at=document.created_at,
+        translation=translation_response,
+    )
 
 
 @router.post(
@@ -112,21 +147,72 @@ async def upload_document(
     )
 
 
+@router.get("/usage", response_model=DocumentUsageResponse)
+async def get_usage(
+    current_user: CurrentUser,
+    session: AsyncSession = Depends(get_async_session),
+) -> DocumentUsageResponse:
+    """
+    Get document usage information for the current user.
+
+    Returns the number of documents uploaded and the page-per-document limit
+    based on the user's subscription tier.
+    """
+    count = await document_service.count_user_documents(
+        session=session, user_id=current_user.id
+    )
+
+    is_premium = current_user.subscription_tier in (
+        SubscriptionTier.PREMIUM,
+        SubscriptionTier.ENTERPRISE,
+    )
+
+    return DocumentUsageResponse(
+        documents_used=count,
+        page_limit=settings.MAX_PAGES_PREMIUM
+        if is_premium
+        else settings.MAX_PAGES_FREE,
+        subscription_tier=current_user.subscription_tier.value,
+    )
+
+
+@router.get("/shared/{share_id}", response_model=DocumentDetailResponse)
+async def get_shared_document(
+    share_id: str,
+    session: AsyncSession = Depends(get_async_session),
+) -> DocumentDetailResponse:
+    """
+    Get a shared document by share_id.
+
+    No authentication required.
+    """
+    document = await document_service.get_by_share_id(session, share_id)
+    return _build_detail_response(document)
+
+
 @router.get("/", response_model=DocumentListResponse)
 async def list_documents(
     current_user: CurrentUser,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
+    search: str | None = Query(default=None, max_length=200),
+    document_type: DocumentType | None = Query(default=None),
+    document_status: DocumentStatus | None = Query(default=None, alias="status"),
     session: AsyncSession = Depends(get_async_session),
 ) -> DocumentListResponse:
     """
     Get paginated list of the current user's uploaded documents.
+
+    Supports optional filtering by search term, document type, and status.
     """
     documents, total = await document_service.list_documents(
         session=session,
         user_id=current_user.id,
         page=page,
         page_size=page_size,
+        search=search,
+        document_type=document_type.value if document_type else None,
+        status_filter=document_status.value if document_status else None,
     )
 
     return DocumentListResponse(
@@ -138,6 +224,7 @@ async def list_documents(
                 page_count=doc.page_count,
                 document_type=doc.document_type,
                 status=doc.status,
+                share_id=doc.share_id,
                 created_at=doc.created_at,
             )
             for doc in documents
@@ -168,31 +255,48 @@ async def get_document(
             detail="Document not found",
         )
 
-    translation_response = None
-    if document.translation:
-        t = document.translation
-        translation_response = DocumentTranslationResponse(
-            id=str(t.id),
-            document_id=str(t.document_id),
-            source_language=t.source_language,
-            target_language=t.target_language,
-            translated_pages=t.translated_pages or [],
-            clauses_detected=t.clauses_detected or [],
-            risk_warnings=t.risk_warnings or [],
-            processing_started_at=t.processing_started_at,
-            processing_completed_at=t.processing_completed_at,
-        )
+    return _build_detail_response(document)
 
-    return DocumentDetailResponse(
+
+@router.post("/{document_id}/share", response_model=DocumentShareResponse)
+async def share_document(
+    document_id: str,
+    current_user: CurrentUser,
+    session: AsyncSession = Depends(get_async_session),
+) -> DocumentShareResponse:
+    """
+    Generate a shareable link for a completed document.
+
+    Returns the existing share_id if one was already generated.
+    """
+    document = await document_service.generate_share_id(
+        session=session,
+        document_id=document_id,
+        user_id=current_user.id,
+    )
+
+    return DocumentShareResponse(
         id=str(document.id),
-        original_filename=document.original_filename,
-        file_size_bytes=document.file_size_bytes,
-        page_count=document.page_count,
-        document_type=document.document_type,
-        status=document.status,
-        error_message=document.error_message,
-        created_at=document.created_at,
-        translation=translation_response,
+        share_id=document.share_id,
+    )
+
+
+@router.delete(
+    "/{document_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_document(
+    document_id: str,
+    current_user: CurrentUser,
+    session: AsyncSession = Depends(get_async_session),
+) -> None:
+    """
+    Delete a document and its associated file.
+    """
+    await document_service.delete_document(
+        session=session,
+        document_id=document_id,
+        user_id=current_user.id,
     )
 
 

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -97,6 +97,9 @@ class Document(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     error_message = Column(Text, nullable=True)
 
+    # Sharing
+    share_id = Column(String(12), unique=True, index=True, nullable=True)
+
     # Relationships
     translation = relationship(
         "DocumentTranslation",

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -53,6 +53,7 @@ class DocumentSummary(BaseModel):
     page_count: int
     document_type: DocumentTypeEnum
     status: DocumentStatusEnum
+    share_id: str | None = None
     created_at: datetime
 
 
@@ -124,8 +125,24 @@ class DocumentDetailResponse(BaseModel):
     document_type: DocumentTypeEnum
     status: DocumentStatusEnum
     error_message: str | None = None
+    share_id: str | None = None
     created_at: datetime
     translation: DocumentTranslationResponse | None = None
+
+
+class DocumentShareResponse(BaseModel):
+    """Response after generating a share link for a document."""
+
+    id: uuid.UUID
+    share_id: str
+
+
+class DocumentUsageResponse(BaseModel):
+    """Document usage limits for the current user."""
+
+    documents_used: int
+    page_limit: int
+    subscription_tier: str
 
 
 class DocumentStatusResponse(BaseModel):

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -8,9 +8,11 @@ import asyncio
 import logging
 import os
 import re
+import secrets
 import uuid
 from datetime import datetime, timezone
 
+from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -434,29 +436,45 @@ async def list_documents(
     user_id: uuid.UUID,
     page: int = 1,
     page_size: int = 20,
+    search: str | None = None,
+    document_type: str | None = None,
+    status_filter: str | None = None,
 ) -> tuple[list[Document], int]:
-    """Get paginated list of user's documents.
+    """Get paginated list of user's documents with optional filters.
 
     Args:
         session: Async database session.
         user_id: User UUID.
         page: Page number (1-indexed).
         page_size: Items per page.
+        search: Optional search term for filename.
+        document_type: Optional document type filter.
+        status_filter: Optional status filter.
 
     Returns:
         Tuple of (documents list, total count).
     """
+    # Build base filter
+    conditions = [Document.user_id == user_id]
+    if search:
+        # Escape LIKE wildcards to prevent injection via %, _, \
+        escaped = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        conditions.append(Document.original_filename.ilike(f"%{escaped}%", escape="\\"))
+    if document_type:
+        conditions.append(Document.document_type == document_type)
+    if status_filter:
+        conditions.append(Document.status == status_filter)
+
     # Count total
-    count_result = await session.execute(
-        select(func.count()).select_from(Document).where(Document.user_id == user_id)
-    )
+    count_query = select(func.count()).select_from(Document).where(*conditions)
+    count_result = await session.execute(count_query)
     total = count_result.scalar() or 0
 
     # Fetch page
     offset = (page - 1) * page_size
     result = await session.execute(
         select(Document)
-        .where(Document.user_id == user_id)
+        .where(*conditions)
         .order_by(Document.created_at.desc())
         .offset(offset)
         .limit(page_size)
@@ -464,3 +482,130 @@ async def list_documents(
     documents = list(result.scalars().all())
 
     return documents, total
+
+
+async def generate_share_id(
+    session: AsyncSession,
+    document_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> Document:
+    """Generate a share_id for a completed document.
+
+    Args:
+        session: Async database session.
+        document_id: Document UUID.
+        user_id: User UUID for ownership check.
+
+    Returns:
+        Updated Document with share_id set.
+
+    Raises:
+        HTTPException: If document not found, not owned, or not completed.
+    """
+    result = await session.execute(
+        select(Document).where(Document.id == document_id, Document.user_id == user_id)
+    )
+    document = result.scalar_one_or_none()
+    if not document:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found",
+        )
+
+    if document.status != DocumentStatus.COMPLETED.value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only completed documents can be shared",
+        )
+
+    # Reuse existing share_id if already generated
+    if not document.share_id:
+        document.share_id = secrets.token_urlsafe(8)
+        await session.commit()
+        await session.refresh(document)
+
+    return document
+
+
+async def get_by_share_id(
+    session: AsyncSession,
+    share_id: str,
+) -> Document:
+    """Get a document by share_id (no auth required).
+
+    Args:
+        session: Async database session.
+        share_id: The share token.
+
+    Returns:
+        Document with translation loaded.
+
+    Raises:
+        HTTPException: If shared document not found.
+    """
+    result = await session.execute(
+        select(Document)
+        .options(selectinload(Document.translation))
+        .where(Document.share_id == share_id)
+    )
+    document = result.scalar_one_or_none()
+    if not document:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Shared document not found",
+        )
+    return document
+
+
+async def delete_document(
+    session: AsyncSession,
+    document_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Delete a document with ownership check.
+
+    Removes the file from disk and deletes the database record.
+
+    Args:
+        session: Async database session.
+        document_id: Document UUID.
+        user_id: User UUID for ownership check.
+
+    Raises:
+        HTTPException: If document not found or not owned.
+    """
+    result = await session.execute(
+        select(Document).where(Document.id == document_id, Document.user_id == user_id)
+    )
+    document = result.scalar_one_or_none()
+    if not document:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found",
+        )
+
+    # Remove file from disk (async to avoid blocking the event loop)
+    if document.file_path and os.path.exists(document.file_path):
+        await asyncio.to_thread(os.remove, document.file_path)
+
+    await session.delete(document)
+    await session.commit()
+
+
+async def count_user_documents(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+) -> int:
+    """Count total documents uploaded by a user.
+
+    Args:
+        session: Async database session.
+        user_id: User UUID.
+
+    Returns:
+        Total document count.
+    """
+    result = await session.execute(
+        select(func.count()).select_from(Document).where(Document.user_id == user_id)
+    )
+    return result.scalar() or 0

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1148,6 +1148,17 @@ export const DocumentDetailResponseSchema = {
             ],
             title: 'Error Message'
         },
+        share_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Share Id'
+        },
         created_at: {
             type: 'string',
             format: 'date-time',
@@ -1234,6 +1245,31 @@ export const DocumentRiskWarningSchema = {
     description: 'Risk warning for a term in the document.'
 } as const;
 
+export const DocumentShareResponseSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        share_id: {
+            type: 'string',
+            title: 'Share Id'
+        }
+    },
+    type: 'object',
+    required: ['id', 'share_id'],
+    title: 'DocumentShareResponse',
+    description: 'Response after generating a share link for a document.'
+} as const;
+
+export const DocumentStatusSchema = {
+    type: 'string',
+    enum: ['uploaded', 'processing', 'completed', 'failed'],
+    title: 'DocumentStatus',
+    description: 'Processing status for uploaded documents.'
+} as const;
+
 export const DocumentStatusEnumSchema = {
     type: 'string',
     enum: ['uploaded', 'processing', 'completed', 'failed'],
@@ -1297,6 +1333,17 @@ export const DocumentSummarySchema = {
         },
         status: {
             '$ref': '#/components/schemas/DocumentStatusEnum'
+        },
+        share_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Share Id'
         },
         created_at: {
             type: 'string',
@@ -1382,6 +1429,13 @@ export const DocumentTranslationResponseSchema = {
     description: 'Full translation result for a document.'
 } as const;
 
+export const DocumentTypeSchema = {
+    type: 'string',
+    enum: ['kaufvertrag', 'mietvertrag', 'expose', 'nebenkostenabrechnung', 'grundbuchauszug', 'teilungserklaerung', 'hausgeldabrechnung', 'unknown'],
+    title: 'DocumentType',
+    description: 'Types of German real estate documents.'
+} as const;
+
 export const DocumentTypeEnumSchema = {
     type: 'string',
     enum: ['kaufvertrag', 'mietvertrag', 'expose', 'nebenkostenabrechnung', 'grundbuchauszug', 'teilungserklaerung', 'hausgeldabrechnung', 'unknown'],
@@ -1419,6 +1473,27 @@ export const DocumentUploadResponseSchema = {
     required: ['id', 'original_filename', 'file_size_bytes', 'page_count', 'document_type', 'status'],
     title: 'DocumentUploadResponse',
     description: 'Response after uploading a document.'
+} as const;
+
+export const DocumentUsageResponseSchema = {
+    properties: {
+        documents_used: {
+            type: 'integer',
+            title: 'Documents Used'
+        },
+        page_limit: {
+            type: 'integer',
+            title: 'Page Limit'
+        },
+        subscription_tier: {
+            type: 'string',
+            title: 'Subscription Tier'
+        }
+    },
+    type: 'object',
+    required: ['documents_used', 'page_limit', 'subscription_tier'],
+    title: 'DocumentUsageResponse',
+    description: 'Document usage limits for the current user.'
 } as const;
 
 export const FinancingAssessmentCreateSchema = {

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { ArticlesListArticlesData, ArticlesListArticlesResponse, ArticlesCreateArticleData, ArticlesCreateArticleResponse, ArticlesSearchArticlesData, ArticlesSearchArticlesResponse, ArticlesGetCategoriesResponse, ArticlesGetArticleData, ArticlesGetArticleResponse, ArticlesRateArticleData, ArticlesRateArticleResponse, ArticlesUpdateArticleData, ArticlesUpdateArticleResponse, ArticlesDeleteArticleData, ArticlesDeleteArticleResponse, AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, AuthForgotPasswordData, AuthForgotPasswordResponse, AuthResetPasswordData, AuthResetPasswordResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, CalculatorsGetSharedPropertyEvaluationData, CalculatorsGetSharedPropertyEvaluationResponse, CalculatorsListStepPropertyEvaluationsData, CalculatorsListStepPropertyEvaluationsResponse, CalculatorsListPropertyEvaluationsResponse, CalculatorsSavePropertyEvaluationData, CalculatorsSavePropertyEvaluationResponse, CalculatorsGetPropertyEvaluationData, CalculatorsGetPropertyEvaluationResponse, CalculatorsDeletePropertyEvaluationData, CalculatorsDeletePropertyEvaluationResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, ItemsReadItemsData, ItemsReadItemsResponse, ItemsCreateItemData, ItemsCreateItemResponse, ItemsReadItemData, ItemsReadItemResponse, ItemsUpdateItemData, ItemsUpdateItemResponse, ItemsDeleteItemData, ItemsDeleteItemResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, PrivateCreateUserData, PrivateCreateUserResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
+import type { ArticlesListArticlesData, ArticlesListArticlesResponse, ArticlesCreateArticleData, ArticlesCreateArticleResponse, ArticlesSearchArticlesData, ArticlesSearchArticlesResponse, ArticlesGetCategoriesResponse, ArticlesGetArticleData, ArticlesGetArticleResponse, ArticlesRateArticleData, ArticlesRateArticleResponse, ArticlesUpdateArticleData, ArticlesUpdateArticleResponse, ArticlesDeleteArticleData, ArticlesDeleteArticleResponse, AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, AuthForgotPasswordData, AuthForgotPasswordResponse, AuthResetPasswordData, AuthResetPasswordResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, CalculatorsGetSharedPropertyEvaluationData, CalculatorsGetSharedPropertyEvaluationResponse, CalculatorsListStepPropertyEvaluationsData, CalculatorsListStepPropertyEvaluationsResponse, CalculatorsListPropertyEvaluationsResponse, CalculatorsSavePropertyEvaluationData, CalculatorsSavePropertyEvaluationResponse, CalculatorsGetPropertyEvaluationData, CalculatorsGetPropertyEvaluationResponse, CalculatorsDeletePropertyEvaluationData, CalculatorsDeletePropertyEvaluationResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsGetUsageResponse, DocumentsGetSharedDocumentData, DocumentsGetSharedDocumentResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsDeleteDocumentData, DocumentsDeleteDocumentResponse, DocumentsShareDocumentData, DocumentsShareDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, ItemsReadItemsData, ItemsReadItemsResponse, ItemsCreateItemData, ItemsCreateItemResponse, ItemsReadItemData, ItemsReadItemResponse, ItemsUpdateItemData, ItemsUpdateItemResponse, ItemsDeleteItemData, ItemsDeleteItemResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, PrivateCreateUserData, PrivateCreateUserResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
 
 export class ArticlesService {
     /**
@@ -824,11 +824,55 @@ export class DocumentsService {
     }
     
     /**
+     * Get Usage
+     * Get document usage information for the current user.
+     *
+     * Returns the number of documents uploaded and the page-per-document limit
+     * based on the user's subscription tier.
+     * @returns DocumentUsageResponse Successful Response
+     * @throws ApiError
+     */
+    public static getUsage(): CancelablePromise<DocumentsGetUsageResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/documents/usage'
+        });
+    }
+    
+    /**
+     * Get Shared Document
+     * Get a shared document by share_id.
+     *
+     * No authentication required.
+     * @param data The data for the request.
+     * @param data.shareId
+     * @returns DocumentDetailResponse Successful Response
+     * @throws ApiError
+     */
+    public static getSharedDocument(data: DocumentsGetSharedDocumentData): CancelablePromise<DocumentsGetSharedDocumentResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/documents/shared/{share_id}',
+            path: {
+                share_id: data.shareId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
      * List Documents
      * Get paginated list of the current user's uploaded documents.
+     *
+     * Supports optional filtering by search term, document type, and status.
      * @param data The data for the request.
      * @param data.page
      * @param data.pageSize
+     * @param data.search
+     * @param data.documentType
+     * @param data.status
      * @returns DocumentListResponse Successful Response
      * @throws ApiError
      */
@@ -838,7 +882,10 @@ export class DocumentsService {
             url: '/api/v1/documents/',
             query: {
                 page: data.page,
-                page_size: data.pageSize
+                page_size: data.pageSize,
+                search: data.search,
+                document_type: data.documentType,
+                status: data.status
             },
             errors: {
                 422: 'Validation Error'
@@ -858,6 +905,50 @@ export class DocumentsService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/documents/{document_id}',
+            path: {
+                document_id: data.documentId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Delete Document
+     * Delete a document and its associated file.
+     * @param data The data for the request.
+     * @param data.documentId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static deleteDocument(data: DocumentsDeleteDocumentData): CancelablePromise<DocumentsDeleteDocumentResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/documents/{document_id}',
+            path: {
+                document_id: data.documentId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Share Document
+     * Generate a shareable link for a completed document.
+     *
+     * Returns the existing share_id if one was already generated.
+     * @param data The data for the request.
+     * @param data.documentId
+     * @returns DocumentShareResponse Successful Response
+     * @throws ApiError
+     */
+    public static shareDocument(data: DocumentsShareDocumentData): CancelablePromise<DocumentsShareDocumentResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/documents/{document_id}/share',
             path: {
                 document_id: data.documentId
             },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -355,6 +355,7 @@ export type DocumentDetailResponse = {
     document_type: DocumentTypeEnum;
     status: DocumentStatusEnum;
     error_message?: (string | null);
+    share_id?: (string | null);
     created_at: string;
     translation?: (DocumentTranslationResponse | null);
 };
@@ -381,6 +382,19 @@ export type DocumentRiskWarning = {
 };
 
 /**
+ * Response after generating a share link for a document.
+ */
+export type DocumentShareResponse = {
+    id: string;
+    share_id: string;
+};
+
+/**
+ * Processing status for uploaded documents.
+ */
+export type DocumentStatus = 'uploaded' | 'processing' | 'completed' | 'failed';
+
+/**
  * Document processing status choices.
  */
 export type DocumentStatusEnum = 'uploaded' | 'processing' | 'completed' | 'failed';
@@ -405,6 +419,7 @@ export type DocumentSummary = {
     page_count: number;
     document_type: DocumentTypeEnum;
     status: DocumentStatusEnum;
+    share_id?: (string | null);
     created_at: string;
 };
 
@@ -424,6 +439,11 @@ export type DocumentTranslationResponse = {
 };
 
 /**
+ * Types of German real estate documents.
+ */
+export type DocumentType = 'kaufvertrag' | 'mietvertrag' | 'expose' | 'nebenkostenabrechnung' | 'grundbuchauszug' | 'teilungserklaerung' | 'hausgeldabrechnung' | 'unknown';
+
+/**
  * Document type choices.
  */
 export type DocumentTypeEnum = 'kaufvertrag' | 'mietvertrag' | 'expose' | 'nebenkostenabrechnung' | 'grundbuchauszug' | 'teilungserklaerung' | 'hausgeldabrechnung' | 'unknown';
@@ -438,6 +458,15 @@ export type DocumentUploadResponse = {
     page_count: number;
     document_type: DocumentTypeEnum;
     status: DocumentStatusEnum;
+};
+
+/**
+ * Document usage limits for the current user.
+ */
+export type DocumentUsageResponse = {
+    documents_used: number;
+    page_limit: number;
+    subscription_tier: string;
 };
 
 /**
@@ -1959,9 +1988,20 @@ export type DocumentsUploadDocumentData = {
 
 export type DocumentsUploadDocumentResponse = (DocumentUploadResponse);
 
+export type DocumentsGetUsageResponse = (DocumentUsageResponse);
+
+export type DocumentsGetSharedDocumentData = {
+    shareId: string;
+};
+
+export type DocumentsGetSharedDocumentResponse = (DocumentDetailResponse);
+
 export type DocumentsListDocumentsData = {
+    documentType?: (DocumentType | null);
     page?: number;
     pageSize?: number;
+    search?: (string | null);
+    status?: (DocumentStatus | null);
 };
 
 export type DocumentsListDocumentsResponse = (DocumentListResponse);
@@ -1971,6 +2011,18 @@ export type DocumentsGetDocumentData = {
 };
 
 export type DocumentsGetDocumentResponse = (DocumentDetailResponse);
+
+export type DocumentsDeleteDocumentData = {
+    documentId: string;
+};
+
+export type DocumentsDeleteDocumentResponse = (void);
+
+export type DocumentsShareDocumentData = {
+    documentId: string;
+};
+
+export type DocumentsShareDocumentResponse = (DocumentShareResponse);
 
 export type DocumentsGetDocumentTranslationData = {
     documentId: string;

--- a/frontend/src/components/Documents/DocumentCard.tsx
+++ b/frontend/src/components/Documents/DocumentCard.tsx
@@ -10,10 +10,13 @@ import {
   Clock,
   FileText,
   Loader2,
+  Share2,
+  Trash2,
 } from "lucide-react"
 
 import { cn } from "@/common/utils"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type {
   DocumentStatus,
@@ -24,6 +27,8 @@ import type {
 interface IProps {
   document: DocumentSummary
   className?: string
+  onDelete?: (id: string) => void
+  onShare?: (id: string) => void
 }
 
 /******************************************************************************
@@ -83,10 +88,11 @@ function formatFileSize(bytes: number): string {
 
 /** Default component. Document summary card. */
 function DocumentCard(props: IProps) {
-  const { document: doc, className } = props
+  const { document: doc, className, onDelete, onShare } = props
 
   const statusConfig = STATUS_CONFIG[doc.status]
   const StatusIcon = statusConfig.icon
+  const isCompleted = doc.status === "completed"
 
   return (
     <Link
@@ -105,18 +111,48 @@ function DocumentCard(props: IProps) {
                 {doc.originalFilename}
               </CardTitle>
             </div>
-            <Badge
-              variant="outline"
-              className={cn("text-xs gap-1 shrink-0", statusConfig.className)}
-            >
-              <StatusIcon
-                className={cn(
-                  "h-3 w-3",
-                  doc.status === "processing" && "animate-spin",
-                )}
-              />
-              {statusConfig.label}
-            </Badge>
+            <div className="flex items-center gap-1 shrink-0">
+              {isCompleted && onShare && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    onShare(doc.id)
+                  }}
+                >
+                  <Share2 className="h-3.5 w-3.5" />
+                </Button>
+              )}
+              {onDelete && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    onDelete(doc.id)
+                  }}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              )}
+              <Badge
+                variant="outline"
+                className={cn("text-xs gap-1", statusConfig.className)}
+              >
+                <StatusIcon
+                  className={cn(
+                    "h-3 w-3",
+                    doc.status === "processing" && "animate-spin",
+                  )}
+                />
+                {statusConfig.label}
+              </Badge>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/frontend/src/components/Documents/DocumentList.tsx
+++ b/frontend/src/components/Documents/DocumentList.tsx
@@ -1,13 +1,22 @@
 /**
  * Document List Component
- * Grid of DocumentCards with pagination
+ * Grid of DocumentCards with filtering and pagination
  */
 
-import { FileText } from "lucide-react"
-import { useState } from "react"
-
+import { FileText, Search } from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useDeleteDocument, useShareDocument } from "@/hooks/mutations"
 import { useDocuments } from "@/hooks/queries"
+import useCustomToast from "@/hooks/useCustomToast"
 import { DocumentCard } from "./DocumentCard"
 
 interface IProps {
@@ -15,15 +24,115 @@ interface IProps {
 }
 
 /******************************************************************************
+                              Constants
+******************************************************************************/
+
+const DOCUMENT_TYPE_OPTIONS = [
+  { value: "kaufvertrag", label: "Purchase Agreement" },
+  { value: "mietvertrag", label: "Rental Agreement" },
+  { value: "expose", label: "Property Listing" },
+  { value: "nebenkostenabrechnung", label: "Utility Bill" },
+  { value: "grundbuchauszug", label: "Land Register" },
+  { value: "teilungserklaerung", label: "Division Declaration" },
+  { value: "hausgeldabrechnung", label: "Condo Fee Statement" },
+  { value: "unknown", label: "Unknown" },
+]
+
+const STATUS_OPTIONS = [
+  { value: "uploaded", label: "Uploaded" },
+  { value: "processing", label: "Processing" },
+  { value: "completed", label: "Completed" },
+  { value: "failed", label: "Failed" },
+]
+
+const ALL_TYPES = "all_types"
+const ALL_STATUSES = "all_statuses"
+
+/******************************************************************************
                               Components
 ******************************************************************************/
 
-/** Default component. Paginated grid of document cards. */
+/** Default component. Paginated grid of document cards with filters. */
 function DocumentList(props: IProps) {
   const { pageSize = 12 } = props
   const [page, setPage] = useState(1)
+  const [searchInput, setSearchInput] = useState("")
+  const [debouncedSearch, setDebouncedSearch] = useState("")
+  const [documentType, setDocumentType] = useState("")
+  const [statusFilter, setStatusFilter] = useState("")
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const { data, isLoading, error } = useDocuments(page, pageSize)
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const deleteMutation = useDeleteDocument()
+  const shareMutation = useShareDocument()
+
+  const filters = useMemo(
+    () => ({
+      search: debouncedSearch || undefined,
+      documentType: documentType || undefined,
+      status: statusFilter || undefined,
+    }),
+    [debouncedSearch, documentType, statusFilter],
+  )
+
+  const { data, isLoading, error } = useDocuments(page, pageSize, filters)
+
+  // Clean up debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+    }
+  }, [])
+
+  // Functions
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchInput(value)
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+    debounceTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(value)
+      setPage(1)
+    }, 300)
+  }, [])
+
+  const handleTypeChange = useCallback((value: string) => {
+    setDocumentType(value === ALL_TYPES ? "" : value)
+    setPage(1)
+  }, [])
+
+  const handleStatusChange = useCallback((value: string) => {
+    setStatusFilter(value === ALL_STATUSES ? "" : value)
+    setPage(1)
+  }, [])
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      if (!window.confirm("Are you sure you want to delete this document?")) {
+        return
+      }
+      deleteMutation.mutate(id, {
+        onSuccess: () => showSuccessToast("Document deleted"),
+        onError: () => showErrorToast("Failed to delete document"),
+      })
+    },
+    [deleteMutation, showSuccessToast, showErrorToast],
+  )
+
+  const handleShare = useCallback(
+    (id: string) => {
+      shareMutation.mutate(id, {
+        onSuccess: (data) => {
+          const url = `${window.location.origin}/documents/shared/${data.shareId}`
+          navigator.clipboard.writeText(url)
+          showSuccessToast("Share link copied to clipboard")
+        },
+        onError: () => showErrorToast("Failed to generate share link"),
+      })
+    },
+    [shareMutation, showSuccessToast, showErrorToast],
+  )
+
+  // Render
 
   if (error) {
     return (
@@ -33,63 +142,112 @@ function DocumentList(props: IProps) {
     )
   }
 
-  if (isLoading) {
-    return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div
-            key={i}
-            className="h-36 rounded-lg border bg-muted/50 animate-pulse"
-          />
-        ))}
-      </div>
-    )
-  }
-
-  if (!data?.data.length) {
-    return (
-      <div className="flex flex-col items-center justify-center py-12 text-center">
-        <FileText className="h-12 w-12 text-muted-foreground/50 mb-4" />
-        <h3 className="text-lg font-medium">No documents yet</h3>
-        <p className="text-sm text-muted-foreground mt-1">
-          Upload a German real estate PDF to get started
-        </p>
-      </div>
-    )
-  }
-
-  const totalPages = Math.ceil(data.total / pageSize)
+  const totalPages = data ? Math.ceil(data.total / pageSize) : 0
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {data.data.map((doc) => (
-          <DocumentCard key={doc.id} document={doc} />
-        ))}
+      {/* Filter bar */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search documents..."
+            value={searchInput}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Select
+          value={documentType || ALL_TYPES}
+          onValueChange={handleTypeChange}
+        >
+          <SelectTrigger className="w-full sm:w-48">
+            <SelectValue placeholder="Document type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_TYPES}>All types</SelectItem>
+            {DOCUMENT_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={statusFilter || ALL_STATUSES}
+          onValueChange={handleStatusChange}
+        >
+          <SelectTrigger className="w-full sm:w-40">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_STATUSES}>All statuses</SelectItem>
+            {STATUS_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            disabled={page <= 1}
-          >
-            Previous
-          </Button>
-          <span className="text-sm text-muted-foreground">
-            Page {page} of {totalPages}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-            disabled={page >= totalPages}
-          >
-            Next
-          </Button>
+      {/* Content */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-36 rounded-lg border bg-muted/50 animate-pulse"
+            />
+          ))}
         </div>
+      ) : !data?.data.length ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <FileText className="h-12 w-12 text-muted-foreground/50 mb-4" />
+          <h3 className="text-lg font-medium">No documents found</h3>
+          <p className="text-sm text-muted-foreground mt-1">
+            {debouncedSearch || documentType || statusFilter
+              ? "Try adjusting your filters"
+              : "Upload a German real estate PDF to get started"}
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {data.data.map((doc) => (
+              <DocumentCard
+                key={doc.id}
+                document={doc}
+                onDelete={handleDelete}
+                onShare={handleShare}
+              />
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/Documents/DocumentUploadForm.tsx
+++ b/frontend/src/components/Documents/DocumentUploadForm.tsx
@@ -1,14 +1,15 @@
 /**
  * Document Upload Form
- * Drag-and-drop PDF upload zone with validation
+ * Drag-and-drop PDF upload zone with validation and usage limits
  */
 
-import { useNavigate } from "@tanstack/react-router"
-import { AlertCircle, FileText, Upload } from "lucide-react"
+import { Link, useNavigate } from "@tanstack/react-router"
+import { AlertCircle, FileText, Info, Upload } from "lucide-react"
 import { useCallback, useState } from "react"
 
 import { cn } from "@/common/utils"
 import { useUploadDocument } from "@/hooks/mutations"
+import { useDocumentUsage } from "@/hooks/queries"
 
 interface IProps {
   className?: string
@@ -24,6 +25,38 @@ const ACCEPTED_TYPE = "application/pdf"
 /******************************************************************************
                               Components
 ******************************************************************************/
+
+/** Usage limit display below the drop zone. */
+function UsageLimitInfo() {
+  const { data: usage } = useDocumentUsage()
+
+  if (!usage) return null
+
+  const isFree = usage.subscriptionTier === "free"
+
+  return (
+    <div className="flex items-start gap-2 mt-3 text-xs text-muted-foreground">
+      <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+      <div>
+        <span>
+          Page limit: {usage.pageLimit} pages per document (
+          {usage.subscriptionTier})
+        </span>
+        {isFree && (
+          <span className="ml-1">
+            &mdash;{" "}
+            <Link
+              to="/settings"
+              className="text-blue-600 hover:underline dark:text-blue-400"
+            >
+              Upgrade for more
+            </Link>
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
 
 /** Default component. PDF upload form with drag-and-drop. */
 function DocumentUploadForm(props: IProps) {
@@ -135,6 +168,8 @@ function DocumentUploadForm(props: IProps) {
           )}
         </div>
       </div>
+
+      <UsageLimitInfo />
 
       {validationError && (
         <div className="flex items-center gap-2 mt-3 text-sm text-destructive">

--- a/frontend/src/hooks/mutations/useDocumentMutations.ts
+++ b/frontend/src/hooks/mutations/useDocumentMutations.ts
@@ -19,3 +19,31 @@ export function useUploadDocument() {
     },
   })
 }
+
+export function useDeleteDocument() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (documentId: string) =>
+      DocumentService.deleteDocument(documentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.documents.all,
+      })
+    },
+  })
+}
+
+export function useShareDocument() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (documentId: string) =>
+      DocumentService.shareDocument(documentId),
+    onSuccess: (_data, documentId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.documents.detail(documentId),
+      })
+    },
+  })
+}

--- a/frontend/src/hooks/queries/useDocumentQueries.ts
+++ b/frontend/src/hooks/queries/useDocumentQueries.ts
@@ -7,10 +7,27 @@ import { useQuery } from "@tanstack/react-query"
 import { queryKeys } from "@/query/queryKeys"
 import { DocumentService } from "@/services/DocumentService"
 
-export function useDocuments(page = 1, pageSize = 20) {
+interface IDocumentFilters extends Record<string, unknown> {
+  search?: string
+  documentType?: string
+  status?: string
+}
+
+export function useDocuments(
+  page = 1,
+  pageSize = 20,
+  filters?: IDocumentFilters,
+) {
   return useQuery({
-    queryKey: queryKeys.documents.list(page),
-    queryFn: () => DocumentService.getDocuments(page, pageSize),
+    queryKey: queryKeys.documents.list(page, filters),
+    queryFn: () =>
+      DocumentService.getDocuments(
+        page,
+        pageSize,
+        filters?.search,
+        filters?.documentType,
+        filters?.status,
+      ),
   })
 }
 
@@ -36,5 +53,20 @@ export function useDocumentStatus(documentId: string, isProcessing: boolean) {
     queryFn: () => DocumentService.getStatus(documentId),
     enabled: !!documentId && isProcessing,
     refetchInterval: isProcessing ? 3000 : false,
+  })
+}
+
+export function useSharedDocument(shareId: string) {
+  return useQuery({
+    queryKey: queryKeys.documents.shared(shareId),
+    queryFn: () => DocumentService.getSharedDocument(shareId),
+    enabled: !!shareId,
+  })
+}
+
+export function useDocumentUsage() {
+  return useQuery({
+    queryKey: queryKeys.documents.usage(),
+    queryFn: () => DocumentService.getUsage(),
   })
 }

--- a/frontend/src/models/document.ts
+++ b/frontend/src/models/document.ts
@@ -22,6 +22,7 @@ export interface DocumentSummary {
   pageCount: number
   documentType: DocumentType
   status: DocumentStatus
+  shareId: string | null
   createdAt: string
 }
 
@@ -67,6 +68,7 @@ export interface DocumentDetail {
   documentType: DocumentType
   status: DocumentStatus
   errorMessage: string | null
+  shareId: string | null
   createdAt: string
   translation: DocumentTranslation | null
 }
@@ -76,6 +78,17 @@ export interface DocumentStatusInfo {
   status: DocumentStatus
   errorMessage: string | null
   pageCount: number
+}
+
+export interface DocumentShareResponse {
+  id: string
+  shareId: string
+}
+
+export interface DocumentUsageInfo {
+  documentsUsed: number
+  pageLimit: number
+  subscriptionTier: string
 }
 
 export interface DocumentListResponse {

--- a/frontend/src/query/queryKeys.ts
+++ b/frontend/src/query/queryKeys.ts
@@ -92,12 +92,15 @@ export const queryKeys = {
   // Document queries
   documents: {
     all: ["documents"] as const,
-    list: (page?: number) =>
-      [...queryKeys.documents.all, "list", page] as const,
+    list: (page?: number, filters?: Record<string, unknown>) =>
+      [...queryKeys.documents.all, "list", page, filters] as const,
     detail: (id: string) => [...queryKeys.documents.all, "detail", id] as const,
     translation: (id: string) =>
       [...queryKeys.documents.all, "translation", id] as const,
     status: (id: string) => [...queryKeys.documents.all, "status", id] as const,
+    shared: (shareId: string) =>
+      [...queryKeys.documents.all, "shared", shareId] as const,
+    usage: () => [...queryKeys.documents.all, "usage"] as const,
   },
 
   // Notification queries

--- a/frontend/src/routes/_layout/documents/$documentId.tsx
+++ b/frontend/src/routes/_layout/documents/$documentId.tsx
@@ -3,9 +3,9 @@
  * Shows processing status, translation, clauses, and risk warnings
  */
 
-import { createFileRoute, Link } from "@tanstack/react-router"
-import { ArrowLeft, FileText } from "lucide-react"
-import { useState } from "react"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { ArrowLeft, FileText, Share2, Trash2 } from "lucide-react"
+import { useCallback, useState } from "react"
 import {
   ClauseHighlights,
   ProcessingStatus,
@@ -16,7 +16,9 @@ import { DOCUMENT_TYPE_LABELS } from "@/components/Documents/DocumentCard"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useDeleteDocument, useShareDocument } from "@/hooks/mutations"
 import { useDocument } from "@/hooks/queries"
+import useCustomToast from "@/hooks/useCustomToast"
 import type { DocumentType } from "@/models/document"
 
 /******************************************************************************
@@ -37,8 +39,41 @@ export const Route = createFileRoute("/_layout/documents/$documentId")({
 /** Default component. Document detail page. */
 function DocumentDetailPage() {
   const { documentId } = Route.useParams()
+  const navigate = useNavigate()
   const { data: doc, isLoading, error } = useDocument(documentId)
   const [activeTab, setActiveTab] = useState("translation")
+
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const deleteMutation = useDeleteDocument()
+  const shareMutation = useShareDocument()
+
+  // Functions
+
+  const handleDelete = useCallback(() => {
+    if (!window.confirm("Are you sure you want to delete this document?")) {
+      return
+    }
+    deleteMutation.mutate(documentId, {
+      onSuccess: () => {
+        showSuccessToast("Document deleted")
+        navigate({ to: "/documents" })
+      },
+      onError: () => showErrorToast("Failed to delete document"),
+    })
+  }, [documentId, deleteMutation, navigate, showSuccessToast, showErrorToast])
+
+  const handleShare = useCallback(() => {
+    shareMutation.mutate(documentId, {
+      onSuccess: (data) => {
+        const url = `${window.location.origin}/documents/shared/${data.shareId}`
+        navigator.clipboard.writeText(url)
+        showSuccessToast("Share link copied to clipboard")
+      },
+      onError: () => showErrorToast("Failed to generate share link"),
+    })
+  }, [documentId, shareMutation, showSuccessToast, showErrorToast])
+
+  // Render
 
   if (error) {
     return (
@@ -94,6 +129,29 @@ function DocumentDetailPage() {
               {doc.pageCount} {doc.pageCount === 1 ? "page" : "pages"}
             </span>
           </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {isCompleted && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleShare}
+              disabled={shareMutation.isPending}
+            >
+              <Share2 className="h-4 w-4 mr-1" />
+              Share
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={handleDelete}
+            disabled={deleteMutation.isPending}
+          >
+            <Trash2 className="h-4 w-4 mr-1" />
+            Delete
+          </Button>
         </div>
       </div>
 

--- a/frontend/src/services/DocumentService.ts
+++ b/frontend/src/services/DocumentService.ts
@@ -8,8 +8,10 @@ import { request } from "@/client/core/request"
 import type {
   DocumentDetail,
   DocumentListResponse,
+  DocumentShareResponse,
   DocumentStatusInfo,
   DocumentTranslation,
+  DocumentUsageInfo,
 } from "@/models/document"
 import { PATHS } from "./common/Paths"
 
@@ -69,13 +71,23 @@ class DocumentServiceClass {
   }
 
   /**
-   * Get paginated list of user's documents
+   * Get paginated list of user's documents with optional filters
    */
-  async getDocuments(page = 1, pageSize = 20): Promise<DocumentListResponse> {
+  async getDocuments(
+    page = 1,
+    pageSize = 20,
+    search?: string,
+    documentType?: string,
+    statusFilter?: string,
+  ): Promise<DocumentListResponse> {
     const params = new URLSearchParams({
       page: String(page),
       page_size: String(pageSize),
     })
+    if (search) params.set("search", search)
+    if (documentType) params.set("document_type", documentType)
+    if (statusFilter) params.set("status", statusFilter)
+
     const response = await request<Record<string, unknown>>(OpenAPI, {
       method: "GET",
       url: `${PATHS.DOCUMENTS.LIST}?${params.toString()}`,
@@ -114,6 +126,49 @@ class DocumentServiceClass {
       url: PATHS.DOCUMENTS.STATUS(documentId),
     })
     return transformKeys<DocumentStatusInfo>(response)
+  }
+
+  /**
+   * Delete a document
+   */
+  async deleteDocument(documentId: string): Promise<void> {
+    await request(OpenAPI, {
+      method: "DELETE",
+      url: PATHS.DOCUMENTS.DELETE(documentId),
+    })
+  }
+
+  /**
+   * Generate a shareable link for a document
+   */
+  async shareDocument(documentId: string): Promise<DocumentShareResponse> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "POST",
+      url: PATHS.DOCUMENTS.SHARE(documentId),
+    })
+    return transformKeys<DocumentShareResponse>(response)
+  }
+
+  /**
+   * Get a shared document by share_id (no auth required)
+   */
+  async getSharedDocument(shareId: string): Promise<DocumentDetail> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url: PATHS.DOCUMENTS.SHARED(shareId),
+    })
+    return transformKeys<DocumentDetail>(response)
+  }
+
+  /**
+   * Get document usage info for the current user
+   */
+  async getUsage(): Promise<DocumentUsageInfo> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url: PATHS.DOCUMENTS.USAGE,
+    })
+    return transformKeys<DocumentUsageInfo>(response)
   }
 }
 

--- a/frontend/src/services/common/Paths.ts
+++ b/frontend/src/services/common/Paths.ts
@@ -89,7 +89,11 @@ export const PATHS = {
   DOCUMENTS: {
     LIST: `${API_V1}/documents`,
     UPLOAD: `${API_V1}/documents/upload`,
+    USAGE: `${API_V1}/documents/usage`,
+    SHARED: (shareId: string) => `${API_V1}/documents/shared/${shareId}`,
     DETAIL: (id: string) => `${API_V1}/documents/${id}`,
+    SHARE: (id: string) => `${API_V1}/documents/${id}/share`,
+    DELETE: (id: string) => `${API_V1}/documents/${id}`,
     TRANSLATION: (id: string) => `${API_V1}/documents/${id}/translation`,
     STATUS: (id: string) => `${API_V1}/documents/${id}/status`,
   },


### PR DESCRIPTION
## Summary
- Add shareable links for completed documents via `share_id` pattern (migration, model, service, endpoint)
- Add document deletion with file cleanup and ownership check
- Add search/filter bar to document list (search by filename, filter by type/status)
- Add usage limit display on upload form showing page limits and upgrade prompt for free tier
- Add share/delete action buttons to document cards and detail page header

## Changes
**Backend (5 files):**
- New migration adding `share_id` column to `document` table
- New service functions: `generate_share_id`, `get_by_share_id`, `delete_document`, `count_user_documents`
- Updated `list_documents` with search/type/status filters
- New endpoints: `GET /usage`, `GET /shared/{share_id}`, `POST /{id}/share`, `DELETE /{id}`
- New schemas: `DocumentShareResponse`, `DocumentUsageResponse`

**Frontend (10 files):**
- New service methods, query keys, mutation hooks, and query hooks
- DocumentCard: share/delete action buttons
- DocumentList: search input + type/status filter dropdowns with debounce
- DocumentUploadForm: usage limit info with upgrade prompt
- Document detail page: share/delete buttons in header

## Test plan
- [ ] Backend: `pytest tests/ -k document` — all document tests pass
- [ ] Frontend: `bun run lint` — no Biome errors
- [ ] Frontend: `tsc --noEmit` — no TypeScript errors
- [ ] Upload a document, wait for processing, verify share button appears
- [ ] Click share → link copied → open in incognito → shared view loads
- [ ] Delete a document → confirm → removed from list
- [ ] Search by filename → list filters; select type/status → list filters
- [ ] Upload form shows page limit and upgrade prompt for free tier