### PR TITLE
fix(evaluation): improve scroll, mobile layout, and form labels

### DIFF
--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -373,21 +373,25 @@ function PropertyEvaluationCalculator(
   return (
     <div className={cn("space-y-6", className)}>
       {/* Header */}
-      <div className="flex items-start gap-4">
-        {journeyId && (
-          <Button variant="ghost" size="icon" asChild>
-            <Link to="/journeys/$journeyId" params={{ journeyId }}>
-              <ArrowLeft className="h-5 w-5" />
-            </Link>
-          </Button>
-        )}
-        <div className="flex-1">
-          <h1 className="text-2xl font-bold">Property Evaluation Calculator</h1>
-          <p className="text-muted-foreground">
-            Analyze investment property cashflow and returns
-          </p>
+      <div className="space-y-3 sm:space-y-0 sm:flex sm:items-start sm:gap-4">
+        <div className="flex items-start gap-3 min-w-0">
+          {journeyId && (
+            <Button variant="ghost" size="icon" className="shrink-0" asChild>
+              <Link to="/journeys/$journeyId" params={{ journeyId }}>
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
+            </Button>
+          )}
+          <div className="min-w-0">
+            <h1 className="text-xl sm:text-2xl font-bold">
+              Property Evaluation Calculator
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Analyze investment property cashflow and returns
+            </p>
+          </div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 shrink-0">
           <Button variant="outline" size="sm" onClick={handleReset}>
             <RefreshCw className="h-4 w-4 mr-2" />
             Reset

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
@@ -114,7 +114,6 @@ function PropertyInfoSection(props: IProps) {
               type="number"
               step="0.1"
               min="0"
-              required
               placeholder="e.g., 25.7"
               value={values.squareMeters || ""}
               onChange={(e) =>

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
@@ -88,7 +88,12 @@ function PropertyInfoSection(props: IProps) {
       <CardContent className="space-y-4 pt-4">
         {/* Address */}
         <div className="space-y-2">
-          <Label htmlFor="address">Address</Label>
+          <Label htmlFor="address">
+            Address{" "}
+            <span className="font-normal text-muted-foreground">
+              (optional)
+            </span>
+          </Label>
           <Input
             id="address"
             type="text"
@@ -101,12 +106,15 @@ function PropertyInfoSection(props: IProps) {
         {/* Size and Price */}
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="squareMeters">Living Space (m²)</Label>
+            <Label htmlFor="squareMeters">
+              Living Space (m²) <span className="text-destructive">*</span>
+            </Label>
             <Input
               id="squareMeters"
               type="number"
               step="0.1"
               min="0"
+              required
               placeholder="e.g., 25.7"
               value={values.squareMeters || ""}
               onChange={(e) =>

--- a/frontend/src/routes/_layout/journeys/$journeyId.property-evaluation.tsx
+++ b/frontend/src/routes/_layout/journeys/$journeyId.property-evaluation.tsx
@@ -4,6 +4,7 @@
  */
 
 import { createFileRoute } from "@tanstack/react-router"
+import { useEffect } from "react"
 
 import { PropertyEvaluationCalculator } from "@/components/Calculators/PropertyEvaluationCalculator"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -53,6 +54,11 @@ function PropertyEvaluationPage() {
   const { journeyId } = Route.useParams()
 
   const { data: journey, isLoading } = useJourney(journeyId)
+
+  // Scroll to top on mount
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
 
   if (isLoading) {
     return <LoadingSkeleton />


### PR DESCRIPTION
## Summary
- **Scroll to top on mount** — evaluation page now loads from the top instead of potentially mid-page (Task 29)
- **Mobile-friendly header** — title and subtitle get full-width rows on small screens with responsive text sizing (Task 30)
- **Form field labels** — Address marked as "(optional)", Living Space marked with required indicator "*" (Task 31)

## Test plan
- [ ] Navigate to property evaluation page — verify it loads scrolled to top
- [ ] View page at 375px viewport — verify title and subtitle are full-width and not truncated
- [ ] Verify Address field shows "(optional)" label
- [ ] Verify Living Space field shows "*" required indicator
- [ ] Submit without Living Space — verify save button stays disabled (results are null)
- [ ] Submit without Address — verify form works normally