### PR TITLE
fix: resolve auth cache leak, journey progress sync, and UI issues

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONUNBUFFERED=1
 
 # Install uv
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /uvx /bin/
+COPY --from=docker.io/astral/uv:0.11.6 /uv /uvx /bin/
 
 # Compile bytecode
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode

--- a/backend/app/api/routes/journeys.py
+++ b/backend/app/api/routes/journeys.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from app.api.deps import CurrentUser, get_db
-from app.models.journey import Journey, JourneyStep, JourneyTask
+from app.models.journey import Journey, JourneyStep, JourneyTask, StepStatus
 from app.models.notification import NotificationType
 from app.schemas.journey import (
     JourneyCreate,
@@ -87,6 +87,9 @@ def _build_step_response(step: JourneyStep) -> JourneyStepResponse:
 
 def _build_journey_response(journey: Journey) -> JourneyResponse:
     steps = [_build_step_summary(s) for s in journey.steps]
+    total = len(journey.steps)
+    completed = sum(1 for s in journey.steps if s.status == StepStatus.COMPLETED)
+    pct = round((completed / total) * 100, 1) if total > 0 else 0
     return JourneyResponse(
         id=journey.id,
         title=journey.title,
@@ -110,6 +113,9 @@ def _build_journey_response(journey: Journey) -> JourneyResponse:
         is_active=journey.is_active,
         created_at=journey.created_at,
         steps=steps,
+        progress_percentage=pct,
+        completed_steps=completed,
+        total_steps=total,
     )
 
 

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -239,6 +239,9 @@ class JourneyResponse(BaseModel):
     is_active: bool
     created_at: datetime
     steps: list[JourneyStepSummary] = []
+    progress_percentage: float = 0
+    completed_steps: int = 0
+    total_steps: int = 0
 
 
 class JourneyDetailResponse(JourneyResponse):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,8 @@ from collections.abc import AsyncGenerator, Generator
 
 import pytest
 import pytest_asyncio
+from alembic import command
+from alembic.config import Config
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -18,6 +20,8 @@ from tests.utils.utils import get_superuser_token_headers
 # Sync fixtures (backward compatibility)
 @pytest.fixture(scope="session", autouse=True)
 def db() -> Generator[Session, None, None]:
+    alembic_cfg = Config("alembic.ini")
+    command.upgrade(alembic_cfg, "head")
     with Session(engine) as session:
         init_db(session)
         yield session

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2405,6 +2405,21 @@ export const JourneyDetailResponseSchema = {
             type: 'array',
             title: 'Steps',
             default: []
+        },
+        progress_percentage: {
+            type: 'number',
+            title: 'Progress Percentage',
+            default: 0
+        },
+        completed_steps: {
+            type: 'integer',
+            title: 'Completed Steps',
+            default: 0
+        },
+        total_steps: {
+            type: 'integer',
+            title: 'Total Steps',
+            default: 0
         }
     },
     type: 'object',
