### PR TITLE
feat(journey): add document upload to review steps

### DIFF
--- a/backend/app/alembic/versions/q8m9n0o1p2r3_add_journey_step_id_to_document.py
+++ b/backend/app/alembic/versions/q8m9n0o1p2r3_add_journey_step_id_to_document.py
@@ -1,0 +1,47 @@
+"""Add journey_step_id to document
+
+Revision ID: q8m9n0o1p2r3
+Revises: p7l8m9n0o1q2
+Create Date: 2026-04-12 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "q8m9n0o1p2r3"
+down_revision = "p7l8m9n0o1q2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document",
+        sa.Column(
+            "journey_step_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_document_journey_step_id",
+        "document",
+        "journey_step",
+        ["journey_step_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_document_journey_step_id",
+        "document",
+        ["journey_step_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_journey_step_id", table_name="document")
+    op.drop_constraint("fk_document_journey_step_id", table_name="document", type_="foreignkey")
+    op.drop_column("document", "journey_step_id")

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -16,6 +16,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import CurrentUser
@@ -133,6 +134,11 @@ async def upload_document(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
+        )
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid journey_step_id: step does not exist",
         )
 
     # Queue background processing

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -5,6 +5,8 @@ processing status, and retrieving translations with clause detection
 and risk warnings.
 """
 
+import uuid
+
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -71,6 +73,7 @@ def _build_detail_response(document: Document) -> DocumentDetailResponse:
         status=document.status,
         error_message=document.error_message,
         share_id=document.share_id,
+        journey_step_id=document.journey_step_id,
         created_at=document.created_at,
         translation=translation_response,
     )
@@ -85,6 +88,7 @@ async def upload_document(
     file: UploadFile,
     background_tasks: BackgroundTasks,
     current_user: CurrentUser,
+    journey_step_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_async_session),
 ) -> DocumentUploadResponse:
     """
@@ -123,6 +127,7 @@ async def upload_document(
             file_content=content,
             filename=file.filename or "document.pdf",
             is_premium=is_premium,
+            journey_step_id=journey_step_id,
         )
     except ValueError as e:
         raise HTTPException(
@@ -144,6 +149,7 @@ async def upload_document(
         page_count=document.page_count,
         document_type=document.document_type,
         status=document.status,
+        journey_step_id=document.journey_step_id,
     )
 
 
@@ -190,6 +196,39 @@ async def get_shared_document(
     return _build_detail_response(document)
 
 
+@router.get("/by-step/{step_id}", response_model=list[DocumentSummary])
+async def get_documents_by_step(
+    step_id: uuid.UUID,
+    current_user: CurrentUser,
+    session: AsyncSession = Depends(get_async_session),
+) -> list[DocumentSummary]:
+    """
+    Get all documents linked to a journey step.
+
+    Returns documents owned by the current user that were uploaded
+    for the specified journey step.
+    """
+    documents = await document_service.get_documents_by_step_id(
+        session=session,
+        step_id=step_id,
+        user_id=current_user.id,
+    )
+    return [
+        DocumentSummary(
+            id=str(doc.id),
+            original_filename=doc.original_filename,
+            file_size_bytes=doc.file_size_bytes,
+            page_count=doc.page_count,
+            document_type=doc.document_type,
+            status=doc.status,
+            share_id=doc.share_id,
+            journey_step_id=doc.journey_step_id,
+            created_at=doc.created_at,
+        )
+        for doc in documents
+    ]
+
+
 @router.get("/", response_model=DocumentListResponse)
 async def list_documents(
     current_user: CurrentUser,
@@ -225,6 +264,7 @@ async def list_documents(
                 document_type=doc.document_type,
                 status=doc.status,
                 share_id=doc.share_id,
+                journey_step_id=doc.journey_step_id,
                 created_at=doc.created_at,
             )
             for doc in documents

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -135,11 +135,13 @@ async def upload_document(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
-    except IntegrityError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid journey_step_id: step does not exist",
-        )
+    except IntegrityError as e:
+        if journey_step_id is not None and "journey_step_id" in str(e.orig):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid journey_step_id: step does not exist",
+            )
+        raise
 
     # Queue background processing
     background_tasks.add_task(

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -79,6 +79,14 @@ class Document(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         index=True,
     )
 
+    # Optional link to a journey step
+    journey_step_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("journey_step.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
     # File metadata
     original_filename = Column(String(500), nullable=False)
     stored_filename = Column(String(500), nullable=False)

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -40,6 +40,7 @@ class DocumentUploadResponse(BaseModel):
     page_count: int
     document_type: DocumentTypeEnum
     status: DocumentStatusEnum
+    journey_step_id: uuid.UUID | None = None
 
 
 class DocumentSummary(BaseModel):
@@ -54,6 +55,7 @@ class DocumentSummary(BaseModel):
     document_type: DocumentTypeEnum
     status: DocumentStatusEnum
     share_id: str | None = None
+    journey_step_id: uuid.UUID | None = None
     created_at: datetime
 
 
@@ -126,6 +128,7 @@ class DocumentDetailResponse(BaseModel):
     status: DocumentStatusEnum
     error_message: str | None = None
     share_id: str | None = None
+    journey_step_id: uuid.UUID | None = None
     created_at: datetime
     translation: DocumentTranslationResponse | None = None
 

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -185,6 +185,7 @@ async def save_upload(
     file_content: bytes,
     filename: str,
     is_premium: bool,
+    journey_step_id: uuid.UUID | None = None,
 ) -> Document:
     """Validate, save, and register an uploaded PDF document.
 
