### PR TITLE
feat(journey): add list vs tab view toggle for journey steps

### DIFF
--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -5,6 +5,7 @@
 
 import { Link } from "@tanstack/react-router"
 import { ArrowLeft, Calendar, Home, MapPin, Trash2, Wallet } from "lucide-react"
+import { useState } from "react"
 import {
   FINANCING_TYPES,
   GERMAN_STATES,
@@ -22,6 +23,8 @@ import { JourneyProvider } from "./JourneyContext"
 import { PhaseIndicator } from "./PhaseIndicator"
 import { ProgressBar } from "./ProgressBar"
 import { StepCard } from "./StepCard"
+import { StepTabView } from "./StepTabView"
+import { type ViewMode, ViewModeToggle } from "./ViewModeToggle"
 
 interface IProps {
   journey?: JourneyPublic
@@ -171,6 +174,16 @@ function JourneyDetail(props: IProps) {
     className,
   } = props
 
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    const stored = localStorage.getItem("heimpath-journey-view-mode")
+    return stored === "tab" ? "tab" : "list"
+  })
+
+  const handleViewModeChange = (mode: ViewMode) => {
+    setViewMode(mode)
+    localStorage.setItem("heimpath-journey-view-mode", mode)
+  }
+
   if (isLoading || !journey) {
     return <JourneyDetailSkeleton />
   }
@@ -228,26 +241,38 @@ function JourneyDetail(props: IProps) {
         </div>
       </div>
 
-      {/* Phase indicator */}
-      <PhaseIndicator
-        currentPhase={journey.current_phase}
-        className="rounded-lg border bg-card p-4"
-      />
+      {/* Phase indicator + view toggle */}
+      <div className="flex items-center gap-3">
+        <PhaseIndicator
+          currentPhase={journey.current_phase}
+          className="flex-1 rounded-lg border bg-card p-4"
+        />
+        <ViewModeToggle viewMode={viewMode} onChange={handleViewModeChange} />
+      </div>
 
       {/* Main content */}
       <JourneyProvider journey={journey}>
         <div className="grid gap-6 lg:grid-cols-3">
-          {/* Steps list */}
+          {/* Steps */}
           <div className="lg:col-span-2 space-y-4">
-            {journey.steps.map((step) => (
-              <StepCard
-                key={step.id}
-                step={step}
-                isActive={step.step_number === journey.current_step_number}
+            {viewMode === "list" ? (
+              journey.steps.map((step) => (
+                <StepCard
+                  key={step.id}
+                  step={step}
+                  isActive={step.step_number === journey.current_step_number}
+                  onTaskToggle={onTaskToggle}
+                  onStepOpen={onStepOpen}
+                />
+              ))
+            ) : (
+              <StepTabView
+                steps={journey.steps}
+                activeStepNumber={journey.current_step_number}
                 onTaskToggle={onTaskToggle}
                 onStepOpen={onStepOpen}
               />
-            ))}
+            )}
           </div>
 
           {/* Sidebar — comes first on mobile via order-first, natural order on desktop */}

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -4,7 +4,6 @@
  */
 
 import { Check, ChevronDown, ChevronRight, Circle, Clock } from "lucide-react"
-import type { ReactNode } from "react"
 import { useState } from "react"
 
 import { PHASE_COLORS } from "@/common/constants"
@@ -17,20 +16,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import type {
-  JourneyStep,
-  JourneyTask,
-  MarketInsightsData,
-  PropertyGoals,
-  StepStatus,
-} from "@/models/journey"
-import { useJourneyContext } from "./JourneyContext"
-import { ProgressBar } from "./ProgressBar"
-import { MarketInsights } from "./StepContent/MarketInsights"
-import { PropertyEvaluationSummary } from "./StepContent/PropertyEvaluationSummary"
-import { PropertyGoalsForm } from "./StepContent/PropertyGoalsForm"
-import { StepDocumentReview } from "./StepContent/StepDocumentReview"
-import { TaskCheckbox } from "./TaskCheckbox"
+import type { JourneyStep, StepStatus } from "@/models/journey"
+import { STEP_CONTENT_REGISTRY, StepBody } from "./StepContent/StepBody"
 
 interface IProps {
   step: JourneyStep
@@ -74,43 +61,6 @@ const STATUS_CONFIG: Record<
   },
 }
 
