### PR TITLE
feat(journey): add bank/financing steps for cash and mortgage buyers

### DIFF
--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -62,7 +62,9 @@ class StepTemplate:
     estimated_costs: dict[str, Any] | None = None
 
 
-# Step templates for the German property buying journey
+# Step templates for the German property buying journey.
+# step_number is a stable template identifier, not a list position — gaps and
+# non-sequential values are expected when conditional steps are inserted.
 STEP_TEMPLATES: list[StepTemplate] = [
     # RESEARCH PHASE
     StepTemplate(
@@ -221,6 +223,37 @@ STEP_TEMPLATES: list[StepTemplate] = [
         conditions={"financing_type": ["mortgage", "mixed"]},
     ),
     StepTemplate(
+        step_number=18,
+        phase=JourneyPhase.PREPARATION,
+        title="Prepare Proof of Funds",
+        description="As a cash buyer, you need to prove you have the funds available. Prepare bank documentation and plan your transfer.",
+        estimated_duration_days=7,
+        content_key="proof_of_funds",
+        tasks=[
+            {
+                "title": "Gather recent bank statements (last 3-6 months)",
+                "is_required": True,
+            },
+            {
+                "title": "Request a proof of funds letter from your bank",
+                "is_required": True,
+            },
+            {
+                "title": "Open a German bank account if you don't have one",
+                "is_required": True,
+            },
+            {
+                "title": "Plan your funds transfer (exchange rates, fees, timing)",
+                "is_required": True,
+            },
+        ],
+        conditions={"financing_type": ["cash"]},
+        prerequisites=[5],
+        related_laws=[
+            "GwG §10-11 (Sorgfaltspflichten — Anti-money laundering due diligence)"
+        ],
+    ),
+    StepTemplate(
         step_number=9,
         phase=JourneyPhase.PREPARATION,
         title="Prepare Required Documents",
@@ -318,13 +351,45 @@ STEP_TEMPLATES: list[StepTemplate] = [
         related_laws=["BGB §311b (Formvorschriften)"],
     ),
     StepTemplate(
+        step_number=19,
+        phase=JourneyPhase.BUYING,
+        title="Secure Final Loan Commitment",
+        description="After reviewing the purchase contract, submit it to your bank to receive the binding loan commitment (Darlehenszusage) before the notary appointment.",
+        estimated_duration_days=14,
+        content_key="loan_commitment",
+        tasks=[
+            {
+                "title": "Submit the purchase contract draft to your bank",
+                "is_required": True,
+            },
+            {
+                "title": "Complete any remaining loan application documents",
+                "is_required": True,
+            },
+            {
+                "title": "Receive the formal loan commitment (Darlehenszusage)",
+                "is_required": True,
+            },
+            {
+                "title": "Review and sign the loan agreement (Darlehensvertrag)",
+                "is_required": True,
+            },
+        ],
+        conditions={"financing_type": ["mortgage", "mixed"]},
+        prerequisites=[13],
+        related_laws=[
+            "BGB §488-505 (Darlehensvertrag)",
+            "BGB §492 (Schriftform bei Verbraucherdarlehen)",
+        ],
+    ),
+    StepTemplate(
         step_number=14,
         phase=JourneyPhase.BUYING,
         title="Sign at the Notary",
         description="Attend the notary appointment and sign the purchase contract.",
         estimated_duration_days=1,
         content_key="notary_signing",
-        prerequisites=[13],
+        prerequisites=[13, 19],
         tasks=[
             {"title": "Bring valid ID to appointment", "is_required": True},
             {"title": "Listen to full contract reading", "is_required": True},

--- a/backend/tests/api/routes/test_journeys.py
+++ b/backend/tests/api/routes/test_journeys.py
@@ -129,6 +129,22 @@ def test_create_journey_cash_buyer_excludes_mortgage_steps(
     # Check that no mortgage-related steps are included
     step_titles = [step["title"] for step in data["steps"]]
     assert "Get Mortgage Pre-Approval" not in step_titles
+    assert "Secure Final Loan Commitment" not in step_titles
+
+    # Cash buyers should get Prepare Proof of Funds
+    assert "Prepare Proof of Funds" in step_titles
+
+
+def test_create_journey_mortgage_buyer_includes_loan_commitment(
+    client: TestClient, db: Session
+) -> None:
+    """Test that mortgage buyers get the loan commitment step but not proof of funds."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey(client, headers)  # default is mortgage
+
+    step_titles = [step["title"] for step in journey["steps"]]
+    assert "Secure Final Loan Commitment" in step_titles
+    assert "Prepare Proof of Funds" not in step_titles
 
 
 def test_list_journeys(client: TestClient, db: Session) -> None:

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -414,8 +414,8 @@ class TestStepTemplates:
     """Tests for step template ordering and content."""
 
     def test_step_templates_total_count(self) -> None:
-        """Test that there are 17 step templates."""
-        assert len(STEP_TEMPLATES) == 17
+        """Test that there are 19 step templates."""
+        assert len(STEP_TEMPLATES) == 19
 
     def test_find_property_is_step_3(self) -> None:
         """Test that Find a Property (property_search) is step 3."""
@@ -479,6 +479,77 @@ class TestStepTemplates:
         assert len(required) == 5
         assert len(optional) == 2
 
+    def test_proof_of_funds_template_exists(self) -> None:
+        """Test that proof_of_funds template exists with correct attributes."""
+        template = next(
+            (t for t in STEP_TEMPLATES if t.content_key == "proof_of_funds"),
+            None,
+        )
+        assert template is not None
+        assert template.step_number == 18
+        assert template.phase == JourneyPhase.PREPARATION
+        assert template.conditions == {"financing_type": ["cash"]}
+        assert template.prerequisites == [5]
+        assert len(template.tasks) == 4
+        assert all(t["is_required"] for t in template.tasks)
+
+    def test_proof_of_funds_included_for_cash_buyer(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that proof_of_funds step is included for cash buyers."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "proof_of_funds"
+        )
+        assert _should_include_step(template, cash_buyer_answers)
+
+    def test_proof_of_funds_excluded_for_mortgage_buyer(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that proof_of_funds step is excluded for mortgage buyers."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "proof_of_funds"
+        )
+        assert not _should_include_step(template, sample_answers)
+
+    def test_loan_commitment_template_exists(self) -> None:
+        """Test that loan_commitment template exists with correct attributes."""
+        template = next(
+            (t for t in STEP_TEMPLATES if t.content_key == "loan_commitment"),
+            None,
+        )
+        assert template is not None
+        assert template.step_number == 19
+        assert template.phase == JourneyPhase.BUYING
+        assert template.conditions == {"financing_type": ["mortgage", "mixed"]}
+        assert template.prerequisites == [13]
+        assert len(template.tasks) == 4
+        assert all(t["is_required"] for t in template.tasks)
+
+    def test_loan_commitment_included_for_mortgage_buyer(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that loan_commitment step is included for mortgage buyers."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "loan_commitment"
+        )
+        assert _should_include_step(template, sample_answers)
+
+    def test_loan_commitment_excluded_for_cash_buyer(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that loan_commitment step is excluded for cash buyers."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "loan_commitment"
+        )
+        assert not _should_include_step(template, cash_buyer_answers)
+
+    def test_notary_signing_prerequisites_include_loan_commitment(self) -> None:
+        """Test that notary signing (step 14) has prerequisites [13, 19]."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "notary_signing"
+        )
+        assert template.prerequisites == [13, 19]
+
     def test_research_phase_steps_order(self) -> None:
         """Test that steps 1-5 are RESEARCH phase with correct content_keys."""
         expected = [
@@ -495,6 +566,89 @@ class TestStepTemplates:
         ):
             assert template.step_number == expected_num
             assert template.content_key == expected_key
+
+
+def _generate_steps(answers: QuestionnaireAnswers) -> list[JourneyStep]:
+    """Generate journey steps from answers and return the JourneyStep objects added to the session."""
+    mock_session = MagicMock()
+    mock_session.exec.return_value.first.return_value = None
+
+    generate_journey(
+        session=mock_session,
+        user_id=uuid.uuid4(),
+        title="Test Journey",
+        answers=answers,
+    )
+
+    return [
+        call.args[0]
+        for call in mock_session.add.call_args_list
+        if isinstance(call.args[0], JourneyStep)
+    ]
+
+
+class TestJourneyStepGeneration:
+    """Tests for step generation with new conditional steps."""
+
+    def test_cash_buyer_includes_proof_of_funds(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that a cash buyer journey includes 'Prepare Proof of Funds'."""
+        steps = _generate_steps(cash_buyer_answers)
+        step_titles = [s.title for s in steps]
+        assert "Prepare Proof of Funds" in step_titles
+
+    def test_cash_buyer_excludes_loan_commitment(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that a cash buyer journey does NOT include 'Secure Final Loan Commitment'."""
+        steps = _generate_steps(cash_buyer_answers)
+        step_titles = [s.title for s in steps]
+        assert "Secure Final Loan Commitment" not in step_titles
+
+    def test_mortgage_buyer_includes_loan_commitment(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that a mortgage buyer journey includes 'Secure Final Loan Commitment'."""
+        steps = _generate_steps(sample_answers)
+        step_titles = [s.title for s in steps]
+        assert "Secure Final Loan Commitment" in step_titles
+
+    def test_mortgage_buyer_excludes_proof_of_funds(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that a mortgage buyer journey does NOT include 'Prepare Proof of Funds'."""
+        steps = _generate_steps(sample_answers)
+        step_titles = [s.title for s in steps]
+        assert "Prepare Proof of Funds" not in step_titles
+
+    def test_cash_buyer_notary_signing_prereq_excludes_loan_commitment(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that for cash buyers, Step 14 prereq resolves to just [remapped 13].
+
+        Step 19 (loan commitment) is excluded for cash buyers, so its prerequisite
+        reference in Step 14 is silently dropped by the remap logic.
+        """
+        steps = _generate_steps(cash_buyer_answers)
+        notary_step = next(
+            (s for s in steps if s.title == "Sign at the Notary"), None
+        )
+        assert notary_step is not None
+        assert notary_step.prerequisites is not None
+        assert len(notary_step.prerequisites) == 1
+
+    def test_mortgage_buyer_notary_signing_has_two_prereqs(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that for mortgage buyers, Step 14 prereqs include both 13 and 19 (remapped)."""
+        steps = _generate_steps(sample_answers)
+        notary_step = next(
+            (s for s in steps if s.title == "Sign at the Notary"), None
+        )
+        assert notary_step is not None
+        assert notary_step.prerequisites is not None
+        assert len(notary_step.prerequisites) == 2
 
 
 def _make_task(

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -497,18 +497,14 @@ class TestStepTemplates:
         self, cash_buyer_answers: QuestionnaireAnswers
     ) -> None:
         """Test that proof_of_funds step is included for cash buyers."""
-        template = next(
-            t for t in STEP_TEMPLATES if t.content_key == "proof_of_funds"
-        )
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "proof_of_funds")
         assert _should_include_step(template, cash_buyer_answers)
 
     def test_proof_of_funds_excluded_for_mortgage_buyer(
         self, sample_answers: QuestionnaireAnswers
     ) -> None:
         """Test that proof_of_funds step is excluded for mortgage buyers."""
-        template = next(
-            t for t in STEP_TEMPLATES if t.content_key == "proof_of_funds"
-        )
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "proof_of_funds")
         assert not _should_include_step(template, sample_answers)
 
     def test_loan_commitment_template_exists(self) -> None:
@@ -529,25 +525,19 @@ class TestStepTemplates:
         self, sample_answers: QuestionnaireAnswers
     ) -> None:
         """Test that loan_commitment step is included for mortgage buyers."""
-        template = next(
-            t for t in STEP_TEMPLATES if t.content_key == "loan_commitment"
-        )
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "loan_commitment")
         assert _should_include_step(template, sample_answers)
 
     def test_loan_commitment_excluded_for_cash_buyer(
         self, cash_buyer_answers: QuestionnaireAnswers
     ) -> None:
         """Test that loan_commitment step is excluded for cash buyers."""
-        template = next(
-            t for t in STEP_TEMPLATES if t.content_key == "loan_commitment"
-        )
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "loan_commitment")
         assert not _should_include_step(template, cash_buyer_answers)
 
     def test_notary_signing_prerequisites_include_loan_commitment(self) -> None:
         """Test that notary signing (step 14) has prerequisites [13, 19]."""
-        template = next(
-            t for t in STEP_TEMPLATES if t.content_key == "notary_signing"
-        )
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "notary_signing")
         assert template.prerequisites == [13, 19]
 
     def test_research_phase_steps_order(self) -> None:
@@ -631,9 +621,7 @@ class TestJourneyStepGeneration:
         reference in Step 14 is silently dropped by the remap logic.
         """
         steps = _generate_steps(cash_buyer_answers)
-        notary_step = next(
-            (s for s in steps if s.title == "Sign at the Notary"), None
-        )
+        notary_step = next((s for s in steps if s.title == "Sign at the Notary"), None)
         assert notary_step is not None
         assert notary_step.prerequisites is not None
         assert len(notary_step.prerequisites) == 1
@@ -643,9 +631,7 @@ class TestJourneyStepGeneration:
     ) -> None:
         """Test that for mortgage buyers, Step 14 prereqs include both 13 and 19 (remapped)."""
         steps = _generate_steps(sample_answers)
-        notary_step = next(
-            (s for s in steps if s.title == "Sign at the Notary"), None
-        )
+        notary_step = next((s for s in steps if s.title == "Sign at the Notary"), None)
         assert notary_step is not None
         assert notary_step.prerequisites is not None
         assert len(notary_step.prerequisites) == 2


### PR DESCRIPTION
## Summary
- Add **Step 18 "Prepare Proof of Funds"** for cash buyers (PREPARATION phase) — covers bank statements, proof of funds letter, German bank account, and transfer planning
- Add **Step 19 "Secure Final Loan Commitment"** for mortgage/mixed buyers (BUYING phase) — covers submitting the purchase contract to the bank, completing loan documents, receiving the Darlehenszusage, and signing the Darlehensvertrag
- Update Step 14 ("Sign at the Notary") prerequisites to `[13, 19]` so mortgage buyers must secure the loan commitment before signing; cash buyers are unaffected via the existing prerequisite remap logic

## Test plan
- [x] Unit tests: 49 tests in `test_journey_service.py` pass (template count, inclusion/exclusion, prerequisite remapping)
- [x] Integration tests: 23 tests in `test_journeys.py` pass (cash buyer gets proof of funds, mortgage buyer gets loan commitment)
- [x] Full backend suite: 646 tests pass
- [x] Frontend SDK regenerated, TypeScript compiles clean