### PR TITLE
feat(evaluation): add info tooltips to field labels

### DIFF
--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/FieldTooltip.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/FieldTooltip.tsx
@@ -1,0 +1,50 @@
+/**
+ * FieldTooltip
+ * Info icon with tooltip that works on both desktop (hover) and mobile (tap)
+ */
+
+import { Info } from "lucide-react"
+import { useState } from "react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+interface IProps {
+  text: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Info icon that shows a tooltip on hover (desktop) or tap (mobile). */
+function FieldTooltip(props: IProps) {
+  const { text } = props
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger
+        type="button"
+        className="inline-flex align-middle ml-1"
+        onClick={(e) => {
+          e.preventDefault()
+          setOpen((prev) => !prev)
+        }}
+      >
+        <Info className="h-3.5 w-3.5 text-muted-foreground" />
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4} className="max-w-64">
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { FieldTooltip }

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/common/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { FieldTooltip } from "../FieldTooltip"
 import type { OperatingCostsInputs } from "../types"
 
 interface IProps {
@@ -104,6 +105,7 @@ function OperatingCostsSection(props: IProps) {
             <div className="space-y-2">
               <Label htmlFor="hausgeldAllocable">
                 House Allowance - Allocable (EUR/month)
+                <FieldTooltip text="Umlagefähige Nebenkosten — costs passed through to the tenant (heating, water, garbage, cleaning, etc.)" />
               </Label>
               <Input
                 id="hausgeldAllocable"
@@ -123,6 +125,7 @@ function OperatingCostsSection(props: IProps) {
             <div className="space-y-2">
               <Label htmlFor="propertyTaxMonthly">
                 Property Tax (EUR/month)
+                <FieldTooltip text="Grundsteuer — municipal property tax, allocable to the tenant under German law" />
               </Label>
               <Input
                 id="propertyTaxMonthly"
@@ -153,6 +156,7 @@ function OperatingCostsSection(props: IProps) {
             <div className="space-y-2">
               <Label htmlFor="hausgeldNonAllocable">
                 House Allowance - Non-allocable (EUR/month)
+                <FieldTooltip text="Nicht umlagefähige Kosten — landlord-only costs that cannot be passed to the tenant (property management fees, etc.)" />
               </Label>
               <Input
                 id="hausgeldNonAllocable"
@@ -170,7 +174,10 @@ function OperatingCostsSection(props: IProps) {
               </p>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="reservesPortion">Reserves (EUR/month)</Label>
+              <Label htmlFor="reservesPortion">
+                Reserves (EUR/month)
+                <FieldTooltip text="Instandhaltungsrücklage — mandatory repair fund contribution for the building, set by the HOA" />
+              </Label>
               <Input
                 id="reservesPortion"
                 type="number"

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
@@ -190,7 +190,7 @@ function OperatingCostsSection(props: IProps) {
                 }
               />
               <p className="text-xs text-muted-foreground">
-                Instandhaltungsrucklage
+                Instandhaltungsrücklage
               </p>
             </div>
           </div>

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/common/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { FieldTooltip } from "../FieldTooltip"
 import type { PropertyInfoInputs } from "../types"
 
 interface IProps {
@@ -108,6 +109,7 @@ function PropertyInfoSection(props: IProps) {
           <div className="space-y-2">
             <Label htmlFor="squareMeters">
               Living Space (m²) <span className="text-destructive">*</span>
+              <FieldTooltip text="Total usable living area in square meters, as listed in the property exposé (Wohnfläche)" />
             </Label>
             <Input
               id="squareMeters"
@@ -155,7 +157,10 @@ function PropertyInfoSection(props: IProps) {
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="brokerFee">Broker Fee (%)</Label>
+              <Label htmlFor="brokerFee">
+                Broker Fee (%)
+                <FieldTooltip text="Maklergebühr — agent commission, typically 3-7% split between buyer and seller" />
+              </Label>
               <Input
                 id="brokerFee"
                 type="number"
@@ -169,7 +174,10 @@ function PropertyInfoSection(props: IProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="notaryFee">Notary Fee (%)</Label>
+              <Label htmlFor="notaryFee">
+                Notary Fee (%)
+                <FieldTooltip text="Notargebühren — legally required for property transfer, typically ~1.5% of purchase price" />
+              </Label>
               <Input
                 id="notaryFee"
                 type="number"
@@ -183,7 +191,10 @@ function PropertyInfoSection(props: IProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="landRegistryFee">Land Registry Fee (%)</Label>
+              <Label htmlFor="landRegistryFee">
+                Land Registry Fee (%)
+                <FieldTooltip text="Grundbuchgebühren — fee for registering ownership in the Grundbuch, typically ~0.5%" />
+              </Label>
               <Input
                 id="landRegistryFee"
                 type="number"
@@ -197,7 +208,10 @@ function PropertyInfoSection(props: IProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="transferTax">Transfer Tax (%)</Label>
+              <Label htmlFor="transferTax">
+                Transfer Tax (%)
+                <FieldTooltip text="Grunderwerbsteuer — varies by state (Bundesland), from 3.5% to 6.5% of purchase price" />
+              </Label>
               <Input
                 id="transferTax"
                 type="number"

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/common/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { FieldTooltip } from "../FieldTooltip"
 import type { RentInputs } from "../types"
 
 interface IProps {
@@ -61,7 +62,10 @@ function RentSection(props: IProps) {
         </p>
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="rentPerSqm">Rent per m² (EUR)</Label>
+            <Label htmlFor="rentPerSqm">
+              Rent per m² (EUR)
+              <FieldTooltip text="Monthly cold rent (Kaltmiete) per square meter, excluding utilities and operating costs" />
+            </Label>
             <Input
               id="rentPerSqm"
               type="number"
@@ -127,7 +131,10 @@ function RentSection(props: IProps) {
           <p className="text-sm font-medium text-muted-foreground">Taxes</p>
           <div className="grid gap-4 sm:grid-cols-3">
             <div className="space-y-2">
-              <Label htmlFor="depreciationRate">Depreciation Rate (%)</Label>
+              <Label htmlFor="depreciationRate">
+                Depreciation Rate (%)
+                <FieldTooltip text="AfA (Absetzung für Abnutzung) — tax-deductible building wear. 2% for buildings built after 1924, 2.5% for older" />
+              </Label>
               <Input
                 id="depreciationRate"
                 type="number"
@@ -141,7 +148,10 @@ function RentSection(props: IProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="buildingShare">Building Share (%)</Label>
+              <Label htmlFor="buildingShare">
+                Building Share (%)
+                <FieldTooltip text="Percentage of purchase price attributable to the building (not land). Used for depreciation calculation" />
+              </Label>
               <Input
                 id="buildingShare"
                 type="number"
@@ -155,7 +165,10 @@ function RentSection(props: IProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="marginalTaxRate">Marginal Tax Rate (%)</Label>
+              <Label htmlFor="marginalTaxRate">
+                Marginal Tax Rate (%)
+                <FieldTooltip text="Your personal income tax rate in Germany (Einkommensteuer). Standard brackets range from 14% to 45%" />
+              </Label>
               <Input
                 id="marginalTaxRate"
                 type="number"
@@ -180,7 +193,10 @@ function RentSection(props: IProps) {
           <p className="text-sm font-medium text-muted-foreground">Forecast</p>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="costIncrease">Cost Increase p.a. (%)</Label>
+              <Label htmlFor="costIncrease">
+                Cost Increase p.a. (%)
+                <FieldTooltip text="Expected annual increase in operating costs, typically tracking inflation" />
+              </Label>
               <Input
                 id="costIncrease"
                 type="number"
@@ -194,7 +210,10 @@ function RentSection(props: IProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="rentIncrease">Rent Increase p.a. (%)</Label>
+              <Label htmlFor="rentIncrease">
+                Rent Increase p.a. (%)
+                <FieldTooltip text="Expected annual rent increase. Subject to Mietpreisbremse (rent cap) in regulated areas" />
+              </Label>
               <Input
                 id="rentIncrease"
                 type="number"
@@ -208,7 +227,10 @@ function RentSection(props: IProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="valueIncrease">Value Increase p.a. (%)</Label>
+              <Label htmlFor="valueIncrease">
+                Value Increase p.a. (%)
+                <FieldTooltip text="Expected annual property value appreciation rate" />
+              </Label>
               <Input
                 id="valueIncrease"
                 type="number"
@@ -224,6 +246,7 @@ function RentSection(props: IProps) {
             <div className="space-y-2">
               <Label htmlFor="equityInterest">
                 Interest on Equity p.a. (%)
+                <FieldTooltip text="Opportunity cost — what your equity could earn if invested elsewhere (e.g., stock market returns)" />
               </Label>
               <Input
                 id="equityInterest"


### PR DESCRIPTION
## Summary
- Adds info icon tooltips (i) next to evaluation form field labels explaining German real estate terminology
- Creates reusable `FieldTooltip` component using Radix Tooltip with controlled state for mobile tap support
- Tooltips work on desktop (hover) and mobile (tap to toggle), fixing the mobile tooltip interaction bug
- 16 fields across Property Info, Rent/Taxes/Forecast, and Operating Costs sections get contextual help
- Tooltip text includes German terms (Grunderwerbsteuer, AfA, Hausgeld, etc.) to bridge the language gap

## Test plan
- [ ] Desktop: hover info icon — verify tooltip appears with German terminology explanation
- [ ] Desktop: hover away — verify tooltip disappears
- [ ] Mobile (375px): tap info icon — verify tooltip appears
- [ ] Mobile: tap again or elsewhere — verify tooltip closes
- [ ] Verify tooltips don't clip viewport edges (Radix auto-repositions)
- [ ] Verify tooltip doesn't interfere with form input interaction
- [ ] Check all 4 sections: Property Info (5), Rent (8), Operating Costs (4)