### PR TITLE
feat(journey): add area/neighborhood selection with city-level market data

### DIFF
--- a/backend/app/api/routes/journeys.py
+++ b/backend/app/api/routes/journeys.py
@@ -505,10 +505,15 @@ async def update_property_goals(
 
     journey.property_goals = existing_goals
 
-    # Auto-generate market insights when Step 1 is completed for the first time.
-    # Insights are only computed once; re-saving an already-completed form does
-    # not overwrite previously generated insights.
-    if existing_goals.get("is_completed") and journey.market_insights is None:
+    # Auto-generate market insights when Step 1 is completed for the first time,
+    # or regenerate when the preferred_area changes.
+    new_area = existing_goals.get("preferred_area")
+    current_area = (journey.market_insights or {}).get("preferred_area")
+    area_changed = new_area != current_area
+
+    if existing_goals.get("is_completed") and (
+        journey.market_insights is None or area_changed
+    ):
         journey.market_insights = compute_market_insights(
             property_location=journey.property_location,
             property_type=journey.property_type,

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -34,6 +34,7 @@ class MarketInsightsData(BaseModel):
     adjusted_min_price_per_sqm: float
     adjusted_max_price_per_sqm: float
     estimated_size_sqm: int | None = None
+    preferred_area: str | None = None
     generated_at: str
 
 
@@ -72,6 +73,9 @@ class PropertyGoals(BaseModel):
     # Property use intent
     property_use: Literal["live_in", "rent_out"] | None = None
 
+    # Preferred area / neighborhood within the selected state
+    preferred_area: str | None = Field(default=None, max_length=100)
+
     # Completion status
     is_completed: bool = False
 
@@ -91,6 +95,7 @@ class PropertyGoalsUpdate(BaseModel):
     max_size_sqm: int | None = Field(default=None, ge=10)
     additional_notes: str | None = Field(default=None, max_length=1000)
     property_use: Literal["live_in", "rent_out"] | None = None
+    preferred_area: str | None = Field(default=None, max_length=100)
     is_completed: bool | None = None
 
 

--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -149,6 +149,238 @@ MARKET_DATA_BY_STATE: dict[str, dict] = {
     },
 }
 
+# ---------------------------------------------------------------------------
+# City-level market data: per-state → per-city pricing
+# Covers the hotspot cities listed in MARKET_DATA_BY_STATE.
+# ---------------------------------------------------------------------------
+
+CITY_MARKET_DATA: dict[str, dict[str, dict]] = {
+    "BW": {
+        "Stuttgart": {
+            "avg_price_per_sqm": 4800,
+            "price_range": {"min": 3200, "max": 7500},
+        },
+        "Freiburg": {
+            "avg_price_per_sqm": 4200,
+            "price_range": {"min": 2800, "max": 6500},
+        },
+        "Karlsruhe": {
+            "avg_price_per_sqm": 3600,
+            "price_range": {"min": 2400, "max": 5500},
+        },
+    },
+    "BY": {
+        "Munich": {
+            "avg_price_per_sqm": 7500,
+            "price_range": {"min": 5000, "max": 12000},
+        },
+        "Nuremberg": {
+            "avg_price_per_sqm": 3800,
+            "price_range": {"min": 2500, "max": 6000},
+        },
+        "Augsburg": {
+            "avg_price_per_sqm": 3500,
+            "price_range": {"min": 2300, "max": 5500},
+        },
+    },
+    "BE": {
+        "Mitte": {
+            "avg_price_per_sqm": 6500,
+            "price_range": {"min": 4500, "max": 10000},
+        },
+        "Prenzlauer Berg": {
+            "avg_price_per_sqm": 5800,
+            "price_range": {"min": 4000, "max": 8500},
+        },
+        "Kreuzberg": {
+            "avg_price_per_sqm": 5500,
+            "price_range": {"min": 3800, "max": 8000},
+        },
+    },
+    "BB": {
+        "Potsdam": {
+            "avg_price_per_sqm": 3800,
+            "price_range": {"min": 2500, "max": 6000},
+        },
+        "Cottbus": {
+            "avg_price_per_sqm": 2200,
+            "price_range": {"min": 1400, "max": 3500},
+        },
+        "Brandenburg an der Havel": {
+            "avg_price_per_sqm": 2400,
+            "price_range": {"min": 1600, "max": 3800},
+        },
+    },
+    "HB": {
+        "Bremen-Mitte": {
+            "avg_price_per_sqm": 3200,
+            "price_range": {"min": 2200, "max": 5000},
+        },
+        "Schwachhausen": {
+            "avg_price_per_sqm": 3500,
+            "price_range": {"min": 2400, "max": 5500},
+        },
+        "Horn-Lehe": {
+            "avg_price_per_sqm": 3000,
+            "price_range": {"min": 2000, "max": 4800},
+        },
+    },
+    "HH": {
+        "Eppendorf": {
+            "avg_price_per_sqm": 7000,
+            "price_range": {"min": 5000, "max": 11000},
+        },
+        "Winterhude": {
+            "avg_price_per_sqm": 6500,
+            "price_range": {"min": 4500, "max": 10000},
+        },
+        "Eimsbüttel": {
+            "avg_price_per_sqm": 6000,
+            "price_range": {"min": 4200, "max": 9500},
+        },
+    },
+    "HE": {
+        "Frankfurt": {
+            "avg_price_per_sqm": 5200,
+            "price_range": {"min": 3500, "max": 8500},
+        },
+        "Wiesbaden": {
+            "avg_price_per_sqm": 4000,
+            "price_range": {"min": 2800, "max": 6500},
+        },
+        "Darmstadt": {
+            "avg_price_per_sqm": 3800,
+            "price_range": {"min": 2600, "max": 6000},
+        },
+    },
+    "MV": {
+        "Rostock": {
+            "avg_price_per_sqm": 2800,
+            "price_range": {"min": 1800, "max": 4500},
+        },
+        "Schwerin": {
+            "avg_price_per_sqm": 2400,
+            "price_range": {"min": 1500, "max": 4000},
+        },
+        "Greifswald": {
+            "avg_price_per_sqm": 2600,
+            "price_range": {"min": 1700, "max": 4200},
+        },
+    },
+    "NI": {
+        "Hannover": {
+            "avg_price_per_sqm": 3200,
+            "price_range": {"min": 2200, "max": 5000},
+        },
+        "Braunschweig": {
+            "avg_price_per_sqm": 2800,
+            "price_range": {"min": 1900, "max": 4500},
+        },
+        "Oldenburg": {
+            "avg_price_per_sqm": 2700,
+            "price_range": {"min": 1800, "max": 4200},
+        },
+    },
+    "NW": {
+        "Düsseldorf": {
+            "avg_price_per_sqm": 4200,
+            "price_range": {"min": 2800, "max": 7000},
+        },
+        "Cologne": {
+            "avg_price_per_sqm": 4000,
+            "price_range": {"min": 2700, "max": 6500},
+        },
+        "Münster": {
+            "avg_price_per_sqm": 3800,
+            "price_range": {"min": 2500, "max": 6000},
+        },
+    },
+    "RP": {
+        "Mainz": {
+            "avg_price_per_sqm": 3200,
+            "price_range": {"min": 2200, "max": 5000},
+        },
+        "Koblenz": {
+            "avg_price_per_sqm": 2600,
+            "price_range": {"min": 1800, "max": 4000},
+        },
+        "Trier": {
+            "avg_price_per_sqm": 2800,
+            "price_range": {"min": 1900, "max": 4200},
+        },
+    },
+    "SL": {
+        "Saarbrücken": {
+            "avg_price_per_sqm": 2200,
+            "price_range": {"min": 1500, "max": 3500},
+        },
+        "Neunkirchen": {
+            "avg_price_per_sqm": 1800,
+            "price_range": {"min": 1200, "max": 2800},
+        },
+        "Homburg": {
+            "avg_price_per_sqm": 1900,
+            "price_range": {"min": 1300, "max": 3000},
+        },
+    },
+    "SN": {
+        "Leipzig": {
+            "avg_price_per_sqm": 3000,
+            "price_range": {"min": 2000, "max": 5000},
+        },
+        "Dresden": {
+            "avg_price_per_sqm": 2800,
+            "price_range": {"min": 1900, "max": 4500},
+        },
+        "Chemnitz": {
+            "avg_price_per_sqm": 1800,
+            "price_range": {"min": 1200, "max": 3000},
+        },
+    },
+    "ST": {
+        "Magdeburg": {
+            "avg_price_per_sqm": 2000,
+            "price_range": {"min": 1300, "max": 3200},
+        },
+        "Halle": {
+            "avg_price_per_sqm": 2100,
+            "price_range": {"min": 1400, "max": 3400},
+        },
+        "Dessau": {
+            "avg_price_per_sqm": 1500,
+            "price_range": {"min": 1000, "max": 2500},
+        },
+    },
+    "SH": {
+        "Kiel": {
+            "avg_price_per_sqm": 3200,
+            "price_range": {"min": 2200, "max": 5200},
+        },
+        "Lübeck": {
+            "avg_price_per_sqm": 3400,
+            "price_range": {"min": 2300, "max": 5500},
+        },
+        "Flensburg": {
+            "avg_price_per_sqm": 2800,
+            "price_range": {"min": 1900, "max": 4500},
+        },
+    },
+    "TH": {
+        "Erfurt": {
+            "avg_price_per_sqm": 2200,
+            "price_range": {"min": 1500, "max": 3500},
+        },
+        "Jena": {
+            "avg_price_per_sqm": 2600,
+            "price_range": {"min": 1800, "max": 4200},
+        },
+        "Weimar": {
+            "avg_price_per_sqm": 2400,
+            "price_range": {"min": 1600, "max": 3800},
+        },
+    },
+}
+
 # Price multipliers relative to apartment prices — mirrors frontend
 PROPERTY_TYPE_MULTIPLIERS: dict[str, float] = {
     "apartment": 1.0,
@@ -157,6 +389,18 @@ PROPERTY_TYPE_MULTIPLIERS: dict[str, float] = {
     "commercial": 1.4,
     "land": 0.4,
 }
+
+
+def _find_city_data(state_code: str, preferred_area: str | None) -> dict | None:
+    """Look up city-level data for a preferred area (case-insensitive)."""
+    if not preferred_area:
+        return None
+    cities = CITY_MARKET_DATA.get(state_code, {})
+    area_lower = preferred_area.lower()
+    for city_name, data in cities.items():
+        if city_name.lower() == area_lower:
+            return data
+    return None
 
 
 def compute_market_insights(
@@ -190,10 +434,22 @@ def compute_market_insights(
 
     multiplier = PROPERTY_TYPE_MULTIPLIERS.get(effective_type, 1.0)
 
-    avg_price = state_data["avg_price_per_sqm"]
+    # Try city-level pricing when a preferred_area is specified
+    preferred_area: str | None = goals.get("preferred_area")
+    city_data = _find_city_data(property_location, preferred_area)
+
+    if city_data:
+        avg_price = city_data["avg_price_per_sqm"]
+        price_min = city_data["price_range"]["min"]
+        price_max = city_data["price_range"]["max"]
+    else:
+        avg_price = state_data["avg_price_per_sqm"]
+        price_min = state_data["price_range"]["min"]
+        price_max = state_data["price_range"]["max"]
+
     adjusted_avg = round(avg_price * multiplier)
-    adjusted_min = round(state_data["price_range"]["min"] * multiplier)
-    adjusted_max = round(state_data["price_range"]["max"] * multiplier)
+    adjusted_min = round(price_min * multiplier)
+    adjusted_max = round(price_max * multiplier)
 
     estimated_sqm: int | None = None
     if budget_euros and adjusted_avg > 0:
@@ -203,8 +459,8 @@ def compute_market_insights(
         "state_code": property_location,
         "state_name": state_info["name"],
         "avg_price_per_sqm": avg_price,
-        "price_range_min": state_data["price_range"]["min"],
-        "price_range_max": state_data["price_range"]["max"],
+        "price_range_min": price_min,
+        "price_range_max": price_max,
         "agent_fee_percent": state_data["agent_fee_percent"],
         "trend": state_data["trend"],
         "hotspots": state_data["hotspots"],
@@ -215,5 +471,6 @@ def compute_market_insights(
         "adjusted_min_price_per_sqm": adjusted_min,
         "adjusted_max_price_per_sqm": adjusted_max,
         "estimated_size_sqm": estimated_sqm,
+        "preferred_area": preferred_area,
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }

--- a/backend/tests/api/routes/test_journeys.py
+++ b/backend/tests/api/routes/test_journeys.py
@@ -737,6 +737,181 @@ def test_property_use_rent_out_round_trips(client: TestClient, db: Session) -> N
     assert r.json()["property_use"] == "rent_out"
 
 
+def test_preferred_area_round_trips(client: TestClient, db: Session) -> None:
+    """Test that preferred_area round-trips through PATCH and GET."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)
+    journey_id = journey["id"]
+
+    r = client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "apartment",
+            "preferred_area": "Mitte",
+            "is_completed": True,
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["preferred_area"] == "Mitte"
+
+    # Verify via GET property-goals
+    r = client.get(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+    )
+    assert r.json()["preferred_area"] == "Mitte"
+
+    # Verify via GET journey detail
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    assert r.json()["property_goals"]["preferred_area"] == "Mitte"
+    # Market insights should also record the preferred area
+    assert r.json()["market_insights"]["preferred_area"] == "Mitte"
+
+
+def test_preferred_area_city_level_insights(client: TestClient, db: Session) -> None:
+    """Setting preferred_area to a known city uses city-level pricing."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)  # BE
+    journey_id = journey["id"]
+
+    r = client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "apartment",
+            "preferred_area": "Mitte",
+            "is_completed": True,
+        },
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    insights = r.json()["market_insights"]
+    # Mitte city data: avg_price_per_sqm = 6500 (vs Berlin state = 5200)
+    assert insights["avg_price_per_sqm"] == 6500
+    assert insights["price_range_min"] == 4500
+    assert insights["price_range_max"] == 10000
+
+
+def test_preferred_area_unknown_falls_back_to_state(
+    client: TestClient, db: Session
+) -> None:
+    """An unknown preferred_area falls back to state-level pricing."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)  # BE
+    journey_id = journey["id"]
+
+    r = client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "apartment",
+            "preferred_area": "Neufahrn",
+            "is_completed": True,
+        },
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    insights = r.json()["market_insights"]
+    # Falls back to Berlin state averages
+    assert insights["avg_price_per_sqm"] == 5200
+    assert insights["preferred_area"] == "Neufahrn"
+
+
+def test_changing_preferred_area_regenerates_insights(
+    client: TestClient, db: Session
+) -> None:
+    """Changing preferred_area regenerates market insights with new city data."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)  # BE
+    journey_id = journey["id"]
+
+    # First: complete with Mitte
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "apartment",
+            "preferred_area": "Mitte",
+            "is_completed": True,
+        },
+    )
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    first_insights = r.json()["market_insights"]
+    assert first_insights["preferred_area"] == "Mitte"
+    assert first_insights["avg_price_per_sqm"] == 6500
+
+    # Second: change to Kreuzberg
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={"preferred_area": "Kreuzberg"},
+    )
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    second_insights = r.json()["market_insights"]
+    assert second_insights["preferred_area"] == "Kreuzberg"
+    assert second_insights["avg_price_per_sqm"] == 5500
+    assert second_insights["generated_at"] != first_insights["generated_at"]
+
+
+def test_clearing_preferred_area_regenerates_state_level_insights(
+    client: TestClient,
+    db: Session,
+) -> None:
+    """Clearing preferred_area regenerates insights with state-level data."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)  # BE
+    journey_id = journey["id"]
+
+    # Set city-level area first
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "apartment",
+            "preferred_area": "Mitte",
+            "is_completed": True,
+        },
+    )
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    assert r.json()["market_insights"]["avg_price_per_sqm"] == 6500
+
+    # Clear preferred_area → should fall back to state-level
+    client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={"preferred_area": None},
+    )
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    insights = r.json()["market_insights"]
+    assert insights["preferred_area"] is None
+    assert insights["avg_price_per_sqm"] == 5200  # Berlin state average
+
+
+def test_preferred_area_case_insensitive_match(client: TestClient, db: Session) -> None:
+    """City matching is case-insensitive."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey_with_state_location(client, headers)  # BE
+    journey_id = journey["id"]
+
+    r = client.patch(
+        f"{settings.API_V1_STR}/journeys/{journey_id}/property-goals",
+        headers=headers,
+        json={
+            "preferred_property_type": "apartment",
+            "preferred_area": "mitte",  # lowercase
+            "is_completed": True,
+        },
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"{settings.API_V1_STR}/journeys/{journey_id}", headers=headers)
+    insights = r.json()["market_insights"]
+    assert insights["avg_price_per_sqm"] == 6500  # city-level data used
+
+
 def test_property_use_invalid_value_returns_422(
     client: TestClient, db: Session
 ) -> None:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3667,6 +3667,17 @@ export const MarketInsightsDataSchema = {
             ],
             title: 'Estimated Size Sqm'
         },