@@ -194,6 +195,7 @@ async def save_upload(
         file_content: Raw file bytes.
         filename: Original filename.
         is_premium: Whether user has premium subscription.
+        journey_step_id: Optional journey step to link the document to.
 
     Returns:
         Created Document database record.
@@ -235,6 +237,7 @@ async def save_upload(
     # Create DB record
     document = Document(
         user_id=user_id,
+        journey_step_id=journey_step_id,
         original_filename=filename,
         stored_filename=stored_filename,
         file_path=file_path,
@@ -590,6 +593,29 @@ async def delete_document(
 
     await session.delete(document)
     await session.commit()
+
+
+async def get_documents_by_step_id(
+    session: AsyncSession,
+    step_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> list[Document]:
+    """Get all documents linked to a journey step, owned by user.
+
+    Args:
+        session: Async database session.
+        step_id: Journey step UUID.
+        user_id: User UUID for ownership check.
+
+    Returns:
+        List of documents linked to the step.
+    """
+    result = await session.execute(
+        select(Document)
+        .where(Document.journey_step_id == step_id, Document.user_id == user_id)
+        .order_by(Document.created_at.desc())
+    )
+    return list(result.scalars().all())
 
 
 async def count_user_documents(

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -177,8 +177,8 @@ class TestGetDocumentsByStepId:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_filters_by_user_ownership(self) -> None:
-        """Ensure the query filters by both step_id and user_id."""
+    async def test_query_filters_by_both_step_and_user(self) -> None:
+        """Ensure the SQL query contains WHERE clauses for both step_id and user_id."""
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
 
@@ -190,5 +190,10 @@ class TestGetDocumentsByStepId:
 
         await get_documents_by_step_id(mock_session, step_id, user_id)
 
-        # Verify execute was called (query contains both filters)
-        mock_session.execute.assert_called_once()
+        # Extract the compiled SQL from the call args
+        call_args = mock_session.execute.call_args
+        query = call_args[0][0]
+        compiled = str(query.compile(compile_kwargs={"literal_binds": False}))
+
+        assert "document.journey_step_id" in compiled
+        assert "document.user_id" in compiled

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -197,3 +197,4 @@ class TestGetDocumentsByStepId:
 
         assert "document.journey_step_id" in compiled
         assert "document.user_id" in compiled
+        assert "ORDER BY document.created_at DESC" in compiled

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -1,9 +1,16 @@
 """Tests for document upload and translation service."""
 
-from app.models.document import DocumentType
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.document import Document, DocumentStatus, DocumentType
 from app.services.document_service import (
     _detect_clauses,
     _detect_document_type,
+    get_documents_by_step_id,
 )
 
 # --- Document type detection tests ---
@@ -110,3 +117,78 @@ class TestDetectClauses:
 
     def test_empty_text(self) -> None:
         assert _detect_clauses("", page_number=1) == []
+
+
+# --- get_documents_by_step_id tests ---
+
+
+def _make_document(
+    user_id: uuid.UUID,
+    journey_step_id: uuid.UUID | None = None,
+) -> Document:
+    """Create a Document instance for testing."""
+    doc = Document(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        journey_step_id=journey_step_id,
+        original_filename="test.pdf",
+        stored_filename="abc_test.pdf",
+        file_path="/tmp/abc_test.pdf",
+        file_size_bytes=1024,
+        page_count=2,
+        document_type=DocumentType.KAUFVERTRAG.value,
+        status=DocumentStatus.COMPLETED.value,
+    )
+    doc.created_at = datetime.now(timezone.utc)
+    return doc
+
+
+class TestGetDocumentsByStepId:
+    @pytest.mark.asyncio
+    async def test_returns_documents_for_step(self) -> None:
+        user_id = uuid.uuid4()
+        step_id = uuid.uuid4()
+        doc = _make_document(user_id, step_id)
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [doc]
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+
+        result = await get_documents_by_step_id(mock_session, step_id, user_id)
+
+        assert len(result) == 1
+        assert result[0].journey_step_id == step_id
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_step_with_no_documents(self) -> None:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+
+        result = await get_documents_by_step_id(
+            mock_session, uuid.uuid4(), uuid.uuid4()
+        )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_filters_by_user_ownership(self) -> None:
+        """Ensure the query filters by both step_id and user_id."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+
+        step_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        await get_documents_by_step_id(mock_session, step_id, user_id)
+
+        # Verify execute was called (query contains both filters)
+        mock_session.execute.assert_called_once()

--- a/frontend/src/components/Documents/DocumentUploadForm.tsx
+++ b/frontend/src/components/Documents/DocumentUploadForm.tsx
@@ -85,14 +85,17 @@ function DocumentUploadForm(props: IProps) {
         return
       }
       setValidationError(null)
-      uploadMutation.mutate(file, {
-        onSuccess: (data) => {
-          navigate({
-            to: "/documents/$documentId",
-            params: { documentId: data.id },
-          })
+      uploadMutation.mutate(
+        { file },
+        {
+          onSuccess: (data) => {
+            navigate({
+              to: "/documents/$documentId",
+              params: { documentId: data.id },
+            })
+          },
         },
-      })
+      )
     },
     [validateFile, uploadMutation, navigate],
   )

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -29,6 +29,7 @@ import { ProgressBar } from "./ProgressBar"
 import { MarketInsights } from "./StepContent/MarketInsights"
 import { PropertyEvaluationSummary } from "./StepContent/PropertyEvaluationSummary"
 import { PropertyGoalsForm } from "./StepContent/PropertyGoalsForm"
+import { StepDocumentReview } from "./StepContent/StepDocumentReview"
 import { TaskCheckbox } from "./TaskCheckbox"
 
 interface IProps {
@@ -102,6 +103,8 @@ const STEP_CONTENT_REGISTRY: Record<
   property_evaluation: (p) => (
     <PropertyEvaluationSummary journeyId={p.journeyId} stepId={p.step.id} />
   ),
+  due_diligence: (p) => <StepDocumentReview stepId={p.step.id} />,
+  review_contract: (p) => <StepDocumentReview stepId={p.step.id} />,
 }
 
 /******************************************************************************

--- a/frontend/src/components/Journey/StepContent/StepDocumentReview.tsx
+++ b/frontend/src/components/Journey/StepContent/StepDocumentReview.tsx
@@ -3,6 +3,7 @@
  * Inline document upload and summary for journey review steps
  */
 
+import { useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import {
   AlertCircle,
@@ -11,13 +12,13 @@ import {
   Loader2,
   Upload,
 } from "lucide-react"
-import { useCallback, useState } from "react"
-
+import { useCallback, useEffect, useRef, useState } from "react"
 import { cn } from "@/common/utils"
 import { Badge } from "@/components/ui/badge"
 import { useUploadDocument } from "@/hooks/mutations"
 import { useDocumentStatus, useStepDocuments } from "@/hooks/queries"
 import type { DocumentSummary } from "@/models/document"
+import { queryKeys } from "@/query/queryKeys"
 
 interface IProps {
   stepId: string
@@ -44,43 +45,68 @@ const STATUS_BADGE_STYLES: Record<string, string> = {
 ******************************************************************************/
 
 /** Single document card with status and warnings. */
-function DocumentCard(props: { doc: DocumentSummary }) {
-  const { doc } = props
+function DocumentCard(props: { doc: DocumentSummary; stepId: string }) {
+  const { doc, stepId } = props
+  const queryClient = useQueryClient()
   const isProcessing = doc.status === "uploaded" || doc.status === "processing"
+  const hasInvalidated = useRef(false)
 
   const { data: statusData } = useDocumentStatus(doc.id, isProcessing)
   const currentStatus = statusData?.status ?? doc.status
+  const errorMessage = statusData?.errorMessage ?? null
+
+  // Refresh the parent step documents query when processing finishes
+  useEffect(() => {
+    if (hasInvalidated.current) return
+    if (currentStatus === "completed" || currentStatus === "failed") {
+      hasInvalidated.current = true
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.documents.byStep(stepId),
+      })
+    }
+  }, [currentStatus, stepId, queryClient])
 
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
-      <div className="flex min-w-0 flex-1 items-center gap-3">
-        <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium">{doc.originalFilename}</p>
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Badge
-              variant="outline"
-              className={cn("text-xs", STATUS_BADGE_STYLES[currentStatus])}
-            >
-              {currentStatus === "processing" && (
-                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-              )}
-              {currentStatus}
-            </Badge>
-            <span>{doc.pageCount} pages</span>
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">
+              {doc.originalFilename}
+            </p>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Badge
+                variant="outline"
+                className={cn("text-xs", STATUS_BADGE_STYLES[currentStatus])}
+              >
+                {currentStatus === "processing" && (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                )}
+                {currentStatus}
+              </Badge>
+              <span>{doc.pageCount} pages</span>
+            </div>
           </div>
         </div>
+
+        {currentStatus === "completed" && (
+          <Link
+            to="/documents/$documentId"
+            params={{ documentId: doc.id }}
+            className="flex shrink-0 items-center gap-1 text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+          >
+            View Translation
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        )}
       </div>
 
-      {currentStatus === "completed" && (
-        <Link
-          to="/documents/$documentId"
-          params={{ documentId: doc.id }}
-          className="flex shrink-0 items-center gap-1 text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
-        >
-          View Translation
-          <ExternalLink className="h-3 w-3" />
-        </Link>
+      {currentStatus === "failed" && errorMessage && (
+        <div className="flex items-center gap-2 px-1 text-xs text-destructive">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{errorMessage}</span>
+        </div>
       )}
     </div>
   )
@@ -230,7 +256,7 @@ function StepDocumentReview(props: IProps) {
       {documents.length > 0 && (
         <div className="space-y-2">
           {documents.map((doc) => (
-            <DocumentCard key={doc.id} doc={doc} />
+            <DocumentCard key={doc.id} doc={doc} stepId={stepId} />
           ))}
         </div>
       )}

--- a/frontend/src/components/Journey/StepContent/StepDocumentReview.tsx
+++ b/frontend/src/components/Journey/StepContent/StepDocumentReview.tsx
@@ -1,0 +1,245 @@
+/**
+ * Step Document Review Component
+ * Inline document upload and summary for journey review steps
+ */
+
+import { Link } from "@tanstack/react-router"
+import {
+  AlertCircle,
+  ExternalLink,
+  FileText,
+  Loader2,
+  Upload,
+} from "lucide-react"
+import { useCallback, useState } from "react"
+
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { useUploadDocument } from "@/hooks/mutations"
+import { useDocumentStatus, useStepDocuments } from "@/hooks/queries"
+import type { DocumentSummary } from "@/models/document"
+
+interface IProps {
+  stepId: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const MAX_FILE_SIZE_MB = 20
+const ACCEPTED_TYPE = "application/pdf"
+
+const STATUS_BADGE_STYLES: Record<string, string> = {
+  uploaded: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  processing:
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  completed:
+    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  failed: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Single document card with status and warnings. */
+function DocumentCard(props: { doc: DocumentSummary }) {
+  const { doc } = props
+  const isProcessing = doc.status === "uploaded" || doc.status === "processing"
+
+  const { data: statusData } = useDocumentStatus(doc.id, isProcessing)
+  const currentStatus = statusData?.status ?? doc.status
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{doc.originalFilename}</p>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Badge
+              variant="outline"
+              className={cn("text-xs", STATUS_BADGE_STYLES[currentStatus])}
+            >
+              {currentStatus === "processing" && (
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+              )}
+              {currentStatus}
+            </Badge>
+            <span>{doc.pageCount} pages</span>
+          </div>
+        </div>
+      </div>
+
+      {currentStatus === "completed" && (
+        <Link
+          to="/documents/$documentId"
+          params={{ documentId: doc.id }}
+          className="flex shrink-0 items-center gap-1 text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+        >
+          View Translation
+          <ExternalLink className="h-3 w-3" />
+        </Link>
+      )}
+    </div>
+  )
+}
+
+/** Compact upload zone for the step. */
+function StepUploadZone(props: {
+  isPending: boolean
+  onUpload: (file: File) => void
+  validationError: string | null
+  uploadError: string | null
+}) {
+  const { isPending, onUpload, validationError, uploadError } = props
+  const [isDragging, setIsDragging] = useState(false)
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setIsDragging(false)
+      const file = e.dataTransfer.files[0]
+      if (file) onUpload(file)
+    },
+    [onUpload],
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }, [])
+
+  const handleDragLeave = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  const handleFileInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      if (file) onUpload(file)
+    },
+    [onUpload],
+  )
+
+  return (
+    <div>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: Drop zone for file uploads */}
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        className={cn(
+          "relative flex items-center gap-3 rounded-lg border-2 border-dashed p-4 transition-colors",
+          isDragging
+            ? "border-blue-500 bg-blue-50 dark:bg-blue-950/20"
+            : "border-muted-foreground/25 hover:border-muted-foreground/50",
+          isPending && "pointer-events-none opacity-60",
+        )}
+      >
+        <input
+          type="file"
+          accept=".pdf"
+          onChange={handleFileInput}
+          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+          disabled={isPending}
+        />
+
+        {isPending ? (
+          <>
+            <Loader2 className="h-5 w-5 shrink-0 animate-spin text-blue-500" />
+            <span className="text-sm">Uploading...</span>
+          </>
+        ) : (
+          <>
+            <Upload className="h-5 w-5 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">
+                Upload a German PDF for translation
+              </p>
+              <p className="text-xs text-muted-foreground">
+                PDF up to {MAX_FILE_SIZE_MB} MB
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+
+      {validationError && (
+        <div className="mt-2 flex items-center gap-2 text-xs text-destructive">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          {validationError}
+        </div>
+      )}
+
+      {uploadError && (
+        <div className="mt-2 flex items-center gap-2 text-xs text-destructive">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          {uploadError}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Default component. Upload zone + document list for a journey step. */
+function StepDocumentReview(props: IProps) {
+  const { stepId } = props
+  const { data: documents = [] } = useStepDocuments(stepId)
+  const uploadMutation = useUploadDocument()
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  const validateFile = useCallback((file: File): string | null => {
+    if (file.type !== ACCEPTED_TYPE) {
+      return "Only PDF files are accepted"
+    }
+    if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+      return `File exceeds maximum size of ${MAX_FILE_SIZE_MB} MB`
+    }
+    return null
+  }, [])
+
+  const handleUpload = useCallback(
+    (file: File) => {
+      const error = validateFile(file)
+      if (error) {
+        setValidationError(error)
+        return
+      }
+      setValidationError(null)
+      uploadMutation.mutate({ file, journeyStepId: stepId })
+    },
+    [validateFile, uploadMutation, stepId],
+  )
+
+  return (
+    <div className="space-y-3">
+      <StepUploadZone
+        isPending={uploadMutation.isPending}
+        onUpload={handleUpload}
+        validationError={validationError}
+        uploadError={
+          uploadMutation.isError
+            ? ((uploadMutation.error as Error)?.message ??
+              "Upload failed. Please try again.")
+            : null
+        }
+      />
+
+      {documents.length > 0 && (
+        <div className="space-y-2">
+          {documents.map((doc) => (
+            <DocumentCard key={doc.id} doc={doc} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { StepDocumentReview }

--- a/frontend/src/hooks/mutations/useDocumentMutations.ts
+++ b/frontend/src/hooks/mutations/useDocumentMutations.ts
@@ -7,15 +7,26 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { queryKeys } from "@/query/queryKeys"
 import { DocumentService } from "@/services/DocumentService"
 
+interface UploadDocumentArgs {
+  file: File
+  journeyStepId?: string
+}
+
 export function useUploadDocument() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (file: File) => DocumentService.uploadDocument(file),
-    onSuccess: () => {
+    mutationFn: ({ file, journeyStepId }: UploadDocumentArgs) =>
+      DocumentService.uploadDocument(file, journeyStepId),
+    onSuccess: (_data, { journeyStepId }) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.documents.all,
       })
+      if (journeyStepId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.documents.byStep(journeyStepId),
+        })
+      }
     },
   })
 }

--- a/frontend/src/hooks/queries/useDocumentQueries.ts
+++ b/frontend/src/hooks/queries/useDocumentQueries.ts
@@ -70,3 +70,11 @@ export function useDocumentUsage() {
     queryFn: () => DocumentService.getUsage(),
   })
 }
+
+export function useStepDocuments(stepId: string) {
+  return useQuery({
+    queryKey: queryKeys.documents.byStep(stepId),
+    queryFn: () => DocumentService.getDocumentsByStep(stepId),
+    enabled: !!stepId,
+  })
+}

--- a/frontend/src/models/document.ts
+++ b/frontend/src/models/document.ts
@@ -23,6 +23,7 @@ export interface DocumentSummary {
   documentType: DocumentType
   status: DocumentStatus
   shareId: string | null
+  journeyStepId: string | null
   createdAt: string
 }
 
@@ -69,6 +70,7 @@ export interface DocumentDetail {
   status: DocumentStatus
   errorMessage: string | null
   shareId: string | null
+  journeyStepId: string | null
   createdAt: string
   translation: DocumentTranslation | null
 }

--- a/frontend/src/query/queryKeys.ts
+++ b/frontend/src/query/queryKeys.ts
@@ -101,6 +101,8 @@ export const queryKeys = {
     shared: (shareId: string) =>
       [...queryKeys.documents.all, "shared", shareId] as const,
     usage: () => [...queryKeys.documents.all, "usage"] as const,
+    byStep: (stepId: string) =>
+      [...queryKeys.documents.all, "byStep", stepId] as const,
   },
 
   // Notification queries

--- a/frontend/src/services/DocumentService.ts
+++ b/frontend/src/services/DocumentService.ts
@@ -10,6 +10,7 @@ import type {
   DocumentListResponse,
   DocumentShareResponse,
   DocumentStatusInfo,
+  DocumentSummary,
   DocumentTranslation,
   DocumentUsageInfo,
 } from "@/models/document"
@@ -23,6 +24,7 @@ interface UploadResponse {
   pageCount: number
   documentType: string
   status: string
+  journeyStepId: string | null
 }
 
 /******************************************************************************
@@ -33,17 +35,37 @@ class DocumentServiceClass {
   /**
    * Upload a PDF document for translation
    */
-  async uploadDocument(file: File): Promise<UploadResponse> {
+  async uploadDocument(
+    file: File,
+    journeyStepId?: string,
+  ): Promise<UploadResponse> {
     const formData = new FormData()
     formData.append("file", file)
 
+    const url = journeyStepId
+      ? `${PATHS.DOCUMENTS.UPLOAD}?journey_step_id=${journeyStepId}`
+      : PATHS.DOCUMENTS.UPLOAD
+
     const response = await request<Record<string, unknown>>(OpenAPI, {
       method: "POST",
-      url: PATHS.DOCUMENTS.UPLOAD,
+      url,
       formData: { file },
       mediaType: "multipart/form-data",
     })
     return transformKeys<UploadResponse>(response)
+  }
+
+  /**
+   * Get documents linked to a specific journey step
+   */
+  async getDocumentsByStep(stepId: string): Promise<DocumentSummary[]> {
+    const response = await request<Record<string, unknown>[]>(OpenAPI, {
+      method: "GET",
+      url: PATHS.DOCUMENTS.BY_STEP(stepId),
+    })
+    return (response as Record<string, unknown>[]).map((doc) =>
+      transformKeys<DocumentSummary>(doc),
+    )
   }
 
   /**

--- a/frontend/src/services/DocumentService.ts
+++ b/frontend/src/services/DocumentService.ts
@@ -43,7 +43,7 @@ class DocumentServiceClass {
     formData.append("file", file)
 
     const url = journeyStepId
-      ? `${PATHS.DOCUMENTS.UPLOAD}?journey_step_id=${journeyStepId}`
+      ? `${PATHS.DOCUMENTS.UPLOAD}?journey_step_id=${encodeURIComponent(journeyStepId)}`
       : PATHS.DOCUMENTS.UPLOAD
 
     const response = await request<Record<string, unknown>>(OpenAPI, {

--- a/frontend/src/services/common/Paths.ts
+++ b/frontend/src/services/common/Paths.ts
@@ -90,6 +90,7 @@ export const PATHS = {
     LIST: `${API_V1}/documents`,
     UPLOAD: `${API_V1}/documents/upload`,
     USAGE: `${API_V1}/documents/usage`,
+    BY_STEP: (stepId: string) => `${API_V1}/documents/by-step/${stepId}`,
     SHARED: (shareId: string) => `${API_V1}/documents/shared/${shareId}`,
     DETAIL: (id: string) => `${API_V1}/documents/${id}`,
     SHARE: (id: string) => `${API_V1}/documents/${id}/share`,


### PR DESCRIPTION
## Summary
- Integrate the document translation pipeline into journey steps 10 (due diligence) and 13 (review contract) so users can upload and translate German PDFs inline
- Add `journey_step_id` nullable FK to Document model with Alembic migration, `GET /api/v1/documents/by-step/{step_id}` endpoint, and updated upload to accept optional step linkage
- New `StepDocumentReview` component with compact upload zone, document summary cards with status polling, and "View Translation" links to the existing detail page

## Test plan
- [ ] `cd backend && python -m pytest tests/services/test_document_service.py -x -q` — all 20 tests pass
- [ ] `cd frontend && npx tsc -p tsconfig.build.json --noEmit` — no type errors
- [ ] Open journey → expand Step 10 → upload zone visible above tasks
- [ ] Upload a PDF → processing spinner → completes → filename + status badge + "View Translation" link
- [ ] Click "View Translation" → navigates to `/documents/$id`
- [ ] Standalone `/documents` upload still works (no regression)
- [ ] `GET /by-step/{step_id}` returns empty for steps with no documents