### PR TITLE
feat(journey): tailor document preparation tasks to user situation

### DIFF
--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -282,20 +282,38 @@ STEP_TEMPLATES: list[StepTemplate] = [
         step_number=9,
         phase=JourneyPhase.PREPARATION,
         title="Prepare Required Documents",
-        description="Gather all documents needed for the property purchase.",
+        description="Gather all documents needed for the property purchase, tailored to your situation.",
         estimated_duration_days=7,
         content_key="documents_prep",
         prerequisites=[5],
         tasks=[
+            # Universal tasks — all buyers
             {"title": "Obtain proof of identity (passport/ID)", "is_required": True},
             {"title": "Get proof of address in Germany", "is_required": True},
-            {"title": "Prepare bank statements", "is_required": True},
+            {"title": "Prepare recent bank statements", "is_required": True},
+            # Non-resident tasks
             {
-                "title": "Gather employment contract/proof of income",
+                "title": "Get apostilled or translated copies of personal documents",
                 "is_required": True,
+                "conditions": {"has_german_residency": False},
+            },
+            {
+                "title": "Obtain proof of legal residency or visa documentation",
+                "is_required": True,
+                "conditions": {"has_german_residency": False},
+            },
+            # Mortgage/mixed tasks
+            {
+                "title": "Gather salary statements and employment contract",
+                "is_required": True,
+                "conditions": {"financing_type": ["mortgage", "mixed"]},
+            },
+            {
+                "title": "Request your SCHUFA credit report",
+                "is_required": True,
+                "conditions": {"financing_type": ["mortgage", "mixed"]},
             },
         ],
-        conditions={"has_german_residency": False},
     ),
     # BUYING PHASE
     StepTemplate(
@@ -483,12 +501,17 @@ STEP_TEMPLATES: list[StepTemplate] = [
 ]
 
 
-def _should_include_step(template: StepTemplate, answers: QuestionnaireAnswers) -> bool:
-    """Check if a step should be included based on questionnaire answers."""
-    if template.conditions is None:
+def _matches_conditions(
+    conditions: dict[str, Any] | None, answers: QuestionnaireAnswers
+) -> bool:
+    """Check if a set of conditions matches the questionnaire answers.
+
+    Used for both step-level and task-level conditional inclusion.
+    """
+    if conditions is None:
         return True
 
-    for field, valid_values in template.conditions.items():
+    for field, valid_values in conditions.items():
         answer_value = getattr(answers, field, None)
         if answer_value is None:
             continue
@@ -507,6 +530,11 @@ def _should_include_step(template: StepTemplate, answers: QuestionnaireAnswers) 
                 return False
 
     return True
+
+
+def _should_include_step(template: StepTemplate, answers: QuestionnaireAnswers) -> bool:
+    """Check if a step should be included based on questionnaire answers."""
+    return _matches_conditions(template.conditions, answers)
 
 
 def generate_journey(
@@ -585,11 +613,14 @@ def generate_journey(
         session.add(step)
         session.flush()
 
-        # Create tasks for this step
-        for i, task_data in enumerate(template.tasks):
+        # Create tasks for this step, filtering by task-level conditions
+        task_order = 0
+        for task_data in template.tasks:
+            if not _matches_conditions(task_data.get("conditions"), answers):
+                continue
             task = JourneyTask(
                 step_id=step.id,
-                order=i,
+                order=task_order,
                 title=task_data["title"],
                 is_required=task_data.get("is_required", True),
                 description=task_data.get("description"),
@@ -597,6 +628,7 @@ def generate_journey(
                 resource_type=task_data.get("resource_type"),
             )
             session.add(task)
+            task_order += 1
 
     session.commit()
     session.refresh(journey)

--- a/backend/tests/api/routes/test_journeys.py
+++ b/backend/tests/api/routes/test_journeys.py
@@ -389,6 +389,42 @@ def test_journey_with_non_resident_includes_document_prep(
     step_titles = [step["title"] for step in data["steps"]]
     assert "Prepare Required Documents" in step_titles
 
+    # Fetch full details to check tasks
+    journey_id = data["id"]
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    detail = r.json()
+    doc_step = next(
+        s for s in detail["steps"] if s["title"] == "Prepare Required Documents"
+    )
+    task_titles = [t["title"] for t in doc_step["tasks"]]
+    assert "Get apostilled or translated copies of personal documents" in task_titles
+
+
+def test_resident_journey_includes_document_prep(
+    client: TestClient, db: Session
+) -> None:
+    """Test that residents also get document preparation step with tailored tasks."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey(client, headers)  # default is resident mortgage
+    journey_id = journey["id"]
+
+    step_titles = [step["title"] for step in journey["steps"]]
+    assert "Prepare Required Documents" in step_titles
+
+    # Fetch full details to check tasks
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    detail = r.json()
+    doc_step = next(
+        s for s in detail["steps"] if s["title"] == "Prepare Required Documents"
+    )
+    task_titles = [t["title"] for t in doc_step["tasks"]]
+
+    # Resident should have mortgage tasks but NOT non-resident tasks
+    assert "Gather salary statements and employment contract" in task_titles
+    assert (
+        "Get apostilled or translated copies of personal documents" not in task_titles
+    )
+
 
 def test_update_property_goals_first_save(client: TestClient, db: Session) -> None:
     """Test saving property goals for the first time (property_goals starts as null)."""

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -20,6 +20,7 @@ from app.services.journey_service import (
     STEP_TEMPLATES,
     JourneyNotFoundError,
     StepNotFoundError,
+    _matches_conditions,
     _should_include_step,
     _sync_step_status_from_tasks,
     generate_journey,
@@ -600,6 +601,36 @@ class TestStepTemplates:
             assert template.content_key == expected_key
 
 
+def _generate_steps_with_tasks(
+    answers: QuestionnaireAnswers,
+) -> dict[str, list[JourneyTask]]:
+    """Generate journey and return a dict mapping step title -> list of tasks.
+
+    Since mock sessions don't assign real IDs, we group by add-call order:
+    each JourneyStep is followed by its JourneyTask objects until the next step.
+    """
+    mock_session = MagicMock()
+    mock_session.exec.return_value.first.return_value = None
+
+    generate_journey(
+        session=mock_session,
+        user_id=uuid.uuid4(),
+        title="Test Journey",
+        answers=answers,
+    )
+
+    result: dict[str, list[JourneyTask]] = {}
+    current_step_title: str | None = None
+    for call in mock_session.add.call_args_list:
+        obj = call.args[0]
+        if isinstance(obj, JourneyStep):
+            current_step_title = obj.title
+            result[current_step_title] = []
+        elif isinstance(obj, JourneyTask) and current_step_title is not None:
+            result[current_step_title].append(obj)
+    return result
+
+
 def _generate_steps(answers: QuestionnaireAnswers) -> list[JourneyStep]:
     """Generate journey steps from answers and return the JourneyStep objects added to the session."""
     mock_session = MagicMock()
@@ -677,6 +708,128 @@ class TestJourneyStepGeneration:
         assert notary_step is not None
         assert notary_step.prerequisites is not None
         assert len(notary_step.prerequisites) == 2
+
+
+class TestMatchesConditions:
+    """Tests for the _matches_conditions helper."""
+
+    def test_none_conditions_always_matches(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that None conditions always match."""
+        assert _matches_conditions(None, sample_answers)
+
+    def test_matches_bool_condition(self, sample_answers: QuestionnaireAnswers) -> None:
+        """Test that boolean condition matches."""
+        assert _matches_conditions({"has_german_residency": True}, sample_answers)
+
+    def test_rejects_bool_condition(self, sample_answers: QuestionnaireAnswers) -> None:
+        """Test that boolean condition rejects non-match."""
+        assert not _matches_conditions({"has_german_residency": False}, sample_answers)
+
+    def test_matches_list_condition(self, sample_answers: QuestionnaireAnswers) -> None:
+        """Test that list condition matches."""
+        assert _matches_conditions(
+            {"financing_type": ["mortgage", "mixed"]}, sample_answers
+        )
+
+    def test_rejects_list_condition(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that list condition rejects non-match."""
+        assert not _matches_conditions(
+            {"financing_type": ["mortgage", "mixed"]}, cash_buyer_answers
+        )
+
+
+class TestTailoredDocumentTasks:
+    """Tests for Step 9 task-level conditional filtering."""
+
+    def test_documents_prep_included_for_all_buyers(
+        self,
+        sample_answers: QuestionnaireAnswers,
+        cash_buyer_answers: QuestionnaireAnswers,
+    ) -> None:
+        """Test that Prepare Required Documents step is included for all buyers."""
+        for answers in [sample_answers, cash_buyer_answers]:
+            steps_with_tasks = _generate_steps_with_tasks(answers)
+            assert "Prepare Required Documents" in steps_with_tasks
+
+    def test_resident_mortgage_gets_universal_and_mortgage_tasks(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that a resident mortgage buyer gets universal + mortgage tasks, not non-resident tasks."""
+        doc_tasks = _generate_steps_with_tasks(sample_answers)[
+            "Prepare Required Documents"
+        ]
+        task_titles = [t.title for t in doc_tasks]
+
+        # Universal tasks
+        assert "Obtain proof of identity (passport/ID)" in task_titles
+        assert "Get proof of address in Germany" in task_titles
+        assert "Prepare recent bank statements" in task_titles
+        # Mortgage tasks
+        assert "Gather salary statements and employment contract" in task_titles
+        assert "Request your SCHUFA credit report" in task_titles
+        # Non-resident tasks should NOT be present
+        assert (
+            "Get apostilled or translated copies of personal documents"
+            not in task_titles
+        )
+        assert (
+            "Obtain proof of legal residency or visa documentation" not in task_titles
+        )
+
+    def test_non_resident_mortgage_gets_all_tasks(
+        self, non_resident_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that a non-resident mortgage buyer gets universal + non-resident + mortgage tasks."""
+        doc_tasks = _generate_steps_with_tasks(non_resident_answers)[
+            "Prepare Required Documents"
+        ]
+        task_titles = [t.title for t in doc_tasks]
+
+        # All 7 tasks should be present
+        assert len(doc_tasks) == 7
+        assert (
+            "Get apostilled or translated copies of personal documents" in task_titles
+        )
+        assert "Obtain proof of legal residency or visa documentation" in task_titles
+        assert "Gather salary statements and employment contract" in task_titles
+        assert "Request your SCHUFA credit report" in task_titles
+
+    def test_cash_resident_gets_only_universal_tasks(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that a cash-paying resident gets only universal tasks."""
+        doc_tasks = _generate_steps_with_tasks(cash_buyer_answers)[
+            "Prepare Required Documents"
+        ]
+        task_titles = [t.title for t in doc_tasks]
+
+        # Only 3 universal tasks
+        assert len(doc_tasks) == 3
+        assert "Obtain proof of identity (passport/ID)" in task_titles
+        assert "Get proof of address in Germany" in task_titles
+        assert "Prepare recent bank statements" in task_titles
+        # No conditional tasks
+        assert "Gather salary statements and employment contract" not in task_titles
+        assert "Request your SCHUFA credit report" not in task_titles
+        assert (
+            "Get apostilled or translated copies of personal documents"
+            not in task_titles
+        )
+
+    def test_task_order_is_sequential(
+        self, non_resident_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that task order values are sequential after filtering."""
+        doc_tasks = _generate_steps_with_tasks(non_resident_answers)[
+            "Prepare Required Documents"
+        ]
+        sorted_tasks = sorted(doc_tasks, key=lambda t: t.order)
+        orders = [t.order for t in sorted_tasks]
+        assert orders == list(range(len(doc_tasks)))
 
 
 def _make_task(


### PR DESCRIPTION
## Summary
- Step 9 ("Prepare Required Documents") was previously only shown to non-residents — now all buyers see it with tasks tailored to their profile
- Extract `_matches_conditions()` from `_should_include_step()` for reusable condition checking at both step and task level
- Add task-level `conditions` support in `generate_journey` — tasks with conditions are filtered per questionnaire answers
- Universal tasks (all buyers): proof of identity, proof of address, bank statements
- Non-resident tasks: apostilled/translated documents, visa/residency proof
- Mortgage/mixed tasks: salary statements + employment contract, SCHUFA credit report

## Test plan
- [x] Unit tests: 5 new `_matches_conditions` tests, 5 new tailored document tests (resident/mortgage, non-resident/mortgage, cash/resident, task order, step inclusion)
- [x] Integration tests: 2 new tests verifying non-resident and resident task filtering via API
- [x] All 88 journey tests pass