+        preferred_area: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Preferred Area'
+        },
         generated_at: {
             type: 'string',
             title: 'Generated At'
@@ -4317,6 +4328,18 @@ export const PropertyGoalsSchema = {
             ],
             title: 'Property Use'
         },
+        preferred_area: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 100
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Preferred Area'
+        },
         is_completed: {
             type: 'boolean',
             title: 'Is Completed',
@@ -4474,6 +4497,18 @@ export const PropertyGoalsUpdateSchema = {
                 }
             ],
             title: 'Property Use'
+        },
+        preferred_area: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 100
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Preferred Area'
         },
         is_completed: {
             anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1078,6 +1078,7 @@ export type MarketInsightsData = {
     adjusted_min_price_per_sqm: number;
     adjusted_max_price_per_sqm: number;
     estimated_size_sqm?: (number | null);
+    preferred_area?: (string | null);
     generated_at: string;
 };
 
@@ -1252,6 +1253,7 @@ export type PropertyGoals = {
     max_size_sqm?: (number | null);
     additional_notes?: (string | null);
     property_use?: ('live_in' | 'rent_out' | null);
+    preferred_area?: (string | null);
     is_completed?: boolean;
 };
 
@@ -1271,6 +1273,7 @@ export type PropertyGoalsUpdate = {
     max_size_sqm?: (number | null);
     additional_notes?: (string | null);
     property_use?: ('live_in' | 'rent_out' | null);
+    preferred_area?: (string | null);
     is_completed?: (boolean | null);
 };
 

--- a/frontend/src/common/constants/propertyGoals.ts
+++ b/frontend/src/common/constants/propertyGoals.ts
@@ -219,6 +219,117 @@ export const MARKET_DATA_BY_STATE: Record<
 }
 
 /**
+ * City-level market data for hotspot cities within each state
+ * Used to refine market insights when a preferred area is specified
+ */
+export const CITY_MARKET_DATA: Record<
+  string,
+  Record<
+    string,
+    {
+      avgPricePerSqm: number
+      priceRange: { min: number; max: number }
+    }
+  >
+> = {
+  BW: {
+    Stuttgart: { avgPricePerSqm: 4800, priceRange: { min: 3200, max: 7500 } },
+    Freiburg: { avgPricePerSqm: 4200, priceRange: { min: 2800, max: 6500 } },
+    Karlsruhe: { avgPricePerSqm: 3600, priceRange: { min: 2400, max: 5500 } },
+  },
+  BY: {
+    Munich: { avgPricePerSqm: 7500, priceRange: { min: 5000, max: 12000 } },
+    Nuremberg: { avgPricePerSqm: 3800, priceRange: { min: 2500, max: 6000 } },
+    Augsburg: { avgPricePerSqm: 3500, priceRange: { min: 2300, max: 5500 } },
+  },
+  BE: {
+    Mitte: { avgPricePerSqm: 6500, priceRange: { min: 4500, max: 10000 } },
+    "Prenzlauer Berg": {
+      avgPricePerSqm: 5800,
+      priceRange: { min: 4000, max: 8500 },
+    },
+    Kreuzberg: { avgPricePerSqm: 5500, priceRange: { min: 3800, max: 8000 } },
+  },
+  BB: {
+    Potsdam: { avgPricePerSqm: 3800, priceRange: { min: 2500, max: 6000 } },
+    Cottbus: { avgPricePerSqm: 2200, priceRange: { min: 1400, max: 3500 } },
+    "Brandenburg an der Havel": {
+      avgPricePerSqm: 2400,
+      priceRange: { min: 1600, max: 3800 },
+    },
+  },
+  HB: {
+    "Bremen-Mitte": {
+      avgPricePerSqm: 3200,
+      priceRange: { min: 2200, max: 5000 },
+    },
+    Schwachhausen: {
+      avgPricePerSqm: 3500,
+      priceRange: { min: 2400, max: 5500 },
+    },
+    "Horn-Lehe": { avgPricePerSqm: 3000, priceRange: { min: 2000, max: 4800 } },
+  },
+  HH: {
+    Eppendorf: { avgPricePerSqm: 7000, priceRange: { min: 5000, max: 11000 } },
+    Winterhude: { avgPricePerSqm: 6500, priceRange: { min: 4500, max: 10000 } },
+    Eimsbüttel: { avgPricePerSqm: 6000, priceRange: { min: 4200, max: 9500 } },
+  },
+  HE: {
+    Frankfurt: { avgPricePerSqm: 5200, priceRange: { min: 3500, max: 8500 } },
+    Wiesbaden: { avgPricePerSqm: 4000, priceRange: { min: 2800, max: 6500 } },
+    Darmstadt: { avgPricePerSqm: 3800, priceRange: { min: 2600, max: 6000 } },
+  },
+  MV: {
+    Rostock: { avgPricePerSqm: 2800, priceRange: { min: 1800, max: 4500 } },
+    Schwerin: { avgPricePerSqm: 2400, priceRange: { min: 1500, max: 4000 } },
+    Greifswald: { avgPricePerSqm: 2600, priceRange: { min: 1700, max: 4200 } },
+  },
+  NI: {
+    Hannover: { avgPricePerSqm: 3200, priceRange: { min: 2200, max: 5000 } },
+    Braunschweig: {
+      avgPricePerSqm: 2800,
+      priceRange: { min: 1900, max: 4500 },
+    },
+    Oldenburg: { avgPricePerSqm: 2700, priceRange: { min: 1800, max: 4200 } },
+  },
+  NW: {
+    Düsseldorf: { avgPricePerSqm: 4200, priceRange: { min: 2800, max: 7000 } },
+    Cologne: { avgPricePerSqm: 4000, priceRange: { min: 2700, max: 6500 } },
+    Münster: { avgPricePerSqm: 3800, priceRange: { min: 2500, max: 6000 } },
+  },
+  RP: {
+    Mainz: { avgPricePerSqm: 3200, priceRange: { min: 2200, max: 5000 } },
+    Koblenz: { avgPricePerSqm: 2600, priceRange: { min: 1800, max: 4000 } },
+    Trier: { avgPricePerSqm: 2800, priceRange: { min: 1900, max: 4200 } },
+  },
+  SL: {
+    Saarbrücken: { avgPricePerSqm: 2200, priceRange: { min: 1500, max: 3500 } },
+    Neunkirchen: { avgPricePerSqm: 1800, priceRange: { min: 1200, max: 2800 } },
+    Homburg: { avgPricePerSqm: 1900, priceRange: { min: 1300, max: 3000 } },
+  },
+  SN: {
+    Leipzig: { avgPricePerSqm: 3000, priceRange: { min: 2000, max: 5000 } },
+    Dresden: { avgPricePerSqm: 2800, priceRange: { min: 1900, max: 4500 } },
+    Chemnitz: { avgPricePerSqm: 1800, priceRange: { min: 1200, max: 3000 } },
+  },
+  ST: {
+    Magdeburg: { avgPricePerSqm: 2000, priceRange: { min: 1300, max: 3200 } },
+    Halle: { avgPricePerSqm: 2100, priceRange: { min: 1400, max: 3400 } },
+    Dessau: { avgPricePerSqm: 1500, priceRange: { min: 1000, max: 2500 } },
+  },
+  SH: {
+    Kiel: { avgPricePerSqm: 3200, priceRange: { min: 2200, max: 5200 } },
+    Lübeck: { avgPricePerSqm: 3400, priceRange: { min: 2300, max: 5500 } },
+    Flensburg: { avgPricePerSqm: 2800, priceRange: { min: 1900, max: 4500 } },
+  },
+  TH: {
+    Erfurt: { avgPricePerSqm: 2200, priceRange: { min: 1500, max: 3500 } },
+    Jena: { avgPricePerSqm: 2600, priceRange: { min: 1800, max: 4200 } },
+    Weimar: { avgPricePerSqm: 2400, priceRange: { min: 1600, max: 3800 } },
+  },
+}
+
+/**
  * Property type price multipliers
  * Relative to apartment prices
  */

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -89,7 +89,11 @@ const STEP_CONTENT_REGISTRY: Record<
   (props: IStepContentProps) => ReactNode
 > = {
   research_goals: (p) => (
-    <PropertyGoalsForm journeyId={p.journeyId} initialGoals={p.propertyGoals} />
+    <PropertyGoalsForm
+      journeyId={p.journeyId}
+      initialGoals={p.propertyGoals}
+      propertyLocation={p.propertyLocation}
+    />
   ),
   market_research: (p) => (
     <MarketInsights

--- a/frontend/src/components/Journey/StepContent/MarketInsights.tsx
+++ b/frontend/src/components/Journey/StepContent/MarketInsights.tsx
@@ -259,6 +259,12 @@ function MarketInsights(props: IProps) {
         <CardTitle className="flex items-center gap-2 text-base">
           <BarChart3 className="h-4 w-4" />
           Market Insights: {stateInfo.name}
+          {marketInsights?.preferred_area && (
+            <span className="font-normal">
+              {" "}
+              &mdash; {marketInsights.preferred_area}
+            </span>
+          )}
         </CardTitle>
         <CardDescription>
           Based on your property goals
@@ -435,11 +441,19 @@ function MarketInsights(props: IProps) {
             Popular Areas in {stateInfo.name}
           </h4>
           <div className="flex flex-wrap gap-2">
-            {marketData.hotspots.map((hotspot) => (
-              <Badge key={hotspot} variant="outline">
-                {hotspot}
-              </Badge>
-            ))}
+            {marketData.hotspots.map((hotspot) => {
+              const isSelected =
+                marketInsights?.preferred_area?.toLowerCase() ===
+                hotspot.toLowerCase()
+              return (
+                <Badge
+                  key={hotspot}
+                  variant={isSelected ? "default" : "outline"}
+                >
+                  {hotspot}
+                </Badge>
+              )
+            })}
           </div>
         </div>
 

--- a/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
+++ b/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
@@ -23,15 +23,18 @@ import { useEffect, useState } from "react"
 import {
   BATHROOM_OPTIONS,
   FLOOR_OPTIONS,
+  MARKET_DATA_BY_STATE,
   PROPERTY_FEATURES,
   PROPERTY_TYPES,
   PROPERTY_USE_OPTIONS,
   ROOM_OPTIONS,
 } from "@/common/constants"
 import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { useUpdatePropertyGoals } from "@/hooks/mutations/useJourneyMutations"
@@ -41,6 +44,7 @@ import { BudgetInput } from "../BudgetInput"
 interface IProps {
   journeyId: string
   initialGoals?: PropertyGoals
+  propertyLocation?: string
   onComplete?: () => void
   className?: string
 }
@@ -131,7 +135,8 @@ function FeatureCheckbox(props: {
 
 /** Default component. Property goals form. */
 function PropertyGoalsForm(props: IProps) {
-  const { journeyId, initialGoals, onComplete, className } = props
+  const { journeyId, initialGoals, propertyLocation, onComplete, className } =
+    props
 
   const [goals, setGoals] = useState<PropertyGoals>({
     preferred_property_type: initialGoals?.preferred_property_type || "",
@@ -144,6 +149,7 @@ function PropertyGoalsForm(props: IProps) {
     features: initialGoals?.features || [],
     additional_notes: initialGoals?.additional_notes || "",
     property_use: initialGoals?.property_use,
+    preferred_area: initialGoals?.preferred_area || "",
     is_completed: initialGoals?.is_completed || false,
   })
 
@@ -163,6 +169,7 @@ function PropertyGoalsForm(props: IProps) {
         features: initialGoals.features || [],
         additional_notes: initialGoals.additional_notes || "",
         property_use: initialGoals.property_use,
+        preferred_area: initialGoals.preferred_area || "",
         is_completed: initialGoals.is_completed || false,
       })
     }
@@ -247,6 +254,53 @@ function PropertyGoalsForm(props: IProps) {
               </SelectionButton>
             ))}
           </div>
+        </div>
+
+        {/* Preferred Area */}
+        <div className="space-y-3">
+          <Label className="text-sm font-medium">
+            Preferred Area (Optional)
+          </Label>
+          <Input
+            placeholder="e.g. Munich, Kreuzberg..."
+            value={goals.preferred_area || ""}
+            onChange={(e) =>
+              setGoals((prev) => ({
+                ...prev,
+                preferred_area: e.target.value,
+              }))
+            }
+          />
+          {propertyLocation &&
+            MARKET_DATA_BY_STATE[propertyLocation]?.hotspots && (
+              <div className="flex flex-wrap gap-2">
+                <span className="text-xs text-muted-foreground self-center">
+                  Suggestions:
+                </span>
+                {MARKET_DATA_BY_STATE[propertyLocation].hotspots.map(
+                  (hotspot) => (
+                    <Badge
+                      key={hotspot}
+                      variant={
+                        goals.preferred_area?.toLowerCase() ===
+                        hotspot.toLowerCase()
+                          ? "default"
+                          : "outline"
+                      }
+                      className="cursor-pointer"
+                      onClick={() =>
+                        setGoals((prev) => ({
+                          ...prev,
+                          preferred_area: hotspot,
+                        }))
+                      }
+                    >
+                      {hotspot}
+                    </Badge>
+                  ),
+                )}
+              </div>
+            )}
         </div>
 
         {/* Property Type */}

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -146,6 +146,7 @@ export interface MarketInsightsData {
   adjusted_min_price_per_sqm: number
   adjusted_max_price_per_sqm: number
   estimated_size_sqm?: number
+  preferred_area?: string
   generated_at: string
 }
 
@@ -163,6 +164,7 @@ export interface PropertyGoals {
   max_size_sqm?: number
   additional_notes?: string
   property_use?: "live_in" | "rent_out"
+  preferred_area?: string
   is_completed?: boolean
 }
 
@@ -180,5 +182,6 @@ export interface PropertyGoalsUpdate {
   max_size_sqm?: number
   additional_notes?: string
   property_use?: "live_in" | "rent_out"
+  preferred_area?: string
   is_completed?: boolean
 }


### PR DESCRIPTION
## Summary
- Add **Preferred Area** optional field to Step 1 (PropertyGoalsForm) with text input and clickable hotspot suggestion badges
- Add city-level pricing data for all 48 hotspot cities across 16 German states (backend + frontend)
- Refine market insights with city-level data when the preferred area matches a known city (case-insensitive); fall back to state averages for unknown areas
- Regenerate market insights automatically when the preferred area changes
- Display preferred area in MarketInsights header and highlight matching hotspot badge

## Test plan
- [x] Backend: 5 new tests — round-trip, city-level insights, unknown area fallback, area change regeneration, case-insensitive matching (all 32 tests pass)
- [x] Frontend: TypeScript type check passes with no errors
- [ ] Manual: open journey → Step 1 → type or select a known city → save → verify Step 2 shows city-level pricing
- [ ] Manual: type unknown area → save → verify fallback to state-level data
- [ ] Manual: change area → re-save → verify insights update with new city data
- [ ] Manual: journey without preferred_area → state-level insights, no regression