### PR TITLE
feat(journey): personalize step 5 buying costs with user budget and state

### DIFF
--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -19,6 +19,7 @@ from app.models.journey import (
     StepStatus,
 )
 from app.schemas.journey import QuestionnaireAnswers
+from app.services.calculator_service import COST_DEFAULTS, STATE_RATES
 
 
 class JourneyError(Exception):
@@ -165,6 +166,8 @@ STEP_TEMPLATES: list[StepTemplate] = [
             {"title": "Compare with market averages", "is_required": True},
         ],
     ),
+    # Task order matters: _personalize_buying_costs() accesses tasks by index
+    # (0=transfer tax, 1=notary, 2=land registry, 3=agent commission).
     StepTemplate(
         step_number=5,
         phase=JourneyPhase.RESEARCH,
@@ -501,6 +504,113 @@ STEP_TEMPLATES: list[StepTemplate] = [
 ]
 
 
+def _format_eur(amount: float) -> str:
+    """Format a float as a rounded EUR string (e.g. '18,000 EUR')."""
+    return f"{amount:,.0f} EUR"
+
+
+def _personalize_cost_task(
+    original: dict[str, Any],
+    title: str,
+    pct: float,
+    budget: int,
+    cost_suffix: str = "",
+) -> tuple[dict[str, Any], str]:
+    """Build a personalized cost task and its estimated_costs string.
+
+    Args:
+        original: Original task dict to spread into the result.
+        title: Personalized task title.
+        pct: Cost percentage rate.
+        budget: User's budget in euros.
+        cost_suffix: Optional suffix inside the parentheses (e.g. ", if applicable").
+
+    Returns:
+        (task_dict, cost_label) tuple.
+    """
+    amount = budget * (pct / 100)
+    desc = f"Estimated: {_format_eur(amount)} ({pct}% of {_format_eur(budget)})"
+    cost_label = f"{_format_eur(amount)} ({pct}%{cost_suffix})"
+    return {**original, "title": title, "description": desc}, cost_label
+
+
+def _personalize_buying_costs(
+    template: StepTemplate, answers: QuestionnaireAnswers
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Personalize Step 5 buying-cost tasks using the user's budget and state.
+
+    Returns a (tasks, estimated_costs) tuple ready to be stored on the step.
+    """
+    budget = answers.budget_euros
+    state_entry = STATE_RATES.get(answers.property_location)
+    fallback_costs = template.estimated_costs or {}
+
+    notary_pct = COST_DEFAULTS.notary_fee_percent
+    registry_pct = COST_DEFAULTS.land_registry_fee_percent
+    agent_pct = COST_DEFAULTS.agent_commission_percent
+
+    tasks: list[dict[str, Any]] = []
+    estimated_costs: dict[str, Any] = {}
+
+    # --- Transfer tax task (state-dependent) ---
+    original_tax_task = template.tasks[0]
+    if state_entry:
+        state_name, tax_rate = state_entry
+        title = f"Calculate Grunderwerbsteuer ({tax_rate}% in {state_name})"
+        if budget is not None:
+            task, cost_label = _personalize_cost_task(
+                original_tax_task, title, tax_rate, budget
+            )
+            tasks.append(task)
+        else:
+            tasks.append({**original_tax_task, "title": title, "description": None})
+            cost_label = f"{tax_rate}% in {state_name}"
+        estimated_costs["grunderwerbsteuer"] = cost_label
+    else:
+        tasks.append(original_tax_task)
+        estimated_costs["grunderwerbsteuer"] = fallback_costs.get(
+            "grunderwerbsteuer", "3.5-6.5% (varies by state)"
+        )
+
+    # --- Notary, land registry, agent tasks (budget-dependent only) ---
+    cost_specs: list[tuple[int, str, float, str, str]] = [
+        (1, f"Estimate notary fees ({notary_pct}%)", notary_pct, "notary_fees", ""),
+        (
+            2,
+            f"Factor in land registry fees ({registry_pct}%)",
+            registry_pct,
+            "land_registry",
+            "",
+        ),
+        (
+            3,
+            f"Budget for agent commission ({agent_pct}%)",
+            agent_pct,
+            "agent_commission",
+            ", if applicable",
+        ),
+    ]
+    for idx, title, pct, cost_key, suffix in cost_specs:
+        original = template.tasks[idx]
+        if budget is not None:
+            task, cost_label = _personalize_cost_task(
+                original, title, pct, budget, cost_suffix=suffix
+            )
+            tasks.append(task)
+            estimated_costs[cost_key] = cost_label
+        else:
+            tasks.append(original)
+            estimated_costs[cost_key] = fallback_costs.get(cost_key, f"{pct}%")
+
+    # --- Total estimated ---
+    if budget is not None:
+        tax_rate_val = state_entry[1] if state_entry else 0
+        total = budget * ((tax_rate_val + notary_pct + registry_pct + agent_pct) / 100)
+        estimated_costs["total_estimated"] = _format_eur(total)
+
+    return tasks, estimated_costs
+
+
 def _matches_conditions(
     conditions: dict[str, Any] | None, answers: QuestionnaireAnswers
 ) -> bool:
@@ -598,6 +708,14 @@ def generate_journey(
             if mapped_prereqs:
                 prerequisites = [p for p in mapped_prereqs if p is not None]
 
+        # Personalize buying costs step with user's budget and state
+        tasks_data = template.tasks
+        step_estimated_costs = template.estimated_costs
+        if template.content_key == "buying_costs":
+            tasks_data, step_estimated_costs = _personalize_buying_costs(
+                template, answers
+            )
+
         step = JourneyStep(
             journey_id=journey.id,
             step_number=current_step,
@@ -608,14 +726,14 @@ def generate_journey(
             content_key=template.content_key,
             prerequisites=prerequisites,
             related_laws=template.related_laws,
-            estimated_costs=template.estimated_costs,
+            estimated_costs=step_estimated_costs,
         )
         session.add(step)
         session.flush()
 
         # Create tasks for this step, filtering by task-level conditions
         task_order = 0
-        for task_data in template.tasks:
+        for task_data in tasks_data:
             if not _matches_conditions(task_data.get("conditions"), answers):
                 continue
             task = JourneyTask(

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -20,7 +20,9 @@ from app.services.journey_service import (
     STEP_TEMPLATES,
     JourneyNotFoundError,
     StepNotFoundError,
+    StepTemplate,
     _matches_conditions,
+    _personalize_buying_costs,
     _should_include_step,
     _sync_step_status_from_tasks,
     generate_journey,
@@ -1227,3 +1229,136 @@ class TestStep4StatusTransitions:
         assert tasks[3].is_completed is False
         assert mock_step.status == StepStatus.NOT_STARTED
         assert mock_step.started_at is None
+
+
+class TestPersonalizeBuyingCosts:
+    """Tests for _personalize_buying_costs helper."""
+
+    @pytest.fixture
+    def buying_costs_template(self) -> StepTemplate:
+        """Return the buying_costs StepTemplate."""
+        return next(t for t in STEP_TEMPLATES if t.content_key == "buying_costs")
+
+    def test_budget_and_valid_state_personalizes_titles_and_descriptions(
+        self, buying_costs_template: StepTemplate
+    ) -> None:
+        """Budget + valid state → titles show state rate, descriptions show EUR amounts."""
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="BE",  # Berlin, 6.0%
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=300_000,
+        )
+
+        tasks, costs = _personalize_buying_costs(buying_costs_template, answers)
+
+        # Transfer tax task personalized to Berlin 6.0%
+        assert "6.0%" in tasks[0]["title"]
+        assert "Berlin" in tasks[0]["title"]
+        assert tasks[0]["description"] is not None
+        assert "18,000 EUR" in tasks[0]["description"]
+
+        # Notary fees task shows EUR amount
+        assert tasks[1]["description"] is not None
+        assert "4,500 EUR" in tasks[1]["description"]
+
+        # Land registry fees task shows EUR amount
+        assert tasks[2]["description"] is not None
+        assert "1,500 EUR" in tasks[2]["description"]
+
+        # Agent commission task shows EUR amount
+        assert tasks[3]["description"] is not None
+        assert "10,710 EUR" in tasks[3]["description"]
+
+    def test_no_budget_with_valid_state_shows_rate_without_amounts(
+        self, buying_costs_template: StepTemplate
+    ) -> None:
+        """No budget + valid state → titles show state rate, no EUR amounts in descriptions."""
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="BY",  # Bayern, 3.5%
+            financing_type=FinancingType.CASH,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=None,
+        )
+
+        tasks, costs = _personalize_buying_costs(buying_costs_template, answers)
+
+        # Transfer tax title personalized to Bayern
+        assert "3.5%" in tasks[0]["title"]
+        assert "Bayern" in tasks[0]["title"]
+        # No description (no budget to compute amounts)
+        assert tasks[0]["description"] is None
+
+        # Non-state tasks fall back to originals (no budget)
+        assert tasks[1].get("description") is None
+        assert tasks[2].get("description") is None
+        assert tasks[3].get("description") is None
+
+    def test_budget_with_unknown_state_falls_back_for_tax_only(
+        self, buying_costs_template: StepTemplate
+    ) -> None:
+        """Budget + unknown state → transfer tax uses original, notary/registry still personalized."""
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.HOUSE,
+            property_location="Frankfurt",  # Not a state code
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=False,
+            has_german_residency=True,
+            budget_euros=500_000,
+        )
+
+        tasks, costs = _personalize_buying_costs(buying_costs_template, answers)
+
+        # Transfer tax task uses original (unknown state)
+        assert tasks[0]["title"] == buying_costs_template.tasks[0]["title"]
+        assert tasks[0].get("description") is None
+
+        # Notary and registry are still personalized with budget
+        assert "7,500 EUR" in tasks[1]["description"]
+        assert "2,500 EUR" in tasks[2]["description"]
+        assert "17,850 EUR" in tasks[3]["description"]
+
+    def test_budget_and_valid_state_estimated_costs_personalized(
+        self, buying_costs_template: StepTemplate
+    ) -> None:
+        """Budget + valid state → estimated_costs dict has EUR amounts and total_estimated."""
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="BE",  # Berlin, 6.0%
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=300_000,
+        )
+
+        _tasks, costs = _personalize_buying_costs(buying_costs_template, answers)
+
+        assert "18,000 EUR" in costs["grunderwerbsteuer"]
+        assert "4,500 EUR" in costs["notary_fees"]
+        assert "1,500 EUR" in costs["land_registry"]
+        assert "10,710 EUR" in costs["agent_commission"]
+        assert "total_estimated" in costs
+        # Total: 300000 * (6.0 + 1.5 + 0.5 + 3.57) / 100 = 34,710
+        assert "34,710 EUR" in costs["total_estimated"]
+
+    def test_no_budget_estimated_costs_has_no_total(
+        self, buying_costs_template: StepTemplate
+    ) -> None:
+        """No budget → estimated_costs has no total_estimated key."""
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="BE",
+            financing_type=FinancingType.CASH,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=None,
+        )
+
+        _tasks, costs = _personalize_buying_costs(buying_costs_template, answers)
+
+        assert "total_estimated" not in costs
+        assert "6.0%" in costs["grunderwerbsteuer"]

--- a/frontend/src/components/Journey/TaskCheckbox.tsx
+++ b/frontend/src/components/Journey/TaskCheckbox.tsx
@@ -51,6 +51,11 @@ function TaskCheckbox(props: IProps) {
         )}
       >
         {task.title}
+        {task.description && (
+          <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+            {task.description}
+          </span>
+        )}
       </label>
     </div>
   )

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -47,7 +47,7 @@ export interface JourneyStep {
   completed_at?: string
   content_key?: string
   related_laws?: string
-  estimated_costs?: string
+  estimated_costs?: Record<string, string>
   tasks: JourneyTask[]
 }
 


### PR DESCRIPTION
## Summary
- Personalize Step 5 ("Learn About Buying Costs") tasks using the user's budget and property state from the questionnaire
- Show computed EUR amounts in task descriptions (e.g., "Estimated: 18,000 EUR") instead of generic percentage ranges
- Render task descriptions as a secondary line below the task title in the frontend
- Fix `estimated_costs` TypeScript type from `string` to `Record<string, string>`

## Test plan
- [x] 5 new unit tests for `_personalize_buying_costs()` covering: budget+state, no budget+state, unknown state, estimated_costs dict, no total without budget
- [x] All 69 journey service tests pass
- [x] All 24 journey API route tests pass
- [x] All 667 backend tests pass
- [x] Frontend TypeScript compiles cleanly
- [ ] Manual: Create journey with budget 300,000 EUR in Berlin → Step 5 tasks show "18,000 EUR" for transfer tax, "4,500 EUR" for notary, etc.