### PR TITLE
refactor(calculator): deduplicate evaluation schemas, input conversion, and formatters

### DIFF
--- a/backend/app/schemas/property_evaluation.py
+++ b/backend/app/schemas/property_evaluation.py
@@ -1,9 +1,61 @@
 """Property evaluation calculator request/response schemas."""
 
+import dataclasses
+import typing
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, create_model
+
+from app.services.property_evaluation_calculator import (
+    AnnualCashflowRow,
+    EvaluationResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pydantic_from_dataclass(
+    dc_cls: type,
+    model_name: str,
+    *,
+    exclude_fields: set[str] | None = None,
+    overrides: dict[str, tuple] | None = None,
+) -> type[BaseModel]:
+    """Create a Pydantic model mirroring a dataclass's field definitions.
+
+    Uses ``typing.get_type_hints()`` to resolve forward-ref annotations
+    (from ``__future__ import annotations`` in the calculator module).
+    """
+    exclude = exclude_fields or set()
+    hints = typing.get_type_hints(dc_cls)
+    field_defs: dict[str, tuple] = {}
+
+    for f in dataclasses.fields(dc_cls):
+        if f.name in exclude:
+            continue
+        default = (
+            f.default
+            if f.default is not dataclasses.MISSING
+            else (
+                f.default_factory()
+                if f.default_factory is not dataclasses.MISSING
+                else ...
+            )
+        )
+        field_defs[f.name] = (hints[f.name], default)
+
+    if overrides:
+        field_defs.update(overrides)
+
+    return create_model(
+        model_name,
+        __config__=ConfigDict(from_attributes=True),
+        **field_defs,
+    )
+
 
 # ---------------------------------------------------------------------------
 # /calculate endpoint schemas
@@ -64,99 +116,17 @@ class PropertyEvaluationCalculateRequest(BaseModel):
     analysis_years: int = 11
 
 
-class AnnualCashflowRowResponse(BaseModel):
-    """One row of the annual cashflow table."""
+AnnualCashflowRowResponse = _pydantic_from_dataclass(
+    AnnualCashflowRow,
+    "AnnualCashflowRowResponse",
+)
 
-    model_config = ConfigDict(from_attributes=True)
-
-    year: int = 0
-    cold_rent: float = 0.0
-    management_annual: float = 0.0
-    operational_cf: float = 0.0
-    loan_balance_start: float = 0.0
-    interest: float = 0.0
-    repayment: float = 0.0
-    loan_balance_end: float = 0.0
-    financing_cf: float = 0.0
-    net_cf_pretax: float = 0.0
-    renovation_deduction: float = 0.0
-    earnings_before_tax: float = 0.0
-    tax_effect_marginal: float = 0.0
-    net_cf_after_tax: float = 0.0
-    taxable_income_adjusted: float = 0.0
-    income_tax_adjusted: float = 0.0
-    actual_tax_saving: float = 0.0
-    property_value: float = 0.0
-    equity_buildup_accumulated: float = 0.0
-    equity_contribution: float = 0.0
-
-
-class PropertyEvaluationCalculateResponse(BaseModel):
-    """Full calculation result from the /calculate endpoint."""
-
-    model_config = ConfigDict(from_attributes=True)
-
-    # Property Purchase
-    price_per_m2: float = 0.0
-    broker_fee_amount: float = 0.0
-    notary_fee_amount: float = 0.0
-    land_registry_fee_amount: float = 0.0
-    property_transfer_tax_amount: float = 0.0
-    total_closing_costs: float = 0.0
-    total_closing_costs_pct: float = 0.0
-    total_investment: float = 0.0
-
-    # Rent
-    apartment_cold_rent_monthly: float = 0.0
-    total_cold_rent_monthly: float = 0.0
-    allocable_costs_monthly: float = 0.0
-    warm_rent_monthly: float = 0.0
-
-    # Management Costs
-    non_allocable_costs_monthly: float = 0.0
-    total_hausgeld_monthly: float = 0.0
-    non_allocable_as_pct_of_cold_rent: float = 0.0
-
-    # Depreciation
-    afa_basis: float = 0.0
-    annual_afa: float = 0.0
-    monthly_afa_display: float = 0.0
-
-    # Financing
-    loan_amount: float = 0.0
-    equity: float = 0.0
-    annual_debt_service: float = 0.0
-    monthly_debt_service: float = 0.0
-    monthly_interest_yr1: float = 0.0
-    monthly_repayment_yr1: float = 0.0
-
-    # Rental Yield
-    net_cold_rent_annual: float = 0.0
-    gross_rental_yield: float = 0.0
-    factor_cold_rent_vs_price: float = 0.0
-
-    # Monthly Cashflow
-    monthly_cashflow_pretax: float = 0.0
-    monthly_taxable_property_income: float = 0.0
-    monthly_tax_benefit: float = 0.0
-    monthly_cashflow_after_tax: float = 0.0
-
-    # Tax Context
-    personal_taxable_income: float = 0.0
-    base_income_tax: float = 0.0
-    avg_tax_rate_display: float = 0.0
-    personal_marginal_tax_rate: float = 0.0
-
-    # Annual Cashflow Table
-    annual_rows: list[AnnualCashflowRowResponse] = []
-
-    # Summary KPIs
-    total_operational_cf: float = 0.0
-    total_financing_cf: float = 0.0
-    total_net_cf_before_tax: float = 0.0
-    total_net_cf_after_tax: float = 0.0
-    total_equity_invested: float = 0.0
-    final_equity_kpi: float = 0.0
+PropertyEvaluationCalculateResponse = _pydantic_from_dataclass(
+    EvaluationResult,
+    "PropertyEvaluationCalculateResponse",
+    exclude_fields={"annual_rows"},
+    overrides={"annual_rows": (list[AnnualCashflowRowResponse], [])},
+)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/property_evaluation_service.py
+++ b/backend/app/services/property_evaluation_service.py
@@ -105,6 +105,48 @@ def calculate_results(inputs: dict) -> dict:
     return _result_to_dict(result)
 
 
+def _request_to_nested_dict(request: PropertyEvaluationCalculateRequest) -> dict:
+    """Map the flat /calculate request to the nested dict format expected by _inputs_from_dict."""
+    return {
+        "property_info": {
+            "address": request.address,
+            "square_meters": request.square_meters,
+            "purchase_price": request.purchase_price,
+            "broker_fee_percent": request.broker_fee_percent,
+            "notary_fee_percent": request.notary_fee_percent,
+            "land_registry_fee_percent": request.land_registry_fee_percent,
+            "transfer_tax_percent": request.property_transfer_tax_percent,
+        },
+        "rent": {
+            "rent_per_sqm": request.rent_per_m2,
+            "parking_rent": request.parking_space_rent,
+            "building_share_percent": request.building_share_percent,
+            "depreciation_rate_percent": request.afa_rate_percent,
+            "personal_taxable_income": request.personal_taxable_income,
+            "marginal_tax_rate_percent": request.marginal_tax_rate_percent,
+            "cost_increase_percent": request.cost_increase_percent,
+            "rent_increase_percent": request.rent_increase_percent,
+            "value_increase_percent": request.value_increase_percent,
+            "equity_interest_percent": request.equity_interest_percent,
+            "renovation_year": request.renovation_year,
+            "renovation_cost": request.renovation_cost,
+            "start_year": request.start_year,
+            "analysis_years": request.analysis_years,
+        },
+        "operating_costs": {
+            "hausgeld_allocable": request.base_allocable_costs,
+            "property_tax_monthly": request.property_tax_monthly,
+            "hausgeld_non_allocable": request.base_non_allocable_costs,
+            "reserves_portion": request.reserves_monthly,
+        },
+        "financing": {
+            "loan_percent": request.loan_percent,
+            "interest_rate_percent": request.interest_rate_percent,
+            "repayment_rate_percent": request.initial_repayment_rate_percent,
+        },
+    }
+
+
 def calculate_from_request(
     request: PropertyEvaluationCalculateRequest,
 ) -> EvaluationResult:
@@ -113,37 +155,7 @@ def calculate_from_request(
     Converts percent-scale request fields to decimal-scale rates,
     runs the full calculation, and returns the typed result.
     """
-    eval_inputs = EvaluationInputs(
-        address=request.address,
-        square_meters=request.square_meters,
-        purchase_price=request.purchase_price,
-        rent_per_m2=request.rent_per_m2,
-        parking_space_rent=request.parking_space_rent,
-        broker_fee_rate=request.broker_fee_percent / 100,
-        notary_fee_rate=request.notary_fee_percent / 100,
-        land_registry_fee_rate=request.land_registry_fee_percent / 100,
-        property_transfer_tax_rate=request.property_transfer_tax_percent / 100,
-        base_allocable_costs=request.base_allocable_costs,
-        property_tax_monthly=request.property_tax_monthly,
-        base_non_allocable_costs=request.base_non_allocable_costs,
-        reserves_monthly=request.reserves_monthly,
-        building_share_pct=request.building_share_percent / 100,
-        afa_rate=request.afa_rate_percent / 100,
-        loan_pct_of_purchase=request.loan_percent / 100,
-        interest_rate=request.interest_rate_percent / 100,
-        initial_repayment_rate=request.initial_repayment_rate_percent / 100,
-        personal_taxable_income=request.personal_taxable_income,
-        personal_marginal_tax_rate=request.marginal_tax_rate_percent / 100,
-        cost_increase_pa=request.cost_increase_percent / 100,
-        rent_increase_pa=request.rent_increase_percent / 100,
-        value_increase_pa=request.value_increase_percent / 100,
-        interest_on_equity_pa=request.equity_interest_percent / 100,
-        renovation_year=request.renovation_year,
-        renovation_cost=request.renovation_cost,
-        start_year=request.start_year,
-        analysis_years=request.analysis_years,
-    )
-    return calculate(eval_inputs)
+    return calculate(_inputs_from_dict(_request_to_nested_dict(request)))
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -141,8 +141,7 @@ export const AnnualCashflowRowResponseSchema = {
         }
     },
     type: 'object',
-    title: 'AnnualCashflowRowResponse',
-    description: 'One row of the annual cashflow table.'
+    title: 'AnnualCashflowRowResponse'
 } as const;
 
 export const ArticleCategorySchema = {
@@ -4419,14 +4418,6 @@ export const PropertyEvaluationCalculateResponseSchema = {
             title: 'Personal Marginal Tax Rate',
             default: 0
         },
-        annual_rows: {
-            items: {
-                '$ref': '#/components/schemas/AnnualCashflowRowResponse'
-            },
-            type: 'array',
-            title: 'Annual Rows',
-            default: []
-        },
         total_operational_cf: {
             type: 'number',
             title: 'Total Operational Cf',
@@ -4456,11 +4447,18 @@ export const PropertyEvaluationCalculateResponseSchema = {
             type: 'number',
             title: 'Final Equity Kpi',
             default: 0
+        },
+        annual_rows: {
+            items: {
+                '$ref': '#/components/schemas/AnnualCashflowRowResponse'
+            },
+            type: 'array',
+            title: 'Annual Rows',
+            default: []
         }
     },
     type: 'object',
-    title: 'PropertyEvaluationCalculateResponse',
-    description: 'Full calculation result from the /calculate endpoint.'
+    title: 'PropertyEvaluationCalculateResponse'
 } as const;
 
 export const PropertyEvaluationCreateSchema = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -16,9 +16,6 @@ export type ActivityItem = {
  */
 export type ActivityType = 'journey_started' | 'step_completed' | 'document_uploaded' | 'calculation_saved' | 'roi_calculated' | 'financing_assessed' | 'law_bookmarked';
 
-/**
- * One row of the annual cashflow table.
- */
 export type AnnualCashflowRowResponse = {
     year?: number;
     cold_rent?: number;
@@ -1252,9 +1249,6 @@ export type PropertyEvaluationCalculateRequest = {
     analysis_years?: number;
 };
 
-/**
- * Full calculation result from the /calculate endpoint.
- */
 export type PropertyEvaluationCalculateResponse = {
     price_per_m2?: number;
     broker_fee_amount?: number;
@@ -1291,13 +1285,13 @@ export type PropertyEvaluationCalculateResponse = {
     base_income_tax?: number;
     avg_tax_rate_display?: number;
     personal_marginal_tax_rate?: number;
-    annual_rows?: Array<AnnualCashflowRowResponse>;
     total_operational_cf?: number;
     total_financing_cf?: number;
     total_net_cf_before_tax?: number;
     total_net_cf_after_tax?: number;
     total_equity_invested?: number;
     final_equity_kpi?: number;
+    annual_rows?: Array<AnnualCashflowRowResponse>;
 };
 
 export type PropertyEvaluationCreate = {

--- a/frontend/src/common/utils/formatters.ts
+++ b/frontend/src/common/utils/formatters.ts
@@ -1,7 +1,36 @@
 /**
  * Shared formatting utilities
- * Common formatters for dates and currencies
+ * Common formatters for dates, currencies, and percentages
  */
+
+// ---------------------------------------------------------------------------
+// Formatter instances (reusable, avoids re-creating Intl objects per call)
+// ---------------------------------------------------------------------------
+
+/** EUR currency formatter with 0 decimal places. */
+export const EUR_FORMATTER_0 = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+})
+
+/** EUR currency formatter with 2 decimal places. */
+export const EUR_FORMATTER_2 = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 2,
+})
+
+/** Percent formatter with 1 decimal place (Intl.NumberFormat style: "percent"). */
+export const PERCENT_FORMATTER = new Intl.NumberFormat("de-DE", {
+  style: "percent",
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+})
+
+// ---------------------------------------------------------------------------
+// Function-form formatters (convenient for templates / PDF generation)
+// ---------------------------------------------------------------------------
 
 /** Format a date string for display. */
 export function formatDate(
@@ -21,9 +50,25 @@ export function formatDate(
 /** Format an amount as EUR currency with no decimals. */
 export function formatEur(amount?: number, fallback = "Not specified"): string {
   if (amount == null) return fallback
-  return new Intl.NumberFormat("de-DE", {
-    style: "currency",
-    currency: "EUR",
-    maximumFractionDigits: 0,
-  }).format(amount)
+  return EUR_FORMATTER_0.format(amount)
+}
+
+/** Format an amount as EUR currency with 2 decimal places. */
+export function formatEur2(amount: number): string {
+  return EUR_FORMATTER_2.format(amount)
+}
+
+/** Format a whole-number percentage string (e.g. 3.57 -> "3.57 %"). */
+export function formatPct(value: number): string {
+  return `${value.toFixed(2)} %`
+}
+
+/** Format a decimal as percentage string (e.g. 0.042 -> "4.20 %"). */
+export function formatPctFromDecimal(value: number): string {
+  return `${(value * 100).toFixed(2)} %`
+}
+
+/** Format a number as a factor display (e.g. 33.2 -> "33.2x"). */
+export function formatFactor(value: number): string {
+  return `${value.toFixed(1)}x`
 }

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/GenerateEvaluationPdf.ts
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/GenerateEvaluationPdf.ts
@@ -5,6 +5,13 @@
 
 import jsPDF from "jspdf"
 import autoTable from "jspdf-autotable"
+import {
+  formatEur as eur,
+  formatEur2 as eur2,
+  formatFactor as factor,
+  formatPct as pct,
+  formatPctFromDecimal as pctFromDecimal,
+} from "@/common/utils/formatters"
 import type {
   EvaluationResults,
   PropertyEvaluationState,
@@ -25,39 +32,6 @@ const CONTENT_WIDTH = 170 // A4 width (210) minus 2 * margin
 /******************************************************************************
                               Functions
 ******************************************************************************/
-
-/** Format a number as EUR currency string. */
-function eur(amount: number): string {
-  return new Intl.NumberFormat("de-DE", {
-    style: "currency",
-    currency: "EUR",
-    maximumFractionDigits: 0,
-  }).format(amount)
-}
-
-/** Format a number as EUR with 2 decimal places. */
-function eur2(amount: number): string {
-  return new Intl.NumberFormat("de-DE", {
-    style: "currency",
-    currency: "EUR",
-    maximumFractionDigits: 2,
-  }).format(amount)
-}
-
-/** Format a number as percentage. */
-function pct(value: number): string {
-  return `${value.toFixed(2)} %`
-}
-
-/** Format a decimal as percentage (e.g. 0.042 -> "4.20 %"). */
-function pctFromDecimal(value: number): string {
-  return `${(value * 100).toFixed(2)} %`
-}
-
-/** Format a number as a factor (e.g. 33.15x). */
-function factor(value: number): string {
-  return `${value.toFixed(1)}x`
-}
 
 /** Add branded header to the PDF. */
 function addHeader(doc: jsPDF, address: string, date: string): number {

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/AnnualCashflowTable.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/AnnualCashflowTable.tsx
@@ -4,6 +4,7 @@
  */
 
 import { cn } from "@/common/utils"
+import { EUR_FORMATTER_0 as EUR_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { AnnualCashflowRow } from "../types"
 
@@ -11,16 +12,6 @@ interface IProps {
   rows: AnnualCashflowRow[]
   className?: string
 }
-
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const EUR_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "currency",
-  currency: "EUR",
-  maximumFractionDigits: 0,
-})
 
 /******************************************************************************
                               Components

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/EvaluationSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/EvaluationSection.tsx
@@ -13,6 +13,10 @@ import {
 } from "lucide-react"
 import { SECTION_COLORS } from "@/common/constants/propertyEvaluation"
 import { cn } from "@/common/utils"
+import {
+  EUR_FORMATTER_2 as CURRENCY_FORMATTER,
+  PERCENT_FORMATTER,
+} from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import type { EvaluationResults } from "../types"
@@ -23,22 +27,6 @@ interface IProps {
   isLoading?: boolean
   className?: string
 }
-
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "currency",
-  currency: "EUR",
-  maximumFractionDigits: 2,
-})
-
-const PERCENT_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "percent",
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1,
-})
 
 /******************************************************************************
                               Functions

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/FinancingSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/FinancingSection.tsx
@@ -6,6 +6,7 @@
 import { Info, Landmark } from "lucide-react"
 import { SECTION_COLORS } from "@/common/constants/propertyEvaluation"
 import { cn } from "@/common/utils"
+import { EUR_FORMATTER_2 as CURRENCY_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
@@ -19,16 +20,6 @@ interface IProps {
   onChange: (updates: Partial<FinancingInputs>) => void
   className?: string
 }
-
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "currency",
-  currency: "EUR",
-  maximumFractionDigits: 2,
-})
 
 /******************************************************************************
                               Components

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
@@ -6,6 +6,7 @@
 import { Receipt } from "lucide-react"
 import { SECTION_COLORS } from "@/common/constants/propertyEvaluation"
 import { cn } from "@/common/utils"
+import { EUR_FORMATTER_2 as CURRENCY_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -18,16 +19,6 @@ interface IProps {
   onChange: (updates: Partial<OperatingCostsInputs>) => void
   className?: string
 }
-
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "currency",
-  currency: "EUR",
-  maximumFractionDigits: 2,
-})
 
 /******************************************************************************
                               Components

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
@@ -6,6 +6,7 @@
 import { Home } from "lucide-react"
 import { SECTION_COLORS } from "@/common/constants/propertyEvaluation"
 import { cn } from "@/common/utils"
+import { EUR_FORMATTER_0 as CURRENCY_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -17,16 +18,6 @@ interface IProps {
   onChange: (updates: Partial<PropertyInfoInputs>) => void
   className?: string
 }
-
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "currency",
-  currency: "EUR",
-  maximumFractionDigits: 0,
-})
 
 /******************************************************************************
                               Components

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
@@ -8,6 +8,7 @@ import { GERMAN_STATES } from "@/common/constants"
 import { SECTION_COLORS } from "@/common/constants/propertyEvaluation"
 import { MARKET_DATA_BY_STATE } from "@/common/constants/propertyGoals"
 import { cn } from "@/common/utils"
+import { EUR_FORMATTER_2 as CURRENCY_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -22,16 +23,6 @@ interface IProps {
   onChange: (updates: Partial<RentInputs>) => void
   className?: string
 }
-
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
-  style: "currency",
-  currency: "EUR",
-  maximumFractionDigits: 2,
-})
 
 /******************************************************************************
                               Components


### PR DESCRIPTION
## Summary

- **Backend schemas**: Derive `AnnualCashflowRowResponse` and `PropertyEvaluationCalculateResponse` from calculator dataclass fields via `pydantic.create_model`, eliminating ~70 lines of duplicated field definitions
- **Backend service**: Refactor `calculate_from_request` to delegate through `_inputs_from_dict` via a `_request_to_nested_dict` bridge, eliminating ~30 lines of duplicated `EvaluationInputs` construction with identical `/100` conversions
- **Frontend formatters**: Consolidate 6+ identical `CURRENCY_FORMATTER` / `EUR_FORMATTER` instances and 5 PDF helper functions into shared `formatters.ts` utilities, imported by all consumers

## Test plan

- [x] 753 backend tests pass
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [x] Ruff lint and format checks pass
- [x] Biome check passes on all 8 changed frontend files
- [x] OpenAPI schema verified: 20 fields on `AnnualCashflowRowResponse`, 42 fields on `PropertyEvaluationCalculateResponse`