-interface IStepContentProps {
-  journeyId: string
-  step: JourneyStep
-  propertyLocation?: string
-  propertyType?: string
-  budgetEuros?: number
-  propertyGoals?: PropertyGoals
-  marketInsights?: MarketInsightsData
-}
-
-const STEP_CONTENT_REGISTRY: Record<
-  string,
-  (props: IStepContentProps) => ReactNode
-> = {
-  research_goals: (p) => (
-    <PropertyGoalsForm
-      journeyId={p.journeyId}
-      initialGoals={p.propertyGoals}
-      propertyLocation={p.propertyLocation}
-    />
-  ),
-  market_research: (p) => (
-    <MarketInsights
-      propertyLocation={p.propertyLocation}
-      propertyType={p.propertyType}
-      budgetEuros={p.budgetEuros}
-      propertyGoals={p.propertyGoals}
-      marketInsights={p.marketInsights}
-    />
-  ),
-  property_evaluation: (p) => (
-    <PropertyEvaluationSummary journeyId={p.journeyId} stepId={p.step.id} />
-  ),
-  due_diligence: (p) => <StepDocumentReview stepId={p.step.id} />,
-  review_contract: (p) => <StepDocumentReview stepId={p.step.id} />,
-}
-
 /******************************************************************************
                               Components
 ******************************************************************************/
@@ -136,72 +86,23 @@ function StatusBadge(props: { status: StepStatus }) {
   )
 }
 
