### PR TITLE
fix(journey): disable floor field for houses, move cost to step 2

### DIFF
--- a/frontend/src/components/Journey/BudgetInput.tsx
+++ b/frontend/src/components/Journey/BudgetInput.tsx
@@ -3,8 +3,7 @@
  * Allows user to set budget range for their property search
  */
 
-import { Euro, Info } from "lucide-react"
-import { COST_DEFAULTS } from "@/common/constants"
+import { Euro } from "lucide-react"
 import { cn } from "@/common/utils"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -14,20 +13,8 @@ interface IProps {
   budgetMax?: number
   onBudgetMinChange: (value: number | undefined) => void
   onBudgetMaxChange: (value: number | undefined) => void
-  targetState?: string
-  transferTaxRate?: number
   className?: string
 }
-
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "currency",
-  currency: "EUR",
-  maximumFractionDigits: 0,
-})
 
 /******************************************************************************
                               Functions
@@ -40,93 +27,17 @@ function parseCurrency(value: string): number | undefined {
   return Number.isNaN(num) ? undefined : num
 }
 
-/** Calculate additional costs. */
-function calculateAdditionalCosts(
-  propertyPrice: number,
-  transferTaxRate: number,
-): {
-  transferTax: number
-  notaryFee: number
-  landRegistry: number
-  agentFee: number
-  total: number
-} {
-  const transferTax = propertyPrice * (transferTaxRate / 100)
-  const notaryFee = propertyPrice * (COST_DEFAULTS.NOTARY_FEE_PERCENT / 100)
-  const landRegistry =
-    propertyPrice * (COST_DEFAULTS.LAND_REGISTRY_FEE_PERCENT / 100)
-  const agentFee =
-    propertyPrice * (COST_DEFAULTS.AGENT_COMMISSION_PERCENT / 100)
-  const total = transferTax + notaryFee + landRegistry + agentFee
-
-  return { transferTax, notaryFee, landRegistry, agentFee, total }
-}
-
 /******************************************************************************
                               Components
 ******************************************************************************/
 
