### PR TITLE
refactor: use mutable type wrappers for JSONB columns

### DIFF
--- a/backend/app/api/routes/journeys.py
+++ b/backend/app/api/routes/journeys.py
@@ -497,28 +497,27 @@ async def update_property_goals(
             detail="Journey not found",
         )
 
-    existing_goals = dict(journey.property_goals) if journey.property_goals else {}
+    if journey.property_goals is None:
+        journey.property_goals = {}
 
     update_data = request.model_dump(exclude_unset=True)
     for field, value in update_data.items():
-        existing_goals[field] = value
-
-    journey.property_goals = existing_goals
+        journey.property_goals[field] = value
 
     # Auto-generate market insights when Step 1 is completed for the first time,
     # or regenerate when the preferred_area changes.
-    new_area = existing_goals.get("preferred_area")
+    new_area = journey.property_goals.get("preferred_area")
     current_area = (journey.market_insights or {}).get("preferred_area")
     area_changed = new_area != current_area
 
-    if existing_goals.get("is_completed") and (
+    if journey.property_goals.get("is_completed") and (
         journey.market_insights is None or area_changed
     ):
         journey.market_insights = compute_market_insights(
             property_location=journey.property_location,
             property_type=journey.property_type,
             budget_euros=journey.budget_euros,
-            property_goals=existing_goals,
+            property_goals=journey.property_goals,
         )
 
     session.add(journey)

--- a/backend/app/models/article.py
+++ b/backend/app/models/article.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
+from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
@@ -94,7 +95,7 @@ class Article(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # Content
     excerpt = Column(Text, nullable=False)
     content = Column(Text, nullable=False)
-    key_takeaways = Column(JSONB, nullable=False, default=list)
+    key_takeaways = Column(MutableList.as_mutable(JSONB), nullable=False, default=list)
 
     # Metadata
     reading_time_minutes = Column(Integer, nullable=False, default=1)
@@ -102,8 +103,10 @@ class Article(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     author_name = Column(String(255), nullable=False)
 
     # Related resources (stored as JSONB)
-    related_law_ids = Column(JSONB, nullable=True, default=list)
-    related_calculator_types = Column(JSONB, nullable=True, default=list)
+    related_law_ids = Column(MutableList.as_mutable(JSONB), nullable=True, default=list)
+    related_calculator_types = Column(
+        MutableList.as_mutable(JSONB), nullable=True, default=list
+    )
 
     # Full-text search
     search_vector = Column(TSVECTOR)

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
@@ -141,9 +142,13 @@ class DocumentTranslation(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     target_language = Column(String(10), nullable=False, default="en")
 
     # Translation content (JSON)
-    translated_pages = Column(JSONB, nullable=False, default=list)
-    clauses_detected = Column(JSONB, nullable=False, default=list)
-    risk_warnings = Column(JSONB, nullable=False, default=list)
+    translated_pages = Column(
+        MutableList.as_mutable(JSONB), nullable=False, default=list
+    )
+    clauses_detected = Column(
+        MutableList.as_mutable(JSONB), nullable=False, default=list
+    )
+    risk_warnings = Column(MutableList.as_mutable(JSONB), nullable=False, default=list)
 
     # Timing
     processing_started_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.orm import relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
@@ -116,10 +117,10 @@ class Journey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     target_purchase_date = Column(DateTime(timezone=True), nullable=True)
 
     # Property goals (Step 1 user input)
-    property_goals = Column(JSONB, nullable=True)
+    property_goals = Column(MutableDict.as_mutable(JSONB), nullable=True)
 
     # Market insights (generated after Step 1 completion)
-    market_insights = Column(JSONB, nullable=True)
+    market_insights = Column(MutableDict.as_mutable(JSONB), nullable=True)
 
     # Progress tracking
     started_at = Column(DateTime(timezone=True), nullable=True)
@@ -171,11 +172,17 @@ class JourneyStep(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     # Content references
     content_key = Column(String(100), nullable=True)  # Key to fetch related content
-    related_laws = Column(JSONB, nullable=True)  # JSON array of related law references
-    estimated_costs = Column(JSONB, nullable=True)  # JSON object with cost breakdown
+    related_laws = Column(
+        MutableList.as_mutable(JSONB), nullable=True
+    )  # JSON array of related law references
+    estimated_costs = Column(
+        MutableDict.as_mutable(JSONB), nullable=True
+    )  # JSON object with cost breakdown
 
     # Prerequisites (step numbers that must be completed first)
-    prerequisites = Column(JSONB, nullable=True)  # JSON array of step numbers
+    prerequisites = Column(
+        MutableList.as_mutable(JSONB), nullable=True
+    )  # JSON array of step numbers
 
     # Relationships
     journey = relationship("Journey", back_populates="steps")


### PR DESCRIPTION
## Summary
- Wrap all JSONB columns across `Journey`, `JourneyStep`, `Article`, and `DocumentTranslation` models with `MutableDict.as_mutable()` or `MutableList.as_mutable()`
- SQLAlchemy now automatically detects in-place dict/list mutations, preventing the class of silent-update bugs fixed in PR #50
- Remove the manual `dict()` shallow copy in `update_property_goals` (no longer needed)
- No migration needed — this is a Python-side type wrapper only

Closes #85

## Test plan
- [x] All 33 journey tests pass (including PR #50 regression tests)
- [x] ruff lint + format clean