### PR TITLE
fix(evaluation): fix page scroll position on navigation

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -21,7 +21,11 @@ if (import.meta.env.VITE_SENTRY_DSN) {
 // Initialize API client with base URL and token handler
 initializeApiClient()
 
-const router = createRouter({ routeTree })
+const router = createRouter({
+  routeTree,
+  defaultPreloadStaleTime: 0,
+  scrollRestoration: true,
+})
 declare module "@tanstack/react-router" {
   interface Register {
     router: typeof router

--- a/frontend/src/routes/_layout/journeys/$journeyId.property-evaluation.tsx
+++ b/frontend/src/routes/_layout/journeys/$journeyId.property-evaluation.tsx
@@ -4,7 +4,6 @@
  */
 
 import { createFileRoute } from "@tanstack/react-router"
-import { useEffect } from "react"
 
 import { PropertyEvaluationCalculator } from "@/components/Calculators/PropertyEvaluationCalculator"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -54,11 +53,6 @@ function PropertyEvaluationPage() {
   const { journeyId } = Route.useParams()
 
   const { data: journey, isLoading } = useJourney(journeyId)
-
-  // Scroll to top on mount
-  useEffect(() => {
-    window.scrollTo(0, 0)
-  }, [])
 
   if (isLoading) {
     return <LoadingSkeleton />


### PR DESCRIPTION
## Summary
- Enable TanStack Router `scrollRestoration` globally so all pages load from the top on navigation
- Remove manual `useEffect`/`window.scrollTo` from the evaluation route (router handles it now)
- Also set `defaultPreloadStaleTime: 0` for correct preloading behavior

## Test plan
- [ ] Navigate to property evaluation from another page — page loads at the top
- [ ] Navigate between tabs on calculators page — scroll resets
- [ ] Test on mobile viewport — same scroll-to-top behavior
- [ ] Browser back/forward — scroll position is restored correctly