### PR TITLE
fix(evaluation): make title and subtitle full-width on mobile

### DIFF
--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -363,7 +363,7 @@ function PropertyEvaluationCalculator(
     <div className={cn("space-y-6", className)}>
       {/* Header */}
       <div className="space-y-3 sm:space-y-0 sm:flex sm:items-start sm:gap-4">
-        <div className="flex items-start gap-3 flex-1 min-w-0">
+        <div className="flex items-start gap-3 sm:flex-1 min-w-0">
           {journeyId && (
             <Button variant="ghost" size="icon" className="shrink-0" asChild>
               <Link to="/journeys/$journeyId" params={{ journeyId }}>

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -363,7 +363,7 @@ function PropertyEvaluationCalculator(
     <div className={cn("space-y-6", className)}>
       {/* Header */}
       <div className="space-y-3 sm:space-y-0 sm:flex sm:items-start sm:gap-4">
-        <div className="flex items-start gap-3 min-w-0">
+        <div className="flex items-start gap-3 flex-1 min-w-0">
           {journeyId && (
             <Button variant="ghost" size="icon" className="shrink-0" asChild>
               <Link to="/journeys/$journeyId" params={{ journeyId }}>
@@ -371,7 +371,7 @@ function PropertyEvaluationCalculator(
               </Link>
             </Button>
           )}
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <h1 className="text-xl sm:text-2xl font-bold">
               Property Evaluation Calculator
             </h1>


### PR DESCRIPTION
## Summary
- Add `flex-1` to the title wrapper divs so the title and subtitle fill remaining width on mobile (375px)
- Prevents title from being compressed when the back button is present

## Test plan
- [ ] View evaluation page at 375px viewport — title and subtitle are full-width and readable
- [ ] View with journey context (back button visible) — title still takes full width
- [ ] View on desktop — no visual change