### PR TITLE
feat(evaluation): add 110% financing toggle

### DIFF
--- a/frontend/src/common/constants/propertyEvaluation.ts
+++ b/frontend/src/common/constants/propertyEvaluation.ts
@@ -26,6 +26,7 @@ export const EVALUATION_DEFAULTS = {
   LOAN_PERCENT: 100,
   INTEREST_RATE_PERCENT: 4.0,
   REPAYMENT_RATE_PERCENT: 2.0,
+  INCLUDE_ACQUISITION_COSTS: false,
 
   // Operating costs defaults (EUR/month absolute - user enters from Abrechnung)
   HAUSGELD_ALLOCABLE: 0,

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -106,6 +106,7 @@ function createInitialState(
       loanPercent: EVALUATION_DEFAULTS.LOAN_PERCENT,
       interestRatePercent: EVALUATION_DEFAULTS.INTEREST_RATE_PERCENT,
       repaymentRatePercent: EVALUATION_DEFAULTS.REPAYMENT_RATE_PERCENT,
+      includeAcquisitionCosts: EVALUATION_DEFAULTS.INCLUDE_ACQUISITION_COSTS,
     },
   }
 }

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/FinancingSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/FinancingSection.tsx
@@ -1,12 +1,13 @@
 /**
  * Financing Section
- * Inputs for loan settings
+ * Inputs for loan settings with optional 110% financing (acquisition costs included)
  */
 
-import { Landmark } from "lucide-react"
+import { Info, Landmark } from "lucide-react"
 import { SECTION_COLORS } from "@/common/constants/propertyEvaluation"
 import { cn } from "@/common/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { FinancingInputs } from "../types"
@@ -42,13 +43,19 @@ function FinancingSection(props: IProps) {
     onChange({ [field]: num })
   }
 
-  // Loan is % of purchase price, equity covers the rest of total investment
-  const loanAmount = purchasePrice * (values.loanPercent / 100)
+  const loanBasis = values.includeAcquisitionCosts
+    ? totalInvestment
+    : purchasePrice
+  const loanAmount = loanBasis * (values.loanPercent / 100)
   const equityAmount = totalInvestment - loanAmount
   const monthlyInterest = (loanAmount * (values.interestRatePercent / 100)) / 12
   const monthlyRepayment =
     (loanAmount * (values.repaymentRatePercent / 100)) / 12
   const debtServiceMonthly = monthlyInterest + monthlyRepayment