@@ -2708,6 +2723,21 @@ export const JourneyResponseSchema = {
             type: 'array',
             title: 'Steps',
             default: []
+        },
+        progress_percentage: {
+            type: 'number',
+            title: 'Progress Percentage',
+            default: 0
+        },
+        completed_steps: {
+            type: 'integer',
+            title: 'Completed Steps',
+            default: 0
+        },
+        total_steps: {
+            type: 'integer',
+            title: 'Total Steps',
+            default: 0
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -737,6 +737,9 @@ export type JourneyDetailResponse = {
     is_active: boolean;
     created_at: string;
     steps?: Array<JourneyStepResponse>;
+    progress_percentage?: number;
+    completed_steps?: number;
+    total_steps?: number;
 };
 
 /**
@@ -806,6 +809,9 @@ export type JourneyResponse = {
     is_active: boolean;
     created_at: string;
     steps?: Array<JourneyStepSummary>;
+    progress_percentage?: number;
+    completed_steps?: number;
+    total_steps?: number;
 };
 
 /**

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -243,6 +243,7 @@ function QuickActions(props: { journeyId?: string }) {
       label: "Evaluate Property",
       icon: TrendingUp,
       to: "/calculators" as const,
+      search: { tab: "property-evaluation" } as const,
       color: "text-teal-600",
     },
     {
@@ -266,7 +267,10 @@ function QuickActions(props: { journeyId?: string }) {
             className="justify-start gap-3"
             asChild
           >
-            <Link to={action.to}>
+            <Link
+              to={action.to}
+              {...("search" in action ? { search: action.search } : {})}
+            >
               <action.icon className={cn("h-4 w-4", action.color)} />
               {action.label}
             </Link>

--- a/frontend/src/components/Journey/JourneyList.tsx
+++ b/frontend/src/components/Journey/JourneyList.tsx
@@ -9,7 +9,7 @@ import { Compass, Plus } from "lucide-react"
 import { cn } from "@/common/utils"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { JourneyPublic } from "@/models/journey"
+import type { JourneyProgress, JourneyPublic } from "@/models/journey"
 import { JourneyCard } from "./JourneyCard"
 
 interface IProps {
@@ -90,9 +90,25 @@ function JourneyList(props: IProps) {
 
   return (
     <div className={cn("grid gap-6 md:grid-cols-2 lg:grid-cols-3", className)}>
-      {journeys.map((journey) => (
-        <JourneyCard key={journey.id} journey={journey} onDelete={onDelete} />
-      ))}
+      {journeys.map((journey) => {
+        const progress: JourneyProgress = {
+          journey_id: journey.id,
+          total_steps: journey.total_steps,
+          completed_steps: journey.completed_steps,
+          current_step_number: journey.current_step_number,
+          current_phase: journey.current_phase,
+          progress_percentage: journey.progress_percentage,
+          phases: {},
+        }
+        return (
+          <JourneyCard
+            key={journey.id}
+            journey={journey}
+            progress={progress}
+            onDelete={onDelete}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/components/Landing/CtaSection.tsx
+++ b/frontend/src/components/Landing/CtaSection.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
+import { isLoggedIn } from "@/hooks/useAuth"
 
 /******************************************************************************
                               Components
@@ -8,29 +9,47 @@ import { Button } from "@/components/ui/button"
 
 /** Default component. Call-to-action banner section. */
 function CtaSection() {
+  const loggedIn = isLoggedIn()
+
   return (
     <section className="bg-gradient-to-r from-blue-600 to-purple-600 py-20 md:py-28">
       <div className="mx-auto max-w-3xl px-4 text-center md:px-6">
         <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">
-          Ready to Start Your German Property Journey?
+          {loggedIn
+            ? "Continue Your German Property Journey"
+            : "Ready to Start Your German Property Journey?"}
         </h2>
         <p className="mt-4 text-lg text-blue-100">
-          Join thousands of international buyers who navigate German real estate
-          with confidence using HeimPath.
+          {loggedIn
+            ? "Pick up where you left off and take the next step toward owning property in Germany."
+            : "Join thousands of international buyers who navigate German real estate with confidence using HeimPath."}
         </p>
         <div className="mt-8 flex flex-col items-center gap-4">
-          <Button size="lg" variant="secondary" className="text-base" asChild>
-            <Link to="/signup">Create Free Account</Link>
-          </Button>
-          <p className="text-sm text-blue-200">
-            Already have an account?{" "}
-            <Link
-              to="/login"
-              className="font-medium text-white underline underline-offset-4 hover:text-blue-100"
-            >
-              Sign in
-            </Link>
-          </p>
+          {loggedIn ? (
+            <Button size="lg" variant="secondary" className="text-base" asChild>
+              <Link to="/dashboard">Continue Your Journey</Link>
+            </Button>
+          ) : (
+            <>
+              <Button
+                size="lg"
+                variant="secondary"
+                className="text-base"
+                asChild
+              >
+                <Link to="/signup">Create Free Account</Link>
+              </Button>
+              <p className="text-sm text-blue-200">
+                Already have an account?{" "}
+                <Link
+                  to="/login"
+                  className="font-medium text-white underline underline-offset-4 hover:text-blue-100"
+                >
+                  Sign in
+                </Link>
+              </p>
+            </>
+          )}
         </div>
       </div>
     </section>

--- a/frontend/src/components/Landing/PropertyEvaluationCtaSection.tsx
+++ b/frontend/src/components/Landing/PropertyEvaluationCtaSection.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router"
 import { ArrowRight, TrendingUp } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { isLoggedIn } from "@/hooks/useAuth"
 
 /******************************************************************************
                               Components
@@ -9,6 +10,8 @@ import { Button } from "@/components/ui/button"
 
 /** Property evaluation CTA banner for the landing page. */
 function PropertyEvaluationCtaSection() {
+  const loggedIn = isLoggedIn()
+
   return (
     <section className="bg-gradient-to-r from-teal-50 to-blue-50 py-16 dark:from-teal-950/20 dark:to-blue-950/20 md:py-20">
       <div className="mx-auto flex max-w-5xl flex-col items-center gap-8 px-4 md:flex-row md:px-6">
@@ -26,23 +29,34 @@ function PropertyEvaluationCtaSection() {
           </p>
         </div>
         <div className="flex shrink-0 flex-col gap-3">
-          <Button size="lg" asChild>
-            <Link
-              to="/signup"
-              search={{ redirect: "/calculators?tab=property-evaluation" }}
-            >
-              Get Started Free
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
-          <Button size="lg" variant="outline" asChild>
-            <Link
-              to="/login"
-              search={{ redirect: "/calculators?tab=property-evaluation" }}
-            >
-              Sign In to Evaluate
-            </Link>
-          </Button>
+          {loggedIn ? (
+            <Button size="lg" asChild>
+              <Link to="/calculators" search={{ tab: "property-evaluation" }}>
+                Evaluate Property
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          ) : (
+            <>
+              <Button size="lg" asChild>
+                <Link
+                  to="/signup"
+                  search={{ redirect: "/calculators?tab=property-evaluation" }}
+                >
+                  Get Started Free
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+              <Button size="lg" variant="outline" asChild>
+                <Link
+                  to="/login"
+                  search={{ redirect: "/calculators?tab=property-evaluation" }}
+                >
+                  Sign In to Evaluate
+                </Link>
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </section>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -9,6 +9,7 @@ import {
   type UserPublic,
   UsersService,
 } from "@/client"
+import { queryClient } from "@/query/client"
 import { handleError } from "@/utils"
 import useCustomToast from "./useCustomToast"
 
@@ -39,6 +40,7 @@ const useAuth = (redirectTo?: string) => {
     const response = await LoginService.loginAccessToken({
       formData: data,
     })
+    queryClient.clear()
     localStorage.setItem("access_token", response.access_token)
   }
 
@@ -55,7 +57,15 @@ const useAuth = (redirectTo?: string) => {
   })
 
   const logout = () => {
+    queryClient.clear()
     localStorage.removeItem("access_token")
+    localStorage.removeItem("heimpath-wizard-state")
+    localStorage.removeItem("heimpath-wizard-step")
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith("property-evaluation-")) {
+        localStorage.removeItem(key)
+      }
+    }
     navigate({ to: "/login" })
   }
 

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -70,6 +70,9 @@ export interface JourneyPublic {
   is_active: boolean
   created_at: string
   steps: JourneyStep[]
+  progress_percentage: number
+  completed_steps: number
+  total_steps: number
 }
 
 /** Frontend wizard state for creating a journey */

--- a/frontend/src/query/client.ts
+++ b/frontend/src/query/client.ts
@@ -6,6 +6,7 @@ import { ApiError } from "@/client"
  */
 const handleApiError = (error: Error) => {
   if (error instanceof ApiError && [401, 403].includes(error.status)) {
+    queryClient.clear()
     localStorage.removeItem("access_token")
     window.location.href = "/login"
   }


### PR DESCRIPTION
## Summary
- **Auth/session bug (critical):** Clear TanStack Query cache on login, logout, and 401/403 auto-logout to prevent stale user data from leaking across sessions. Also clears user-specific localStorage keys (wizard state, property evaluations) on logout.
- **Journey progress out of sync:** Add `progress_percentage`, `completed_steps`, and `total_steps` fields to the journey list API response. `JourneyList` now passes a `JourneyProgress` object to each `JourneyCard` so the progress bar matches the detail page.
- **Dashboard evaluate link:** "Evaluate Property" quick action now includes `tab=property-evaluation` search param so the calculators page opens to the correct tab.
- **Landing page CTAs:** `CtaSection` and `PropertyEvaluationCtaSection` are now auth-aware — logged-in users see "Continue Your Journey" / "Evaluate Property" instead of signup/login buttons.
- **Docker build fix:** Switch uv image from `ghcr.io/astral-sh/uv:0.9.26` (403 Forbidden) to `docker.io/astral/uv:0.11.6`.
- **Test DB fix:** Run `alembic upgrade head` in the test session fixture so the test DB schema stays in sync with migrations.

## Test plan
- [ ] Log in as User A, browse journeys/calculators, log out, log in as User B — User B's data shows immediately with no stale data
- [ ] Complete tasks in a journey, navigate to My Journeys list — progress bar matches the detail page
- [ ] Click "Evaluate Property" quick action on dashboard — calculators page opens on the property-evaluation tab
- [ ] Visit landing page while logged in — CTA shows "Continue Your Journey" and "Evaluate Property"
- [ ] Visit landing page while logged out — original signup/login buttons display
- [ ] `cd frontend && npx tsc -p tsconfig.build.json --noEmit` — clean
- [ ] `cd frontend && bun run lint` — clean
- [ ] `cd backend && pytest tests/ -x -q` — 632 passed
- [ ] `docker compose build backend` — succeeds