-/** Cost breakdown display. */
-function CostBreakdown(props: { budgetMax: number; transferTaxRate: number }) {
-  const { budgetMax, transferTaxRate } = props
-  const costs = calculateAdditionalCosts(budgetMax, transferTaxRate)
-
-  return (
-    <div className="rounded-lg border bg-muted/50 p-4 space-y-3">
-      <div className="flex items-center gap-2">
-        <Info className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm font-medium">
-          Estimated additional costs for {CURRENCY_FORMATTER.format(budgetMax)}
-        </span>
-      </div>
-      <div className="grid gap-2 text-sm">
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">
-            Property Transfer Tax ({transferTaxRate}%)
-          </span>
-          <span>{CURRENCY_FORMATTER.format(costs.transferTax)}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">
-            Notary Fee (~{COST_DEFAULTS.NOTARY_FEE_PERCENT}%)
-          </span>
-          <span>{CURRENCY_FORMATTER.format(costs.notaryFee)}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">
-            Land Registry (~{COST_DEFAULTS.LAND_REGISTRY_FEE_PERCENT}%)
-          </span>
-          <span>{CURRENCY_FORMATTER.format(costs.landRegistry)}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">
-            Agent Fee (~{COST_DEFAULTS.AGENT_COMMISSION_PERCENT}%)
-          </span>
-          <span>{CURRENCY_FORMATTER.format(costs.agentFee)}</span>
-        </div>
-        <div className="flex justify-between border-t pt-2 font-medium">
-          <span>Total Additional Costs</span>
-          <span className="text-blue-600">
-            {CURRENCY_FORMATTER.format(costs.total)}
-          </span>
-        </div>
-        <div className="flex justify-between font-semibold text-base">
-          <span>Total Investment</span>
-          <span>{CURRENCY_FORMATTER.format(budgetMax + costs.total)}</span>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-/** Default component. Budget range input with cost calculator. */
+/** Default component. Budget range input. */
 function BudgetInput(props: IProps) {
   const {
     budgetMin,
     budgetMax,
     onBudgetMinChange,
     onBudgetMaxChange,
-    transferTaxRate = 5.0,
     className,
   } = props
 
@@ -180,13 +91,6 @@ function BudgetInput(props: IProps) {
           </div>
         </div>
       </div>
-
-      {budgetMax && budgetMax > 0 && (
-        <CostBreakdown
-          budgetMax={budgetMax}
-          transferTaxRate={transferTaxRate}
-        />
-      )}
 
       {budgetMin && budgetMax && budgetMin > budgetMax && (
         <p className="text-sm text-destructive">

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -6,7 +6,6 @@
 import { useNavigate } from "@tanstack/react-router"
 import { ArrowLeft, ArrowRight, Loader2, Sparkles } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
-import { GERMAN_STATES } from "@/common/constants"
 import { cn } from "@/common/utils"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -234,8 +233,6 @@ function JourneyWizard(props: IProps) {
     })
   }
 
-  const selectedState = GERMAN_STATES.find((s) => s.code === state.targetState)
-
   const renderStep = () => {
     if (showSummary) {
       return <JourneySummary state={state} />
@@ -270,8 +267,6 @@ function JourneyWizard(props: IProps) {
             budgetMax={state.budgetMax}
             onBudgetMinChange={(v) => updateState({ budgetMin: v })}
             onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
-            targetState={state.targetState}
-            transferTaxRate={selectedState?.transferTaxRate}
           />
         )
       case 5:

--- a/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
+++ b/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
@@ -165,6 +165,26 @@ function PropertyGoalsForm(props: IProps) {
     }
   }, [initialGoals])
 
+  // Floor/elevator are irrelevant for houses and land
+  const isFloorRelevant =
+    goals.preferred_property_type !== "house" &&
+    goals.preferred_property_type !== "land"
+
+  const handlePropertyTypeChange = (value: string) => {
+    setGoals((prev) => {
+      const floorIrrelevant = value === "house" || value === "land"
+      return {
+        ...prev,
+        preferred_property_type: value,
+        // Clear floor and elevator when switching to a type without floors
+        ...(floorIrrelevant && {
+          preferred_floor: "",
+          has_elevator_required: false,
+        }),
+      }
+    })
+  }
+
   const handleFeatureToggle = (feature: string, checked: boolean) => {
     setGoals((prev) => ({
       ...prev,
@@ -211,12 +231,7 @@ function PropertyGoalsForm(props: IProps) {
               <SelectionButton
                 key={type.value}
                 selected={goals.preferred_property_type === type.value}
-                onClick={() =>
-                  setGoals((prev) => ({
-                    ...prev,
-                    preferred_property_type: type.value,
-                  }))
-                }
+                onClick={() => handlePropertyTypeChange(type.value)}
               >
                 {type.label.split(" ")[0]}
               </SelectionButton>
@@ -275,7 +290,12 @@ function PropertyGoalsForm(props: IProps) {
         </div>
 
         {/* Floor Preference */}
-        <div className="space-y-3">
+        <div
+          className={cn(
+            "space-y-3",
+            !isFloorRelevant && "opacity-50 pointer-events-none",
+          )}
+        >
           <Label className="text-sm font-medium">Preferred Floor</Label>
           <div className="grid grid-cols-2 gap-2">
             {FLOOR_OPTIONS.map((option) => (
@@ -293,16 +313,25 @@ function PropertyGoalsForm(props: IProps) {
               </SelectionButton>
             ))}
           </div>
+          {!isFloorRelevant && (
+            <p className="text-xs text-muted-foreground">
+              Floor preference is not applicable for this property type
+            </p>
+          )}
         </div>
 
         {/* Elevator Required */}
         <label
           htmlFor="elevator-required"
-          className="flex cursor-pointer items-center gap-3"
+          className={cn(
+            "flex cursor-pointer items-center gap-3",
+            !isFloorRelevant && "opacity-50 pointer-events-none",
+          )}
         >
           <Checkbox
             id="elevator-required"
             checked={goals.has_elevator_required}
+            disabled={!isFloorRelevant}
             onCheckedChange={(checked) =>
               setGoals((prev) => ({
                 ...prev,


### PR DESCRIPTION
## Summary
- Disable floor preference and elevator checkbox when property type is "House" or "Land" (clears values on switch, shows helper text explaining why)
- Remove cost breakdown from Step 1 BudgetInput — Step 2 (MarketInsights) already displays "Based on Your Budget" with proper state-specific transfer tax rates
- Clean up dead code (unused GERMAN_STATES import, selectedState variable)

## Test plan
- [ ] Select House → floor field greyed out, not clickable
- [ ] Select Apartment → floor field active and selectable
- [ ] Select Land → floor field greyed out
- [ ] Switch from Apartment (with floor selected) to House → floor value cleared
- [ ] Step 1 budget input: no cost breakdown shown below budget fields
- [ ] Step 2 with budget set + state selected: "Based on Your Budget" section visible with correct figures