-/** Inline task list with progress for a step. */
-function StepTasks(props: {
-  tasks: JourneyTask[]
-  stepId: string
-  stepStatus: StepStatus
-  onToggle?: (stepId: string, taskId: string, isCompleted: boolean) => void
-}) {
-  const { tasks, stepId, stepStatus, onToggle } = props
-
-  const completedTasks = tasks.filter((t) => t.is_completed).length
-  const totalTasks = tasks.length
-  const progressPercent =
-    totalTasks > 0 ? (completedTasks / totalTasks) * 100 : 0
-  const isDisabled = stepStatus === "skipped"
-
-  const handleToggle = (taskId: string, isCompleted: boolean) => {
-    onToggle?.(stepId, taskId, isCompleted)
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="space-y-2">
-        <div className="flex items-center justify-between text-sm">
-          <span className="font-medium text-muted-foreground">Tasks</span>
-          <span className="text-sm text-muted-foreground">
-            {completedTasks} of {totalTasks}
-          </span>
-        </div>
-        <ProgressBar value={progressPercent} size="sm" />
-      </div>
-      <div className="space-y-2">
-        {tasks.map((task) => (
-          <TaskCheckbox
-            key={task.id}
-            task={task}
-            onToggle={handleToggle}
-            disabled={isDisabled}
-          />
-        ))}
-      </div>
-    </div>
-  )
-}
-
 /** Default component. Collapsible step card. */
 function StepCard(props: IProps) {
   const { step, isActive = false, onTaskToggle, onStepOpen, className } = props
-  const { journey } = useJourneyContext()
 
   const [isExpanded, setIsExpanded] = useState(isActive)
 
-  const contentRenderer = step.content_key
-    ? STEP_CONTENT_REGISTRY[step.content_key]
-    : undefined
+  const hasContentRenderer = step.content_key
+    ? !!STEP_CONTENT_REGISTRY[step.content_key]
+    : false
 
   const hasTasks = step.tasks.length > 0
   const hasBody =
-    !!contentRenderer || hasTasks || !!step.estimated_duration_days
+    hasContentRenderer || hasTasks || !!step.estimated_duration_days
 
   const handleToggleExpanded = () => {
     if (!hasBody) return
-    const opening = !isExpanded
-    setIsExpanded(opening)
-    if (opening && step.status === "not_started") {
-      onStepOpen?.(step.id)
-    }
+    setIsExpanded(!isExpanded)
   }
 
   return (
@@ -247,35 +148,12 @@ function StepCard(props: IProps) {
       </CardHeader>
 
       {isExpanded && (
-        <CardContent className="space-y-4 pt-0">
-          {contentRenderer && (
-            <div>
-              {contentRenderer({
-                journeyId: journey.id,
-                step,
-                propertyLocation: journey.property_location,
-                propertyType: journey.property_type,
-                budgetEuros: journey.budget_euros,
-                propertyGoals: journey.property_goals,
-                marketInsights: journey.market_insights,
-              })}
-            </div>
-          )}
-
-          {hasTasks && (
-            <StepTasks
-              tasks={step.tasks}
-              stepId={step.id}
-              stepStatus={step.status}
-              onToggle={onTaskToggle}
-            />
-          )}
-
-          {step.estimated_duration_days && (
-            <p className="text-xs text-muted-foreground">
-              Estimated duration: {step.estimated_duration_days} days
-            </p>
-          )}
+        <CardContent className="pt-0">
+          <StepBody
+            step={step}
+            onTaskToggle={onTaskToggle}
+            onStepOpen={onStepOpen}
+          />
         </CardContent>
       )}
     </Card>

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -1,0 +1,176 @@
+/**
+ * Step Body Component
+ * Reusable step content renderer (content registry + tasks + duration)
+ * Used by both StepCard (list view) and StepTabView (tab view)
+ */
+
+import type { ReactNode } from "react"
+import { useEffect } from "react"
+
+import type {
+  JourneyStep,
+  JourneyTask,
+  MarketInsightsData,
+  PropertyGoals,
+  StepStatus,
+} from "@/models/journey"
+import { useJourneyContext } from "../JourneyContext"
+import { ProgressBar } from "../ProgressBar"
+import { TaskCheckbox } from "../TaskCheckbox"
+import { MarketInsights } from "./MarketInsights"
+import { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
+import { PropertyGoalsForm } from "./PropertyGoalsForm"
+import { StepDocumentReview } from "./StepDocumentReview"
+
+interface IProps {
+  step: JourneyStep
+  onTaskToggle?: (stepId: string, taskId: string, isCompleted: boolean) => void
+  onStepOpen?: (stepId: string) => void
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+interface IStepContentProps {
+  journeyId: string
+  step: JourneyStep
+  propertyLocation?: string
+  propertyType?: string
+  budgetEuros?: number
+  propertyGoals?: PropertyGoals
+  marketInsights?: MarketInsightsData
+}
+
+const STEP_CONTENT_REGISTRY: Record<
+  string,
+  (props: IStepContentProps) => ReactNode
+> = {
+  research_goals: (p) => (
+    <PropertyGoalsForm
+      journeyId={p.journeyId}
+      initialGoals={p.propertyGoals}
+      propertyLocation={p.propertyLocation}
+    />
+  ),
+  market_research: (p) => (
+    <MarketInsights
+      propertyLocation={p.propertyLocation}
+      propertyType={p.propertyType}
+      budgetEuros={p.budgetEuros}
+      propertyGoals={p.propertyGoals}
+      marketInsights={p.marketInsights}
+    />
+  ),
+  property_evaluation: (p) => (
+    <PropertyEvaluationSummary journeyId={p.journeyId} stepId={p.step.id} />
+  ),
+  due_diligence: (p) => <StepDocumentReview stepId={p.step.id} />,
+  review_contract: (p) => <StepDocumentReview stepId={p.step.id} />,
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Inline task list with progress for a step. */
+function StepTasks(props: {
+  tasks: JourneyTask[]
+  stepId: string
+  stepStatus: StepStatus
+  onToggle?: (stepId: string, taskId: string, isCompleted: boolean) => void
+}) {
+  const { tasks, stepId, stepStatus, onToggle } = props
+
+  const completedTasks = tasks.filter((t) => t.is_completed).length
+  const totalTasks = tasks.length
+  const progressPercent =
+    totalTasks > 0 ? (completedTasks / totalTasks) * 100 : 0
+  const isDisabled = stepStatus === "skipped"
+
+  const handleToggle = (taskId: string, isCompleted: boolean) => {
+    onToggle?.(stepId, taskId, isCompleted)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-muted-foreground">Tasks</span>
+          <span className="text-sm text-muted-foreground">
+            {completedTasks} of {totalTasks}
+          </span>
+        </div>
+        <ProgressBar value={progressPercent} size="sm" />
+      </div>
+      <div className="space-y-2">
+        {tasks.map((task) => (
+          <TaskCheckbox
+            key={task.id}
+            task={task}
+            onToggle={handleToggle}
+            disabled={isDisabled}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** Renders the body content for a journey step: content renderer + tasks + duration. */
+function StepBody(props: IProps) {
+  const { step, onTaskToggle, onStepOpen } = props
+  const { journey } = useJourneyContext()
+
+  const contentRenderer = step.content_key
+    ? STEP_CONTENT_REGISTRY[step.content_key]
+    : undefined
+
+  const hasTasks = step.tasks.length > 0
+
+  useEffect(() => {
+    if (step.status === "not_started") {
+      onStepOpen?.(step.id)
+    }
+  }, [step.id, step.status, onStepOpen])
+
+  return (
+    <div className="space-y-4">
+      {contentRenderer && (
+        <div>
+          {contentRenderer({
+            journeyId: journey.id,
+            step,
+            propertyLocation: journey.property_location,
+            propertyType: journey.property_type,
+            budgetEuros: journey.budget_euros,
+            propertyGoals: journey.property_goals,
+            marketInsights: journey.market_insights,
+          })}
+        </div>
+      )}
+
+      {hasTasks && (
+        <StepTasks
+          tasks={step.tasks}
+          stepId={step.id}
+          stepStatus={step.status}
+          onToggle={onTaskToggle}
+        />
+      )}
+
+      {step.estimated_duration_days && (
+        <p className="text-xs text-muted-foreground">
+          Estimated duration: {step.estimated_duration_days} days
+        </p>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { StepBody, STEP_CONTENT_REGISTRY }
+export type { IStepContentProps }

--- a/frontend/src/components/Journey/StepContent/index.ts
+++ b/frontend/src/components/Journey/StepContent/index.ts
@@ -6,3 +6,4 @@
 export { MarketInsights } from "./MarketInsights"
 export { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
 export { PropertyGoalsForm } from "./PropertyGoalsForm"
+export { StepBody } from "./StepBody"

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -1,0 +1,149 @@
+/**
+ * Step Tab View Component
+ * Two-level tab navigation: phase pills (outer) → step tabs (inner)
+ * Alternative to the list view for viewing journey steps
+ */
+
+import { useMemo, useState } from "react"
+
+import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
+import { cn } from "@/common/utils"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { JourneyPhase, JourneyStep } from "@/models/journey"
+import { StepBody } from "./StepContent/StepBody"
+
+interface IProps {
+  steps: JourneyStep[]
+  activeStepNumber: number
+  onTaskToggle: (stepId: string, taskId: string, isCompleted: boolean) => void
+  onStepOpen?: (stepId: string) => void
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function StepTabView(props: IProps) {
+  const { steps, activeStepNumber, onTaskToggle, onStepOpen } = props
+
+  const activeStep = steps.find((s) => s.step_number === activeStepNumber)
+  const defaultPhase = activeStep?.phase ?? "research"
+
+  const [selectedPhase, setSelectedPhase] = useState<JourneyPhase>(defaultPhase)
+
+  const stepsByPhase = useMemo(() => {
+    const grouped: Record<JourneyPhase, JourneyStep[]> = {
+      research: [],
+      preparation: [],
+      buying: [],
+      closing: [],
+    }
+    for (const step of steps) {
+      grouped[step.phase].push(step)
+    }
+    return grouped
+  }, [steps])
+
+  const phaseSteps = stepsByPhase[selectedPhase]
+
+  const defaultStepId = useMemo(() => {
+    if (activeStep && activeStep.phase === selectedPhase) {
+      return activeStep.id
+    }
+    return phaseSteps[0]?.id ?? ""
+  }, [activeStep, selectedPhase, phaseSteps])
+
+  return (
+    <div className="space-y-4">
+      {/* Phase pills */}
+      <Tabs
+        value={selectedPhase}
+        onValueChange={(v) => setSelectedPhase(v as JourneyPhase)}
+      >
+        <TabsList className="flex w-full flex-wrap gap-1">
+          {JOURNEY_PHASES.map((phase) => (
+            <TabsTrigger
+              key={phase.key}
+              value={phase.key}
+              className={cn(
+                "text-xs sm:text-sm",
+                selectedPhase === phase.key && PHASE_COLORS[phase.key],
+              )}
+            >
+              {phase.label}
+              <span className="ml-1 text-xs text-muted-foreground">
+                ({stepsByPhase[phase.key as JourneyPhase].length})
+              </span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Step tabs within selected phase */}
+      {phaseSteps.length > 0 && (
+        <Tabs key={selectedPhase} defaultValue={defaultStepId}>
+          <TabsList className="flex w-full flex-wrap gap-1">
+            {phaseSteps.map((step) => (
+              <TabsTrigger
+                key={step.id}
+                value={step.id}
+                className={cn(
+                  "text-xs sm:text-sm",
+                  step.step_number === activeStepNumber &&
+                    "ring-2 ring-blue-600 ring-offset-1",
+                )}
+              >
+                <span className="mr-1 font-mono text-xs text-muted-foreground">
+                  {step.step_number}.
+                </span>
+                <span className="max-w-[12ch] truncate sm:max-w-[20ch]">
+                  {step.title}
+                </span>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          {phaseSteps.map((step) => (
+            <TabsContent key={step.id} value={step.id}>
+              <Card>
+                <CardHeader>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      Step {step.step_number}
+                    </div>
+                    <CardTitle className="text-base sm:text-lg">
+                      {step.title}
+                    </CardTitle>
+                    {step.description && (
+                      <CardDescription>{step.description}</CardDescription>
+                    )}
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <StepBody
+                    step={step}
+                    onTaskToggle={onTaskToggle}
+                    onStepOpen={onStepOpen}
+                  />
+                </CardContent>
+              </Card>
+            </TabsContent>
+          ))}
+        </Tabs>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { StepTabView }

--- a/frontend/src/components/Journey/ViewModeToggle.tsx
+++ b/frontend/src/components/Journey/ViewModeToggle.tsx
@@ -1,0 +1,54 @@
+/**
+ * View Mode Toggle Component
+ * Switches between list and tab view for journey steps
+ */
+
+import { LayoutGrid, List } from "lucide-react"
+
+import { cn } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+
+type ViewMode = "list" | "tab"
+
+interface IProps {
+  viewMode: ViewMode
+  onChange: (mode: ViewMode) => void
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function ViewModeToggle(props: IProps) {
+  const { viewMode, onChange } = props
+
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        variant={viewMode === "list" ? "default" : "ghost"}
+        size="icon-sm"
+        aria-label="List view"
+        onClick={() => onChange("list")}
+        className={cn(viewMode === "list" && "pointer-events-none")}
+      >
+        <List className="h-4 w-4" />
+      </Button>
+      <Button
+        variant={viewMode === "tab" ? "default" : "ghost"}
+        size="icon-sm"
+        aria-label="Tab view"
+        onClick={() => onChange("tab")}
+        className={cn(viewMode === "tab" && "pointer-events-none")}
+      >
+        <LayoutGrid className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ViewModeToggle }
+export type { ViewMode }

--- a/frontend/src/components/Journey/index.ts
+++ b/frontend/src/components/Journey/index.ts
@@ -19,7 +19,6 @@ export { ProgressBar } from "./ProgressBar"
 export { PropertyTypeSelector } from "./PropertyTypeSelector"
 export { ResidencySelector } from "./ResidencySelector"
 export { StepCard } from "./StepCard"
-export { StepTabView } from "./StepTabView"
 // Step content components
 export {
   MarketInsights,
@@ -27,7 +26,8 @@ export {
   PropertyGoalsForm,
   StepBody,
 } from "./StepContent"
-export { ViewModeToggle } from "./ViewModeToggle"
+export { StepTabView } from "./StepTabView"
 export { TaskCheckbox } from "./TaskCheckbox"
 export { TimelineSelector } from "./TimelineSelector"
+export { ViewModeToggle } from "./ViewModeToggle"
 export { WizardStepIndicator } from "./WizardStepIndicator"

--- a/frontend/src/components/Journey/index.ts
+++ b/frontend/src/components/Journey/index.ts
@@ -19,12 +19,15 @@ export { ProgressBar } from "./ProgressBar"
 export { PropertyTypeSelector } from "./PropertyTypeSelector"
 export { ResidencySelector } from "./ResidencySelector"
 export { StepCard } from "./StepCard"
+export { StepTabView } from "./StepTabView"
 // Step content components
 export {
   MarketInsights,
   PropertyEvaluationSummary,
   PropertyGoalsForm,
+  StepBody,
 } from "./StepContent"
+export { ViewModeToggle } from "./ViewModeToggle"
 export { TaskCheckbox } from "./TaskCheckbox"
 export { TimelineSelector } from "./TimelineSelector"
 export { WizardStepIndicator } from "./WizardStepIndicator"


### PR DESCRIPTION
## Summary
- Extract `StepBody` from `StepCard` into a reusable component shared by both list and tab views
- Add `ViewModeToggle` (List / LayoutGrid icons) next to the phase indicator for switching views
- Add `StepTabView` with two-level tab navigation: phase pills (outer) → step tabs (inner), rendering step content via `StepBody`
- View preference persists in localStorage (`heimpath-journey-view-mode`)

## Test plan
- [ ] Open journey detail — list view renders as before (no regression)
- [ ] Click tab icon — switches to tab view grouped by phase
- [ ] Phase pills show all 4 phases; clicking a phase shows its steps as inner tabs
- [ ] Active step is auto-selected on first load
- [ ] Step content (forms, tasks, market insights) renders correctly in tab view
- [ ] Toggle preference persists across page reloads
- [ ] Responsive: tab triggers wrap on mobile