+
+  const loanLabel = values.includeAcquisitionCosts
+    ? "Loan (% of total investment)"
+    : "Loan (% of purchase price)"
 
   return (
     <Card className={cn("overflow-hidden", className)}>
@@ -62,10 +69,46 @@ function FinancingSection(props: IProps) {
         </p>
       </CardHeader>
       <CardContent className="space-y-4 pt-4">
+        {/* 110% financing toggle */}
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="includeAcquisitionCosts"
+            checked={values.includeAcquisitionCosts}
+            onCheckedChange={(checked) =>
+              onChange({ includeAcquisitionCosts: checked === true })
+            }
+            className="mt-0.5"
+          />
+          <div>
+            <Label
+              htmlFor="includeAcquisitionCosts"
+              className="cursor-pointer leading-tight"
+            >
+              Include acquisition costs in loan (110% financing)
+            </Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              Finance both the purchase price and all additional costs (notary,
+              broker, transfer tax, land registry)
+            </p>
+          </div>
+        </div>
+
+        {values.includeAcquisitionCosts && (
+          <div className="flex items-start gap-2 rounded-md bg-blue-50 p-3 dark:bg-blue-950/30">
+            <Info className="h-4 w-4 shrink-0 mt-0.5 text-blue-600 dark:text-blue-400" />
+            <p className="text-xs text-blue-800 dark:text-blue-300">
+              110% financing means your bank loan covers the property price plus
+              all acquisition costs. This reduces required equity to zero but
+              increases monthly payments and total interest paid. Many German
+              banks offer this for creditworthy borrowers.
+            </p>
+          </div>
+        )}
+
         {/* Loan settings */}
         <div className="grid gap-4 sm:grid-cols-3">
           <div className="space-y-2">
-            <Label htmlFor="loanPercent">Loan (% of purchase price)</Label>
+            <Label htmlFor="loanPercent">{loanLabel}</Label>
             <Input
               id="loanPercent"
               type="number"
@@ -116,6 +159,14 @@ function FinancingSection(props: IProps) {
         {/* Financing summary */}
         {purchasePrice > 0 && (
           <div className="rounded-md bg-purple-50 p-3 space-y-2 dark:bg-purple-950/30">
+            {values.includeAcquisitionCosts && (
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">Loan Basis</span>
+                <span className="font-medium">
+                  {CURRENCY_FORMATTER.format(totalInvestment)}
+                </span>
+              </div>
+            )}
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Loan Amount</span>
               <span className="font-medium">
@@ -126,8 +177,13 @@ function FinancingSection(props: IProps) {
               <span className="text-muted-foreground">
                 Own Capital / Equity
               </span>
-              <span className="font-medium">
-                {CURRENCY_FORMATTER.format(equityAmount)}
+              <span
+                className={cn(
+                  "font-medium",
+                  equityAmount <= 0 && "text-amber-600 dark:text-amber-400",
+                )}
+              >
+                {CURRENCY_FORMATTER.format(Math.max(equityAmount, 0))}
               </span>
             </div>
             <div className="flex justify-between text-sm border-t pt-2 mt-2">

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/usePropertyEvaluation.ts
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/usePropertyEvaluation.ts
@@ -68,9 +68,11 @@ function usePropertyEvaluation(
       netColdRentYearly > 0 ? propertyInfo.purchasePrice / netColdRentYearly : 0
 
     // ========== Financing Metrics ==========
-    // Loan is a percentage of purchase price (not total investment)
-    const loanAmount =
-      propertyInfo.purchasePrice * (financing.loanPercent / 100)
+    // Loan basis: purchase price only, or total investment (110% financing)
+    const loanBasis = financing.includeAcquisitionCosts
+      ? totalInvestment
+      : propertyInfo.purchasePrice
+    const loanAmount = loanBasis * (financing.loanPercent / 100)
     // Equity covers the gap: total investment minus loan
     const equityAmount = totalInvestment - loanAmount
 

--- a/frontend/src/models/propertyEvaluation.ts
+++ b/frontend/src/models/propertyEvaluation.ts
@@ -36,6 +36,7 @@ export interface FinancingInputs {
   loanPercent: number
   interestRatePercent: number
   repaymentRatePercent: number
+  includeAcquisitionCosts: boolean
 }
 
 export interface EvaluationResults {


### PR DESCRIPTION
## Summary
- Adds a checkbox toggle to the financing section: "Include acquisition costs in loan (110% financing)"
- When enabled, the loan basis switches from purchase price to total investment (purchase price + notary, broker, transfer tax, land registry fees)
- Shows an explanatory info box when toggled on, explaining what 110% financing means for foreign buyers
- Equity amount highlights in amber when it drops to zero
- Loan basis row appears in the summary when 110% mode is active
- Backward compatible with existing saved evaluations (missing field defaults to `false`)

## Test plan
- [ ] Toggle off (default) — verify loan calculates against purchase price only
- [ ] Toggle on — verify loan basis includes acquisition costs, monthly payments increase
- [ ] Toggle on with 100% loan — verify equity shows 0 in amber
- [ ] Verify info box appears/disappears with toggle
- [ ] Verify label updates: "% of purchase price" vs "% of total investment"
- [ ] Save an evaluation with 110% on — reload and verify toggle state persists
- [ ] Load an old saved evaluation (without the field) — verify defaults to off