### PR TITLE
feat(evaluation): display average rent per sqm by state

### DIFF
--- a/frontend/src/common/constants/propertyGoals.ts
+++ b/frontend/src/common/constants/propertyGoals.ts
@@ -60,6 +60,8 @@ export const MARKET_DATA_BY_STATE: Record<
   {
     avgPricePerSqm: number
     priceRange: { min: number; max: number }
+    avgRentPerSqm: number
+    rentRange: { min: number; max: number }
     agentFeePercent: number
     trend: "rising" | "stable" | "falling"
     hotspots: string[]
@@ -68,6 +70,8 @@ export const MARKET_DATA_BY_STATE: Record<
   BW: {
     avgPricePerSqm: 3800,
     priceRange: { min: 2500, max: 6000 },
+    avgRentPerSqm: 10.5,
+    rentRange: { min: 7.5, max: 14.0 },
     agentFeePercent: 3.57,
     trend: "stable",
     hotspots: ["Stuttgart", "Freiburg", "Karlsruhe"],
@@ -75,6 +79,8 @@ export const MARKET_DATA_BY_STATE: Record<
   BY: {
     avgPricePerSqm: 4500,
     priceRange: { min: 2800, max: 9000 },
+    avgRentPerSqm: 12.0,
+    rentRange: { min: 8.0, max: 18.0 },
     agentFeePercent: 3.57,
     trend: "stable",
     hotspots: ["Munich", "Nuremberg", "Augsburg"],
@@ -82,6 +88,8 @@ export const MARKET_DATA_BY_STATE: Record<
   BE: {
     avgPricePerSqm: 5200,
     priceRange: { min: 3500, max: 8000 },
+    avgRentPerSqm: 13.5,
+    rentRange: { min: 10.0, max: 17.0 },
     agentFeePercent: 3.57,
     trend: "rising",
     hotspots: ["Mitte", "Prenzlauer Berg", "Kreuzberg"],
@@ -89,6 +97,8 @@ export const MARKET_DATA_BY_STATE: Record<
   BB: {
     avgPricePerSqm: 2800,
     priceRange: { min: 1800, max: 4500 },
+    avgRentPerSqm: 8.0,
+    rentRange: { min: 6.0, max: 11.0 },
     agentFeePercent: 3.57,
     trend: "rising",
     hotspots: ["Potsdam", "Cottbus", "Brandenburg an der Havel"],
@@ -96,6 +106,8 @@ export const MARKET_DATA_BY_STATE: Record<
   HB: {
     avgPricePerSqm: 2900,
     priceRange: { min: 2000, max: 4500 },
+    avgRentPerSqm: 8.5,
+    rentRange: { min: 6.5, max: 11.0 },
     agentFeePercent: 2.98,
     trend: "stable",
     hotspots: ["Bremen-Mitte", "Schwachhausen", "Horn-Lehe"],
@@ -103,6 +115,8 @@ export const MARKET_DATA_BY_STATE: Record<
   HH: {
     avgPricePerSqm: 5800,
     priceRange: { min: 4000, max: 10000 },
+    avgRentPerSqm: 13.0,
+    rentRange: { min: 9.5, max: 17.5 },
     agentFeePercent: 3.12,
     trend: "stable",
     hotspots: ["Eppendorf", "Winterhude", "Eimsbüttel"],
@@ -110,6 +124,8 @@ export const MARKET_DATA_BY_STATE: Record<
   HE: {
     avgPricePerSqm: 3600,
     priceRange: { min: 2200, max: 7000 },
+    avgRentPerSqm: 11.0,
+    rentRange: { min: 8.0, max: 15.0 },
     agentFeePercent: 2.98,
     trend: "stable",
     hotspots: ["Frankfurt", "Wiesbaden", "Darmstadt"],
@@ -117,6 +133,8 @@ export const MARKET_DATA_BY_STATE: Record<
   MV: {
     avgPricePerSqm: 2200,
     priceRange: { min: 1400, max: 4000 },
+    avgRentPerSqm: 7.5,
+    rentRange: { min: 5.5, max: 10.0 },
     agentFeePercent: 2.98,
     trend: "rising",
     hotspots: ["Rostock", "Schwerin", "Greifswald"],
@@ -124,6 +142,8 @@ export const MARKET_DATA_BY_STATE: Record<
   NI: {
     avgPricePerSqm: 2600,
     priceRange: { min: 1800, max: 4500 },
+    avgRentPerSqm: 8.5,
+    rentRange: { min: 6.5, max: 11.5 },
     agentFeePercent: 2.98,
     trend: "stable",
     hotspots: ["Hannover", "Braunschweig", "Oldenburg"],
@@ -131,6 +151,8 @@ export const MARKET_DATA_BY_STATE: Record<
   NW: {
     avgPricePerSqm: 3200,
     priceRange: { min: 2000, max: 6000 },
+    avgRentPerSqm: 9.5,
+    rentRange: { min: 7.0, max: 13.5 },
     agentFeePercent: 3.57,
     trend: "stable",
     hotspots: ["Düsseldorf", "Cologne", "Münster"],
@@ -138,6 +160,8 @@ export const MARKET_DATA_BY_STATE: Record<
   RP: {
     avgPricePerSqm: 2400,
     priceRange: { min: 1600, max: 4000 },
+    avgRentPerSqm: 8.0,
+    rentRange: { min: 6.0, max: 10.5 },
     agentFeePercent: 2.98,
     trend: "stable",
     hotspots: ["Mainz", "Koblenz", "Trier"],
@@ -145,6 +169,8 @@ export const MARKET_DATA_BY_STATE: Record<
   SL: {
     avgPricePerSqm: 2000,
     priceRange: { min: 1400, max: 3200 },
+    avgRentPerSqm: 7.0,
+    rentRange: { min: 5.5, max: 9.0 },
     agentFeePercent: 3.57,
     trend: "stable",
     hotspots: ["Saarbrücken", "Neunkirchen", "Homburg"],
@@ -152,6 +178,8 @@ export const MARKET_DATA_BY_STATE: Record<
   SN: {
     avgPricePerSqm: 2400,
     priceRange: { min: 1600, max: 4000 },
+    avgRentPerSqm: 7.5,
+    rentRange: { min: 5.5, max: 10.0 },
     agentFeePercent: 2.98,
     trend: "rising",
     hotspots: ["Leipzig", "Dresden", "Chemnitz"],
@@ -159,6 +187,8 @@ export const MARKET_DATA_BY_STATE: Record<
   ST: {
     avgPricePerSqm: 1800,
     priceRange: { min: 1200, max: 3000 },
+    avgRentPerSqm: 6.5,
+    rentRange: { min: 5.0, max: 8.5 },
     agentFeePercent: 2.98,
     trend: "stable",
     hotspots: ["Magdeburg", "Halle", "Dessau"],
@@ -166,6 +196,8 @@ export const MARKET_DATA_BY_STATE: Record<
   SH: {
     avgPricePerSqm: 3000,
     priceRange: { min: 2000, max: 5500 },
+    avgRentPerSqm: 9.5,
+    rentRange: { min: 7.0, max: 12.5 },
     agentFeePercent: 3.57,
     trend: "stable",
     hotspots: ["Kiel", "Lübeck", "Flensburg"],
@@ -173,6 +205,8 @@ export const MARKET_DATA_BY_STATE: Record<
   TH: {
     avgPricePerSqm: 1900,
     priceRange: { min: 1300, max: 3200 },
+    avgRentPerSqm: 6.5,
+    rentRange: { min: 5.0, max: 8.5 },
     agentFeePercent: 2.98,
     trend: "stable",
     hotspots: ["Erfurt", "Jena", "Weimar"],

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -409,6 +409,7 @@ function PropertyEvaluationCalculator(
             values={state.rent}
             squareMeters={state.propertyInfo.squareMeters}
             totalAllocableCosts={totalAllocableCosts}
+            stateCode={initialState}
             onChange={updateRent}
           />
           <OperatingCostsSection

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
@@ -3,8 +3,10 @@
  * Inputs for rental income, depreciation, tax settings, and forecast assumptions
  */
 
-import { Banknote } from "lucide-react"
+import { Banknote, Info } from "lucide-react"
+import { GERMAN_STATES } from "@/common/constants"
 import { SECTION_COLORS } from "@/common/constants/propertyEvaluation"
+import { MARKET_DATA_BY_STATE } from "@/common/constants/propertyGoals"
 import { cn } from "@/common/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -16,6 +18,7 @@ interface IProps {
   values: RentInputs
   squareMeters: number
   totalAllocableCosts: number
+  stateCode?: string
   onChange: (updates: Partial<RentInputs>) => void
   className?: string
 }
@@ -36,8 +39,19 @@ const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
 
 /** Default component. Rent, Taxes, Forecast section. */
 function RentSection(props: IProps) {
-  const { values, squareMeters, totalAllocableCosts, onChange, className } =
-    props
+  const {
+    values,
+    squareMeters,
+    totalAllocableCosts,
+    stateCode,
+    onChange,
+    className,
+  } = props
+
+  const marketData = stateCode ? MARKET_DATA_BY_STATE[stateCode] : undefined
+  const stateName = stateCode
+    ? GERMAN_STATES.find((s) => s.code === stateCode)?.name
+    : undefined
 
   const handleNumberChange = (field: keyof RentInputs, value: string) => {
     const num = parseFloat(value) || 0
@@ -91,6 +105,15 @@ function RentSection(props: IProps) {
             />
           </div>
         </div>
+        {marketData && stateName && (
+          <p className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Info className="h-3 w-3 shrink-0" />
+            Average in {stateName}:{" "}
+            {CURRENCY_FORMATTER.format(marketData.avgRentPerSqm)}/m² (range:{" "}
+            {CURRENCY_FORMATTER.format(marketData.rentRange.min)} –{" "}
+            {CURRENCY_FORMATTER.format(marketData.rentRange.max)})
+          </p>
+        )}
 
         {/* Rent summary */}
         {squareMeters > 0 && (


### PR DESCRIPTION
## Summary
- Add `avgRentPerSqm` and `rentRange` data to `MARKET_DATA_BY_STATE` for all 16 German states (based on 2024 Mietspiegel cold rent averages)
- Show a contextual info badge below the rent input when a state code is available from the journey (e.g. "Average in Berlin: 13,50 €/m² (range: 10,00 € – 17,00 €)")
- No badge shown for standalone calculator usage (no state)

## Test plan
- [ ] `npx tsc -p tsconfig.build.json --noEmit` — passes
- [ ] `bun run lint` — passes
- [ ] Open evaluation from journey with state set — average rent badge appears below rent input
- [ ] Open standalone calculator (no state) — no badge shown