### PR TITLE
refactor(calculator): use horizontal form layout

### DIFF
--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/FormRow.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/FormRow.tsx
@@ -1,0 +1,47 @@
+/**
+ * FormRow
+ * Horizontal label-input layout that stacks vertically on mobile
+ */
+
+import type { ReactNode } from "react"
+import { Label } from "@/components/ui/label"
+import { FieldTooltip } from "./FieldTooltip"
+
+interface IProps {
+  htmlFor?: string
+  label: string
+  tooltip?: string
+  required?: boolean
+  optional?: boolean
+  children: ReactNode
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Horizontal label-input row. Stacks on mobile, inline on sm+. */
+function FormRow(props: IProps) {
+  const { htmlFor, label, tooltip, required, optional, children } = props
+  return (
+    <div className="grid gap-1.5 sm:grid-cols-[12rem_1fr] sm:items-center">
+      <Label htmlFor={htmlFor} className="leading-tight">
+        {label}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+        {optional && (
+          <span className="ml-1 font-normal text-muted-foreground">
+            (optional)
+          </span>
+        )}
+        {tooltip && <FieldTooltip text={tooltip} />}
+      </Label>
+      {children}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { FormRow }

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/FinancingSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/FinancingSection.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { FormRow } from "../FormRow"
 import type { FinancingInputs } from "../types"
 
 interface IProps {
@@ -45,8 +46,8 @@ function FinancingSection(props: IProps) {
   const debtServiceMonthly = monthlyInterest + monthlyRepayment
 
   const loanLabel = values.includeAcquisitionCosts
-    ? "Loan (% of total investment)"
-    : "Loan (% of purchase price)"
+    ? "Loan (% of total inv.)"
+    : "Loan (% of price)"
 
   return (
     <Card className={cn("overflow-hidden", className)}>
@@ -59,7 +60,7 @@ function FinancingSection(props: IProps) {
           Retrieve from bank offer
         </p>
       </CardHeader>
-      <CardContent className="space-y-4 pt-4">
+      <CardContent className="space-y-3 pt-4">
         {/* 110% financing toggle */}
         <div className="flex items-start gap-3">
           <Checkbox
@@ -97,55 +98,46 @@ function FinancingSection(props: IProps) {
         )}
 
         {/* Loan settings */}
-        <div className="grid gap-4 sm:grid-cols-3">
-          <div className="space-y-2">
-            <Label htmlFor="loanPercent">{loanLabel}</Label>
-            <Input
-              id="loanPercent"
-              type="number"
-              step="5"
-              min="0"
-              max="100"
-              placeholder="e.g., 100"
-              value={values.loanPercent || ""}
-              onChange={(e) =>
-                handleNumberChange("loanPercent", e.target.value)
-              }
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="interestRate">Interest Rate (%)</Label>
-            <Input
-              id="interestRate"
-              type="number"
-              step="0.1"
-              min="0"
-              max="15"
-              placeholder="e.g., 4.0"
-              value={values.interestRatePercent || ""}
-              onChange={(e) =>
-                handleNumberChange("interestRatePercent", e.target.value)
-              }
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="repaymentRate">
-              Initial Repayment / Acquittance (%)
-            </Label>
-            <Input
-              id="repaymentRate"
-              type="number"
-              step="0.5"
-              min="0"
-              max="10"
-              placeholder="e.g., 2.0"
-              value={values.repaymentRatePercent || ""}
-              onChange={(e) =>
-                handleNumberChange("repaymentRatePercent", e.target.value)
-              }
-            />
-          </div>
-        </div>
+        <FormRow htmlFor="loanPercent" label={loanLabel}>
+          <Input
+            id="loanPercent"
+            type="number"
+            step="5"
+            min="0"
+            max="100"
+            placeholder="e.g., 100"
+            value={values.loanPercent || ""}
+            onChange={(e) => handleNumberChange("loanPercent", e.target.value)}
+          />
+        </FormRow>
+        <FormRow htmlFor="interestRate" label="Interest Rate (%)">
+          <Input
+            id="interestRate"
+            type="number"
+            step="0.1"
+            min="0"
+            max="15"
+            placeholder="e.g., 4.0"
+            value={values.interestRatePercent || ""}
+            onChange={(e) =>
+              handleNumberChange("interestRatePercent", e.target.value)
+            }
+          />
+        </FormRow>
+        <FormRow htmlFor="repaymentRate" label="Repayment Rate (%)">
+          <Input
+            id="repaymentRate"
+            type="number"
+            step="0.5"
+            min="0"
+            max="10"
+            placeholder="e.g., 2.0"
+            value={values.repaymentRatePercent || ""}
+            onChange={(e) =>
+              handleNumberChange("repaymentRatePercent", e.target.value)
+            }
+          />
+        </FormRow>
 
         {/* Financing summary */}
         {purchasePrice > 0 && (

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
@@ -9,8 +9,7 @@ import { cn } from "@/common/utils"
 import { EUR_FORMATTER_2 as CURRENCY_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { FieldTooltip } from "../FieldTooltip"
+import { FormRow } from "../FormRow"
 import type { OperatingCostsInputs } from "../types"
 
 interface IProps {
@@ -36,7 +35,6 @@ function OperatingCostsSection(props: IProps) {
     onChange({ [field]: num })
   }
 
-  // Derive display values
   const totalAllocable = values.hausgeldAllocable + values.propertyTaxMonthly
   const totalNonAllocable = values.hausgeldNonAllocable + values.reservesPortion
   const overallHausgeld = totalAllocable + totalNonAllocable
@@ -51,7 +49,7 @@ function OperatingCostsSection(props: IProps) {
           Operating Costs
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4 pt-4">
+      <CardContent className="space-y-3 pt-4">
         {/* Monthly Management Costs summary */}
         <p className="text-sm font-medium text-muted-foreground">
           Monthly Management Costs
@@ -92,48 +90,40 @@ function OperatingCostsSection(props: IProps) {
           <p className="text-sm font-medium text-muted-foreground">
             Allocable and Non-Allocable Costs (retrieve from Abrechnung)
           </p>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="hausgeldAllocable">
-                House Allowance - Allocable (EUR/month)
-                <FieldTooltip text="Umlagefähige Nebenkosten — costs passed through to the tenant (heating, water, garbage, cleaning, etc.)" />
-              </Label>
-              <Input
-                id="hausgeldAllocable"
-                type="number"
-                step="10"
-                min="0"
-                placeholder="e.g., 116"
-                value={values.hausgeldAllocable || ""}
-                onChange={(e) =>
-                  handleNumberChange("hausgeldAllocable", e.target.value)
-                }
-              />
-              <p className="text-xs text-muted-foreground">
-                Allocable portion passed to tenant
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="propertyTaxMonthly">
-                Property Tax (EUR/month)
-                <FieldTooltip text="Grundsteuer — municipal property tax, allocable to the tenant under German law" />
-              </Label>
-              <Input
-                id="propertyTaxMonthly"
-                type="number"
-                step="1"
-                min="0"
-                placeholder="e.g., 7"
-                value={values.propertyTaxMonthly || ""}
-                onChange={(e) =>
-                  handleNumberChange("propertyTaxMonthly", e.target.value)
-                }
-              />
-              <p className="text-xs text-muted-foreground">
-                Grundsteuer - allocable to tenant
-              </p>
-            </div>
-          </div>
+          <FormRow
+            htmlFor="hausgeldAllocable"
+            label="Allocable Hausgeld (EUR/mo)"
+            tooltip="Umlagefähige Nebenkosten — costs passed through to the tenant (heating, water, garbage, cleaning, etc.)"
+          >
+            <Input
+              id="hausgeldAllocable"
+              type="number"
+              step="10"
+              min="0"
+              placeholder="e.g., 116"
+              value={values.hausgeldAllocable || ""}
+              onChange={(e) =>
+                handleNumberChange("hausgeldAllocable", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="propertyTaxMonthly"
+            label="Property Tax (EUR/mo)"
+            tooltip="Grundsteuer — municipal property tax, allocable to the tenant under German law"
+          >
+            <Input
+              id="propertyTaxMonthly"
+              type="number"
+              step="1"
+              min="0"
+              placeholder="e.g., 7"
+              value={values.propertyTaxMonthly || ""}
+              onChange={(e) =>
+                handleNumberChange("propertyTaxMonthly", e.target.value)
+              }
+            />
+          </FormRow>
 
           {/* Computed total allocable */}
           <div className="rounded-md bg-muted/50 p-2">
@@ -143,48 +133,40 @@ function OperatingCostsSection(props: IProps) {
             </div>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="hausgeldNonAllocable">
-                House Allowance - Non-allocable (EUR/month)
-                <FieldTooltip text="Nicht umlagefähige Kosten — landlord-only costs that cannot be passed to the tenant (property management fees, etc.)" />
-              </Label>
-              <Input
-                id="hausgeldNonAllocable"
-                type="number"
-                step="10"
-                min="0"
-                placeholder="e.g., 23"
-                value={values.hausgeldNonAllocable || ""}
-                onChange={(e) =>
-                  handleNumberChange("hausgeldNonAllocable", e.target.value)
-                }
-              />
-              <p className="text-xs text-muted-foreground">
-                Non-allocable landlord expense
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="reservesPortion">
-                Reserves (EUR/month)
-                <FieldTooltip text="Instandhaltungsrücklage — mandatory repair fund contribution for the building, set by the HOA" />
-              </Label>
-              <Input
-                id="reservesPortion"
-                type="number"
-                step="1"
-                min="0"
-                placeholder="e.g., 7"
-                value={values.reservesPortion || ""}
-                onChange={(e) =>
-                  handleNumberChange("reservesPortion", e.target.value)
-                }
-              />
-              <p className="text-xs text-muted-foreground">
-                Instandhaltungsrücklage
-              </p>
-            </div>
-          </div>
+          <FormRow
+            htmlFor="hausgeldNonAllocable"
+            label="Non-alloc. Hausgeld (EUR/mo)"
+            tooltip="Nicht umlagefähige Kosten — landlord-only costs that cannot be passed to the tenant (property management fees, etc.)"
+          >
+            <Input
+              id="hausgeldNonAllocable"
+              type="number"
+              step="10"
+              min="0"
+              placeholder="e.g., 23"
+              value={values.hausgeldNonAllocable || ""}
+              onChange={(e) =>
+                handleNumberChange("hausgeldNonAllocable", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="reservesPortion"
+            label="Reserves (EUR/month)"
+            tooltip="Instandhaltungsrücklage — mandatory repair fund contribution for the building, set by the HOA"
+          >
+            <Input
+              id="reservesPortion"
+              type="number"
+              step="1"
+              min="0"
+              placeholder="e.g., 7"
+              value={values.reservesPortion || ""}
+              onChange={(e) =>
+                handleNumberChange("reservesPortion", e.target.value)
+              }
+            />
+          </FormRow>
 
           {/* Computed total non-allocable */}
           <div className="rounded-md bg-muted/50 p-2">

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/PropertyInfoSection.tsx
@@ -9,8 +9,7 @@ import { cn } from "@/common/utils"
 import { EUR_FORMATTER_0 as CURRENCY_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { FieldTooltip } from "../FieldTooltip"
+import { FormRow } from "../FormRow"
 import type { PropertyInfoInputs } from "../types"
 
 interface IProps {
@@ -20,7 +19,7 @@ interface IProps {
 }
 
 /******************************************************************************
-                              Components
+                              Functions
 ******************************************************************************/
 
 /** Format number with thousand separators. */
@@ -34,6 +33,10 @@ function parseNumber(value: string): number {
   const cleaned = value.replace(/[^\d]/g, "")
   return cleaned ? parseInt(cleaned, 10) : 0
 }
+
+/******************************************************************************
+                              Components
+******************************************************************************/
 
 /** Default component. Property information section. */
 function PropertyInfoSection(props: IProps) {
@@ -77,15 +80,8 @@ function PropertyInfoSection(props: IProps) {
           Retrieve from Expose
         </p>
       </CardHeader>
-      <CardContent className="space-y-4 pt-4">
-        {/* Address */}
-        <div className="space-y-2">
-          <Label htmlFor="address">
-            Address{" "}
-            <span className="font-normal text-muted-foreground">
-              (optional)
-            </span>
-          </Label>
+      <CardContent className="space-y-3 pt-4">
+        <FormRow htmlFor="address" label="Address" optional>
           <Input
             id="address"
             type="text"
@@ -93,41 +89,37 @@ function PropertyInfoSection(props: IProps) {
             value={values.address}
             onChange={(e) => onChange({ address: e.target.value })}
           />
-        </div>
-
-        {/* Size and Price */}
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="squareMeters">
-              Living Space (m²) <span className="text-destructive">*</span>
-              <FieldTooltip text="Total usable living area in square meters, as listed in the property exposé (Wohnfläche)" />
-            </Label>
-            <Input
-              id="squareMeters"
-              type="number"
-              step="0.1"
-              min="0"
-              placeholder="e.g., 25.7"
-              value={values.squareMeters || ""}
-              onChange={(e) =>
-                handlePercentChange("squareMeters", e.target.value)
-              }
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="purchasePrice">Purchase Price (EUR)</Label>
-            <Input
-              id="purchasePrice"
-              type="text"
-              inputMode="numeric"
-              placeholder="e.g., 240,000"
-              value={formatNumber(values.purchasePrice)}
-              onChange={(e) =>
-                handleNumberChange("purchasePrice", e.target.value)
-              }
-            />
-          </div>
-        </div>
+        </FormRow>
+        <FormRow
+          htmlFor="squareMeters"
+          label="Living Space (m²)"
+          tooltip="Total usable living area in square meters, as listed in the property exposé (Wohnfläche)"
+          required
+        >
+          <Input
+            id="squareMeters"
+            type="number"
+            step="0.1"
+            min="0"
+            placeholder="e.g., 25.7"
+            value={values.squareMeters || ""}
+            onChange={(e) =>
+              handlePercentChange("squareMeters", e.target.value)
+            }
+          />
+        </FormRow>
+        <FormRow htmlFor="purchasePrice" label="Purchase Price (EUR)">
+          <Input
+            id="purchasePrice"
+            type="text"
+            inputMode="numeric"
+            placeholder="e.g., 240,000"
+            value={formatNumber(values.purchasePrice)}
+            onChange={(e) =>
+              handleNumberChange("purchasePrice", e.target.value)
+            }
+          />
+        </FormRow>
 
         {/* Price per sqm display */}
         {pricePerSqm > 0 && (
@@ -146,76 +138,74 @@ function PropertyInfoSection(props: IProps) {
           <p className="text-sm font-medium text-muted-foreground">
             Transaction Costs
           </p>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="brokerFee">
-                Broker Fee (%)
-                <FieldTooltip text="Maklergebühr — agent commission, typically 3-7% split between buyer and seller" />
-              </Label>
-              <Input
-                id="brokerFee"
-                type="number"
-                step="0.01"
-                min="0"
-                max="10"
-                value={values.brokerFeePercent || ""}
-                onChange={(e) =>
-                  handlePercentChange("brokerFeePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="notaryFee">
-                Notary Fee (%)
-                <FieldTooltip text="Notargebühren — legally required for property transfer, typically ~1.5% of purchase price" />
-              </Label>
-              <Input
-                id="notaryFee"
-                type="number"
-                step="0.01"
-                min="0"
-                max="5"
-                value={values.notaryFeePercent || ""}
-                onChange={(e) =>
-                  handlePercentChange("notaryFeePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="landRegistryFee">
-                Land Registry Fee (%)
-                <FieldTooltip text="Grundbuchgebühren — fee for registering ownership in the Grundbuch, typically ~0.5%" />
-              </Label>
-              <Input
-                id="landRegistryFee"
-                type="number"
-                step="0.01"
-                min="0"
-                max="2"
-                value={values.landRegistryFeePercent || ""}
-                onChange={(e) =>
-                  handlePercentChange("landRegistryFeePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="transferTax">
-                Transfer Tax (%)
-                <FieldTooltip text="Grunderwerbsteuer — varies by state (Bundesland), from 3.5% to 6.5% of purchase price" />
-              </Label>
-              <Input
-                id="transferTax"
-                type="number"
-                step="0.1"
-                min="0"
-                max="10"
-                value={values.transferTaxPercent || ""}
-                onChange={(e) =>
-                  handlePercentChange("transferTaxPercent", e.target.value)
-                }
-              />
-            </div>
-          </div>
+          <FormRow
+            htmlFor="brokerFee"
+            label="Broker Fee (%)"
+            tooltip="Maklergebühr — agent commission, typically 3-7% split between buyer and seller"
+          >
+            <Input
+              id="brokerFee"
+              type="number"
+              step="0.01"
+              min="0"
+              max="10"
+              value={values.brokerFeePercent || ""}
+              onChange={(e) =>
+                handlePercentChange("brokerFeePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="notaryFee"
+            label="Notary Fee (%)"
+            tooltip="Notargebühren — legally required for property transfer, typically ~1.5% of purchase price"
+          >
+            <Input
+              id="notaryFee"
+              type="number"
+              step="0.01"
+              min="0"
+              max="5"
+              value={values.notaryFeePercent || ""}
+              onChange={(e) =>
+                handlePercentChange("notaryFeePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="landRegistryFee"
+            label="Land Registry Fee (%)"
+            tooltip="Grundbuchgebühren — fee for registering ownership in the Grundbuch, typically ~0.5%"
+          >
+            <Input
+              id="landRegistryFee"
+              type="number"
+              step="0.01"
+              min="0"
+              max="2"
+              value={values.landRegistryFeePercent || ""}
+              onChange={(e) =>
+                handlePercentChange("landRegistryFeePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="transferTax"
+            label="Transfer Tax (%)"
+            tooltip="Grunderwerbsteuer — varies by state (Bundesland), from 3.5% to 6.5% of purchase price"
+          >
+            <Input
+              id="transferTax"
+              type="number"
+              step="0.1"
+              min="0"
+              max="10"
+              value={values.transferTaxPercent || ""}
+              onChange={(e) =>
+                handlePercentChange("transferTaxPercent", e.target.value)
+              }
+            />
+          </FormRow>
         </div>
 
         {/* Total incidental costs display */}

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/RentSection.tsx
@@ -11,8 +11,7 @@ import { cn } from "@/common/utils"
 import { EUR_FORMATTER_2 as CURRENCY_FORMATTER } from "@/common/utils/formatters"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { FieldTooltip } from "../FieldTooltip"
+import { FormRow } from "../FormRow"
 import type { RentInputs } from "../types"
 
 interface IProps {
@@ -60,42 +59,37 @@ function RentSection(props: IProps) {
           Rent, Taxes, Forecast
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4 pt-4">
+      <CardContent className="space-y-3 pt-4">
         {/* Monthly Rent subsection */}
         <p className="text-sm font-medium text-muted-foreground">
           Monthly Rent (retrieve from Expose)
         </p>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="rentPerSqm">
-              Rent per m² (EUR)
-              <FieldTooltip text="Monthly cold rent (Kaltmiete) per square meter, excluding utilities and operating costs" />
-            </Label>
-            <Input
-              id="rentPerSqm"
-              type="number"
-              step="0.5"
-              min="0"
-              placeholder="e.g., 12"
-              value={values.rentPerSqm || ""}
-              onChange={(e) => handleNumberChange("rentPerSqm", e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="parkingRent">Parking Rent (EUR/month)</Label>
-            <Input
-              id="parkingRent"
-              type="number"
-              step="10"
-              min="0"
-              placeholder="e.g., 50"
-              value={values.parkingRent || ""}
-              onChange={(e) =>
-                handleNumberChange("parkingRent", e.target.value)
-              }
-            />
-          </div>
-        </div>
+        <FormRow
+          htmlFor="rentPerSqm"
+          label="Rent per m² (EUR)"
+          tooltip="Monthly cold rent (Kaltmiete) per square meter, excluding utilities and operating costs"
+        >
+          <Input
+            id="rentPerSqm"
+            type="number"
+            step="0.5"
+            min="0"
+            placeholder="e.g., 12"
+            value={values.rentPerSqm || ""}
+            onChange={(e) => handleNumberChange("rentPerSqm", e.target.value)}
+          />
+        </FormRow>
+        <FormRow htmlFor="parkingRent" label="Parking Rent (EUR/mo)">
+          <Input
+            id="parkingRent"
+            type="number"
+            step="10"
+            min="0"
+            placeholder="e.g., 50"
+            value={values.parkingRent || ""}
+            onChange={(e) => handleNumberChange("parkingRent", e.target.value)}
+          />
+        </FormRow>
         {marketData && stateName && (
           <p className="flex items-center gap-1 text-xs text-muted-foreground">
             <Info className="h-3 w-3 shrink-0" />
@@ -143,63 +137,58 @@ function RentSection(props: IProps) {
         {/* Taxes subsection */}
         <div className="space-y-3 border-t pt-4">
           <p className="text-sm font-medium text-muted-foreground">Taxes</p>
-          <div className="grid gap-4 sm:grid-cols-3">
-            <div className="space-y-2">
-              <Label htmlFor="depreciationRate">
-                Depreciation Rate (%)
-                <FieldTooltip text="AfA (Absetzung für Abnutzung) — tax-deductible building wear. 2% for buildings built after 1924, 2.5% for older" />
-              </Label>
-              <Input
-                id="depreciationRate"
-                type="number"
-                step="0.1"
-                min="0"
-                max="5"
-                value={values.depreciationRatePercent || ""}
-                onChange={(e) =>
-                  handleNumberChange("depreciationRatePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="buildingShare">
-                Building Share (%)
-                <FieldTooltip text="Percentage of purchase price attributable to the building (not land). Used for depreciation calculation" />
-              </Label>
-              <Input
-                id="buildingShare"
-                type="number"
-                step="5"
-                min="0"
-                max="100"
-                value={values.buildingSharePercent || ""}
-                onChange={(e) =>
-                  handleNumberChange("buildingSharePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="marginalTaxRate">
-                Marginal Tax Rate (%)
-                <FieldTooltip text="Your personal income tax rate in Germany (Einkommensteuer). Standard brackets range from 14% to 45%" />
-              </Label>
-              <Input
-                id="marginalTaxRate"
-                type="number"
-                step="1"
-                min="0"
-                max="50"
-                placeholder="e.g., 42"
-                value={values.marginalTaxRatePercent || ""}
-                onChange={(e) =>
-                  handleNumberChange("marginalTaxRatePercent", e.target.value)
-                }
-              />
-              <p className="text-xs text-muted-foreground">
-                Personal income tax bracket
-              </p>
-            </div>
-          </div>
+          <FormRow
+            htmlFor="depreciationRate"
+            label="Depreciation Rate (%)"
+            tooltip="AfA (Absetzung für Abnutzung) — tax-deductible building wear. 2% for buildings built after 1924, 2.5% for older"
+          >
+            <Input
+              id="depreciationRate"
+              type="number"
+              step="0.1"
+              min="0"
+              max="5"
+              value={values.depreciationRatePercent || ""}
+              onChange={(e) =>
+                handleNumberChange("depreciationRatePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="buildingShare"
+            label="Building Share (%)"
+            tooltip="Percentage of purchase price attributable to the building (not land). Used for depreciation calculation"
+          >
+            <Input
+              id="buildingShare"
+              type="number"
+              step="5"
+              min="0"
+              max="100"
+              value={values.buildingSharePercent || ""}
+              onChange={(e) =>
+                handleNumberChange("buildingSharePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="marginalTaxRate"
+            label="Marginal Tax Rate (%)"
+            tooltip="Your personal income tax rate in Germany (Einkommensteuer). Standard brackets range from 14% to 45%"
+          >
+            <Input
+              id="marginalTaxRate"
+              type="number"
+              step="1"
+              min="0"
+              max="50"
+              placeholder="e.g., 42"
+              value={values.marginalTaxRatePercent || ""}
+              onChange={(e) =>
+                handleNumberChange("marginalTaxRatePercent", e.target.value)
+              }
+            />
+          </FormRow>
         </div>
 
         {/* Tax Context subsection */}
@@ -207,25 +196,23 @@ function RentSection(props: IProps) {
           <p className="text-sm font-medium text-muted-foreground">
             Tax Context
           </p>
-          <div className="grid gap-4 sm:grid-cols-1">
-            <div className="space-y-2">
-              <Label htmlFor="personalTaxableIncome">
-                Personal Taxable Income (EUR/year)
-                <FieldTooltip text="Your annual taxable income from employment or other sources. Used for progressive tax calculation (§32a EStG)" />
-              </Label>
-              <Input
-                id="personalTaxableIncome"
-                type="number"
-                step="1000"
-                min="0"
-                placeholder="e.g., 60000"
-                value={values.personalTaxableIncome || ""}
-                onChange={(e) =>
-                  handleNumberChange("personalTaxableIncome", e.target.value)
-                }
-              />
-            </div>
-          </div>
+          <FormRow
+            htmlFor="personalTaxableIncome"
+            label="Taxable Income (EUR/yr)"
+            tooltip="Your annual taxable income from employment or other sources. Used for progressive tax calculation (§32a EStG)"
+          >
+            <Input
+              id="personalTaxableIncome"
+              type="number"
+              step="1000"
+              min="0"
+              placeholder="e.g., 60000"
+              value={values.personalTaxableIncome || ""}
+              onChange={(e) =>
+                handleNumberChange("personalTaxableIncome", e.target.value)
+              }
+            />
+          </FormRow>
         </div>
 
         {/* Renovation subsection */}
@@ -233,43 +220,41 @@ function RentSection(props: IProps) {
           <p className="text-sm font-medium text-muted-foreground">
             Renovation
           </p>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="renovationYear">
-                Renovation Year
-                <FieldTooltip text="Year number (1-10) when renovation occurs. Set to 0 for no renovation" />
-              </Label>
-              <Input
-                id="renovationYear"
-                type="number"
-                step="1"
-                min="0"
-                max="20"
-                placeholder="0 = none"
-                value={values.renovationYear || ""}
-                onChange={(e) =>
-                  handleNumberChange("renovationYear", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="renovationCost">
-                Renovation Cost (EUR)
-                <FieldTooltip text="Total renovation cost, tax-deductible in the renovation year" />
-              </Label>
-              <Input
-                id="renovationCost"
-                type="number"
-                step="1000"
-                min="0"
-                placeholder="e.g., 15000"
-                value={values.renovationCost || ""}
-                onChange={(e) =>
-                  handleNumberChange("renovationCost", e.target.value)
-                }
-              />
-            </div>
-          </div>
+          <FormRow
+            htmlFor="renovationYear"
+            label="Renovation Year"
+            tooltip="Year number (1-10) when renovation occurs. Set to 0 for no renovation"
+          >
+            <Input
+              id="renovationYear"
+              type="number"
+              step="1"
+              min="0"
+              max="20"
+              placeholder="0 = none"
+              value={values.renovationYear || ""}
+              onChange={(e) =>
+                handleNumberChange("renovationYear", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="renovationCost"
+            label="Renovation Cost (EUR)"
+            tooltip="Total renovation cost, tax-deductible in the renovation year"
+          >
+            <Input
+              id="renovationCost"
+              type="number"
+              step="1000"
+              min="0"
+              placeholder="e.g., 15000"
+              value={values.renovationCost || ""}
+              onChange={(e) =>
+                handleNumberChange("renovationCost", e.target.value)
+              }
+            />
+          </FormRow>
         </div>
 
         {/* Analysis Period subsection */}
@@ -277,117 +262,111 @@ function RentSection(props: IProps) {
           <p className="text-sm font-medium text-muted-foreground">
             Analysis Period
           </p>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="startYear">
-                Start Year
-                <FieldTooltip text="First year of the investment analysis" />
-              </Label>
-              <Input
-                id="startYear"
-                type="number"
-                step="1"
-                min="2020"
-                max="2040"
-                value={values.startYear || ""}
-                onChange={(e) =>
-                  handleNumberChange("startYear", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="analysisYears">
-                Analysis Years
-                <FieldTooltip text="Number of years to project (last year is the exit/sale year)" />
-              </Label>
-              <Input
-                id="analysisYears"
-                type="number"
-                step="1"
-                min="2"
-                max="30"
-                value={values.analysisYears || ""}
-                onChange={(e) =>
-                  handleNumberChange("analysisYears", e.target.value)
-                }
-              />
-            </div>
-          </div>
+          <FormRow
+            htmlFor="startYear"
+            label="Start Year"
+            tooltip="First year of the investment analysis"
+          >
+            <Input
+              id="startYear"
+              type="number"
+              step="1"
+              min="2020"
+              max="2040"
+              value={values.startYear || ""}
+              onChange={(e) => handleNumberChange("startYear", e.target.value)}
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="analysisYears"
+            label="Analysis Years"
+            tooltip="Number of years to project (last year is the exit/sale year)"
+          >
+            <Input
+              id="analysisYears"
+              type="number"
+              step="1"
+              min="2"
+              max="30"
+              value={values.analysisYears || ""}
+              onChange={(e) =>
+                handleNumberChange("analysisYears", e.target.value)
+              }
+            />
+          </FormRow>
         </div>
 
         {/* Forecast subsection */}
         <div className="space-y-3 border-t pt-4">
           <p className="text-sm font-medium text-muted-foreground">Forecast</p>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="costIncrease">
-                Cost Increase p.a. (%)
-                <FieldTooltip text="Expected annual increase in operating costs, typically tracking inflation" />
-              </Label>
-              <Input
-                id="costIncrease"
-                type="number"
-                step="0.1"
-                min="0"
-                max="10"
-                value={values.costIncreasePercent || ""}
-                onChange={(e) =>
-                  handleNumberChange("costIncreasePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="rentIncrease">
-                Rent Increase p.a. (%)
-                <FieldTooltip text="Expected annual rent increase. Subject to Mietpreisbremse (rent cap) in regulated areas" />
-              </Label>
-              <Input
-                id="rentIncrease"
-                type="number"
-                step="0.1"
-                min="0"
-                max="10"
-                value={values.rentIncreasePercent || ""}
-                onChange={(e) =>
-                  handleNumberChange("rentIncreasePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="valueIncrease">
-                Value Increase p.a. (%)
-                <FieldTooltip text="Expected annual property value appreciation rate" />
-              </Label>
-              <Input
-                id="valueIncrease"
-                type="number"
-                step="0.1"
-                min="0"
-                max="10"
-                value={values.valueIncreasePercent || ""}
-                onChange={(e) =>
-                  handleNumberChange("valueIncreasePercent", e.target.value)
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="equityInterest">
-                Interest on Equity p.a. (%)
-                <FieldTooltip text="Opportunity cost — what your equity could earn if invested elsewhere (e.g., stock market returns)" />
-              </Label>
-              <Input
-                id="equityInterest"
-                type="number"
-                step="0.5"
-                min="0"
-                max="20"
-                value={values.equityInterestPercent || ""}
-                onChange={(e) =>
-                  handleNumberChange("equityInterestPercent", e.target.value)
-                }
-              />
-            </div>
-          </div>
+          <FormRow
+            htmlFor="costIncrease"
+            label="Cost Increase p.a. (%)"
+            tooltip="Expected annual increase in operating costs, typically tracking inflation"
+          >
+            <Input
+              id="costIncrease"
+              type="number"
+              step="0.1"
+              min="0"
+              max="10"
+              value={values.costIncreasePercent || ""}
+              onChange={(e) =>
+                handleNumberChange("costIncreasePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="rentIncrease"
+            label="Rent Increase p.a. (%)"
+            tooltip="Expected annual rent increase. Subject to Mietpreisbremse (rent cap) in regulated areas"
+          >
+            <Input
+              id="rentIncrease"
+              type="number"
+              step="0.1"
+              min="0"
+              max="10"
+              value={values.rentIncreasePercent || ""}
+              onChange={(e) =>
+                handleNumberChange("rentIncreasePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="valueIncrease"
+            label="Value Increase p.a. (%)"
+            tooltip="Expected annual property value appreciation rate"
+          >
+            <Input
+              id="valueIncrease"
+              type="number"
+              step="0.1"
+              min="0"
+              max="10"
+              value={values.valueIncreasePercent || ""}
+              onChange={(e) =>
+                handleNumberChange("valueIncreasePercent", e.target.value)
+              }
+            />
+          </FormRow>
+          <FormRow
+            htmlFor="equityInterest"
+            label="Equity Interest p.a. (%)"
+            tooltip="Opportunity cost — what your equity could earn if invested elsewhere (e.g., stock market returns)"
+          >
+            <Input
+              id="equityInterest"
+              type="number"
+              step="0.5"
+              min="0"
+              max="20"
+              value={values.equityInterestPercent || ""}
+              onChange={(e) =>
+                handleNumberChange("equityInterestPercent", e.target.value)
+              }
+            />
+          </FormRow>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- Add reusable `FormRow` component with horizontal label-input layout (`sm:grid-cols-[12rem_1fr]`) that stacks vertically on mobile
- Convert all 4 input sections (PropertyInfo, Rent, OperatingCosts, Financing) from stacked label-above-input to inline horizontal rows
- Remove redundant helper text below inputs (already covered by tooltips), shorten labels for horizontal fit

## Motivation
The property evaluation calculator required excessive scrolling due to stacked label/input pairs across ~28 fields. Each field previously took ~68px (label + gap + input). With horizontal layout, each field takes ~40px — reducing page height by ~780px on desktop.

## Test plan
- [ ] Verify all input sections render correctly on desktop (labels left, inputs right)
- [ ] Verify mobile layout stacks labels above inputs (< 640px)
- [ ] Verify tooltips still appear on hover/tap for all fields
- [ ] Verify all computed summary boxes (price/m², incidental costs, rent summary, etc.) unchanged
- [ ] Verify financing checkbox toggle still works
- [ ] TypeScript compiles (`npx tsc --noEmit`)
- [ ] Biome lint passes