### PR TITLE
feat(journey): add property research tasks to step 3

### DIFF
--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -114,16 +114,41 @@ STEP_TEMPLATES: list[StepTemplate] = [
         step_number=3,
         phase=JourneyPhase.RESEARCH,
         title="Find a Property",
-        description="Search for properties matching your criteria.",
+        description="Search for properties matching your criteria and gather key information during viewings.",
         estimated_duration_days=30,
         content_key="property_search",
         prerequisites=[2],
         tasks=[
             {"title": "Set up alerts on ImmoScout24, Immowelt", "is_required": True},
             {"title": "Contact local Makler (agents)", "is_required": False},
-            {"title": "Schedule viewings", "is_required": True},
+            {"title": "Schedule and attend viewings", "is_required": True},
             {"title": "Take notes and photos at viewings", "is_required": True},
+            {
+                "title": "Request the property exposé from the agent",
+                "is_required": True,
+            },
+            {
+                "title": "Check the Grundbuchauszug (land registry extract)",
+                "is_required": True,
+            },
+            {
+                "title": "Review the Energieausweis (energy certificate)",
+                "is_required": True,
+            },
+            {
+                "title": "Verify building permits and planning permissions",
+                "is_required": False,
+            },
+            {
+                "title": "Check for encumbrances or easements on the property",
+                "is_required": False,
+            },
+            {
+                "title": "Consider commissioning a building survey",
+                "is_required": False,
+            },
         ],
+        related_laws=["GBO (Grundbuchordnung)", "EnEV (Energieeinsparverordnung)"],
     ),
     StepTemplate(
         step_number=4,

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -424,6 +424,29 @@ class TestStepTemplates:
         assert template.content_key == "property_search"
         assert template.phase == JourneyPhase.RESEARCH
 
+    def test_step_3_property_search_tasks(self) -> None:
+        """Test that step 3 has 10 tasks: 6 required, 4 optional."""
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "property_search")
+        assert len(template.tasks) == 10
+        required = [t for t in template.tasks if t["is_required"]]
+        optional = [t for t in template.tasks if not t["is_required"]]
+        assert len(required) == 6
+        assert len(optional) == 4
+
+    def test_step_3_includes_research_tasks(self) -> None:
+        """Test that step 3 includes property research tasks like exposé and land registry."""
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "property_search")
+        task_titles = [t["title"] for t in template.tasks]
+        assert any("exposé" in t for t in task_titles)
+        assert any("Grundbuchauszug" in t for t in task_titles)
+        assert any("Energieausweis" in t for t in task_titles)
+
+    def test_step_3_has_related_laws(self) -> None:
+        """Test that step 3 references relevant German laws."""
+        template = next(t for t in STEP_TEMPLATES if t.content_key == "property_search")
+        assert template.related_laws is not None
+        assert len(template.related_laws) > 0
+
     def test_property_evaluation_template_exists(self) -> None:
         """Test that property_evaluation template exists with correct attributes."""
         template = next(


### PR DESCRIPTION
## Summary
- Expand Step 3 ("Find a Property") from 4 generic search tasks to 10 comprehensive research tasks
- New tasks: request exposé, check Grundbuchauszug, review Energieausweis, verify building permits, check encumbrances, consider building survey
- Add related German law references (GBO, EnEV) to Step 3
- 6 required tasks (search setup, viewings, exposé, land registry, energy cert) + 4 optional (agents, permits, encumbrances, survey)

## Test plan
- [x] Unit tests: 3 new tests for Step 3 task count, research task content, and related laws
- [x] Integration tests: all 23 pass unchanged
- [x] Full suite: 75 journey tests pass