### PR TITLE
feat(calculator): add shareable property evaluation links

### DIFF
--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -7,9 +7,11 @@ import { Link } from "@tanstack/react-router"
 import {
   ArrowLeft,
   Download,
+  ExternalLink,
   Loader2,
   RefreshCw,
   Save,
+  Share2,
   Trash2,
 } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
@@ -182,9 +184,10 @@ function SavedEvaluations(props: {
   evaluations: PropertyEvaluationSummary[]
   onDelete: (id: string) => void
   onLoad: (id: string) => void
+  onCopyShare: (shareId: string) => void
   loadingId: string | null
 }) {
-  const { evaluations, onDelete, onLoad, loadingId } = props
+  const { evaluations, onDelete, onLoad, onCopyShare, loadingId } = props
 
   return (
     <Card>
@@ -227,17 +230,33 @@ function SavedEvaluations(props: {
                 {isLoading ? (
                   <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
                 ) : (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onDelete(ev.id)
-                    }}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  <div className="flex shrink-0">
+                    {ev.shareId && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onCopyShare(ev.shareId as string)
+                        }}
+                        title="Copy share link"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onDelete(ev.id)
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
                 )}
               </button>
             )
@@ -267,6 +286,7 @@ function PropertyEvaluationCalculator(
     loadFromStorage(journeyId, initialState, initialBudget),
   )
   const [saveName, setSaveName] = useState("")
+  const [shareUrl, setShareUrl] = useState("")
   const [loadingId, setLoadingId] = useState<string | null>(null)
 
   const effectiveState = isOwnerOccupier
@@ -342,6 +362,7 @@ function PropertyEvaluationCalculator(
 
   const handleSave = () => {
     if (!results) return
+    setShareUrl("")
     saveEvaluation.mutate(
       {
         name: saveName || undefined,
@@ -349,12 +370,32 @@ function PropertyEvaluationCalculator(
         inputs: state,
       },
       {
-        onSuccess: () => {
+        onSuccess: (saved) => {
           setSaveName("")
           showSuccessToast("Property evaluation saved")
+          if (saved.shareId) {
+            setShareUrl(
+              `${window.location.origin}/shared/evaluation/${saved.shareId}`,
+            )
+          }
         },
         onError: handleError.bind(showErrorToast),
       },
+    )
+  }
+
+  const handleCopyShareUrl = () => {
+    navigator.clipboard.writeText(shareUrl).then(
+      () => showSuccessToast("Share link copied to clipboard"),
+      () => showErrorToast("Failed to copy link"),
+    )
+  }
+
+  const handleCopyShareId = (shareId: string) => {
+    const url = `${window.location.origin}/shared/evaluation/${shareId}`
+    navigator.clipboard.writeText(url).then(
+      () => showSuccessToast("Share link copied to clipboard"),
+      () => showErrorToast("Failed to copy link"),
     )
   }
 
@@ -487,6 +528,24 @@ function PropertyEvaluationCalculator(
                 <Save className="h-4 w-4" />
                 {saveEvaluation.isPending ? "Saving..." : "Save Evaluation"}
               </Button>
+              {shareUrl && (
+                <div className="rounded-lg border p-3 space-y-2">
+                  <p className="text-sm font-medium flex items-center gap-2">
+                    <Share2 className="h-4 w-4" />
+                    Share Link
+                  </p>
+                  <div className="flex gap-2">
+                    <Input value={shareUrl} readOnly className="text-xs" />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleCopyShareUrl}
+                    >
+                      Copy
+                    </Button>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>
@@ -503,6 +562,7 @@ function PropertyEvaluationCalculator(
           evaluations={savedEvals.data}
           onDelete={handleDelete}
           onLoad={handleLoad}
+          onCopyShare={handleCopyShareId}
           loadingId={loadingId}
         />
       )}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as LayoutLawsIndexRouteImport } from './routes/_layout/laws/index
 import { Route as LayoutJourneysIndexRouteImport } from './routes/_layout/journeys/index'
 import { Route as LayoutDocumentsIndexRouteImport } from './routes/_layout/documents/index'
 import { Route as LayoutArticlesIndexRouteImport } from './routes/_layout/articles/index'
+import { Route as SharedEvaluationShareIdRouteImport } from './routes/shared/evaluation.$shareId'
 import { Route as LayoutLawsBookmarksRouteImport } from './routes/_layout/laws/bookmarks'
 import { Route as LayoutLawsLawIdRouteImport } from './routes/_layout/laws/$lawId'
 import { Route as LayoutJourneysNewRouteImport } from './routes/_layout/journeys/new'
@@ -119,6 +120,11 @@ const LayoutArticlesIndexRoute = LayoutArticlesIndexRouteImport.update({
   path: '/articles/',
   getParentRoute: () => LayoutRoute,
 } as any)
+const SharedEvaluationShareIdRoute = SharedEvaluationShareIdRouteImport.update({
+  id: '/shared/evaluation/$shareId',
+  path: '/shared/evaluation/$shareId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LayoutLawsBookmarksRoute = LayoutLawsBookmarksRouteImport.update({
   id: '/laws/bookmarks',
   path: '/laws/bookmarks',
@@ -182,6 +188,7 @@ export interface FileRoutesByFullPath {
   '/journeys/new': typeof LayoutJourneysNewRoute
   '/laws/$lawId': typeof LayoutLawsLawIdRoute
   '/laws/bookmarks': typeof LayoutLawsBookmarksRoute
+  '/shared/evaluation/$shareId': typeof SharedEvaluationShareIdRoute
   '/articles/': typeof LayoutArticlesIndexRoute
   '/documents/': typeof LayoutDocumentsIndexRoute
   '/journeys/': typeof LayoutJourneysIndexRoute
@@ -207,6 +214,7 @@ export interface FileRoutesByTo {
   '/journeys/new': typeof LayoutJourneysNewRoute
   '/laws/$lawId': typeof LayoutLawsLawIdRoute
   '/laws/bookmarks': typeof LayoutLawsBookmarksRoute
+  '/shared/evaluation/$shareId': typeof SharedEvaluationShareIdRoute
   '/articles': typeof LayoutArticlesIndexRoute
   '/documents': typeof LayoutDocumentsIndexRoute
   '/journeys': typeof LayoutJourneysIndexRoute
@@ -235,6 +243,7 @@ export interface FileRoutesById {
   '/_layout/journeys/new': typeof LayoutJourneysNewRoute
   '/_layout/laws/$lawId': typeof LayoutLawsLawIdRoute
   '/_layout/laws/bookmarks': typeof LayoutLawsBookmarksRoute
+  '/shared/evaluation/$shareId': typeof SharedEvaluationShareIdRoute
   '/_layout/articles/': typeof LayoutArticlesIndexRoute
   '/_layout/documents/': typeof LayoutDocumentsIndexRoute
   '/_layout/journeys/': typeof LayoutJourneysIndexRoute
@@ -263,6 +272,7 @@ export interface FileRouteTypes {
     | '/journeys/new'
     | '/laws/$lawId'
     | '/laws/bookmarks'
+    | '/shared/evaluation/$shareId'
     | '/articles/'
     | '/documents/'
     | '/journeys/'
@@ -288,6 +298,7 @@ export interface FileRouteTypes {
     | '/journeys/new'
     | '/laws/$lawId'
     | '/laws/bookmarks'
+    | '/shared/evaluation/$shareId'
     | '/articles'
     | '/documents'
     | '/journeys'
@@ -315,6 +326,7 @@ export interface FileRouteTypes {
     | '/_layout/journeys/new'
     | '/_layout/laws/$lawId'
     | '/_layout/laws/bookmarks'
+    | '/shared/evaluation/$shareId'
     | '/_layout/articles/'
     | '/_layout/documents/'
     | '/_layout/journeys/'
@@ -331,6 +343,7 @@ export interface RootRouteChildren {
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
+  SharedEvaluationShareIdRoute: typeof SharedEvaluationShareIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -453,6 +466,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/articles/'
       preLoaderRoute: typeof LayoutArticlesIndexRouteImport
       parentRoute: typeof LayoutRoute
+    }
+    '/shared/evaluation/$shareId': {
+      id: '/shared/evaluation/$shareId'
+      path: '/shared/evaluation/$shareId'
+      fullPath: '/shared/evaluation/$shareId'
+      preLoaderRoute: typeof SharedEvaluationShareIdRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_layout/laws/bookmarks': {
       id: '/_layout/laws/bookmarks'
@@ -579,6 +599,7 @@ const rootRouteChildren: RootRouteChildren = {
   ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,
   VerifyEmailRoute: VerifyEmailRoute,
+  SharedEvaluationShareIdRoute: SharedEvaluationShareIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/shared/evaluation.$shareId.tsx
+++ b/frontend/src/routes/shared/evaluation.$shareId.tsx
@@ -1,0 +1,241 @@
+/**
+ * Shared Property Evaluation Page
+ * Public read-only view of a shared property evaluation — no auth required.
+ */
+
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { AlertCircle, ArrowRight, Loader2 } from "lucide-react"
+import { formatEur } from "@/common/utils"
+import {
+  EUR_FORMATTER_2 as CURRENCY_FORMATTER,
+  PERCENT_FORMATTER,
+} from "@/common/utils/formatters"
+import {
+  AnnualCashflowTable,
+  EvaluationSection,
+} from "@/components/Calculators/PropertyEvaluationCalculator/sections"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { usePropertyEvaluationByShareId } from "@/hooks/queries/useCalculatorQueries"
+import type { PropertyEvaluationRecord } from "@/models/propertyEvaluation"
+
+export const Route = createFileRoute("/shared/evaluation/$shareId")({
+  component: SharedEvaluationPage,
+})
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Mini card for a single input field. */
+function InputCard(props: { label: string; value: string }) {
+  const { label, value } = props
+
+  return (
+    <div className="rounded-md border p-2">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="font-medium text-sm">{value}</p>
+    </div>
+  )
+}
+
+/** Read-only summary of the evaluation inputs. */
+function SharedInputSummary(props: { evaluation: PropertyEvaluationRecord }) {
+  const { evaluation } = props
+  const { propertyInfo, rent, operatingCosts, financing } = evaluation.inputs
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {/* Property Info */}
+      <Card>
+        <CardHeader className="py-3">
+          <CardTitle className="text-sm">Property Info</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-2 pt-0">
+          {propertyInfo.address && (
+            <div className="col-span-2 rounded-md border p-2">
+              <p className="text-xs text-muted-foreground">Address</p>
+              <p className="font-medium text-sm">{propertyInfo.address}</p>
+            </div>
+          )}
+          <InputCard label="Size" value={`${propertyInfo.squareMeters} m²`} />
+          <InputCard
+            label="Purchase Price"
+            value={formatEur(propertyInfo.purchasePrice)}
+          />
+          <InputCard
+            label="Broker Fee"
+            value={`${propertyInfo.brokerFeePercent}%`}
+          />
+          <InputCard
+            label="Transfer Tax"
+            value={`${propertyInfo.transferTaxPercent}%`}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Rent Parameters */}
+      <Card>
+        <CardHeader className="py-3">
+          <CardTitle className="text-sm">Rent Parameters</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-2 pt-0">
+          <InputCard
+            label="Rent / m²"
+            value={CURRENCY_FORMATTER.format(rent.rentPerSqm)}
+          />
+          <InputCard
+            label="Parking Rent"
+            value={CURRENCY_FORMATTER.format(rent.parkingRent)}
+          />
+          <InputCard
+            label="Tax Rate"
+            value={PERCENT_FORMATTER.format(rent.marginalTaxRatePercent / 100)}
+          />
+          <InputCard
+            label="Analysis Period"
+            value={`${rent.analysisYears} years`}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Operating Costs */}
+      <Card>
+        <CardHeader className="py-3">
+          <CardTitle className="text-sm">Operating Costs</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-2 pt-0">
+          <InputCard
+            label="Hausgeld (allocable)"
+            value={CURRENCY_FORMATTER.format(operatingCosts.hausgeldAllocable)}
+          />
+          <InputCard
+            label="Property Tax"
+            value={CURRENCY_FORMATTER.format(operatingCosts.propertyTaxMonthly)}
+          />
+          <InputCard
+            label="Hausgeld (non-alloc.)"
+            value={CURRENCY_FORMATTER.format(
+              operatingCosts.hausgeldNonAllocable,
+            )}
+          />
+          <InputCard
+            label="Reserves"
+            value={CURRENCY_FORMATTER.format(operatingCosts.reservesPortion)}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Financing */}
+      <Card>
+        <CardHeader className="py-3">
+          <CardTitle className="text-sm">Financing</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-2 pt-0">
+          <InputCard label="Loan" value={`${financing.loanPercent}%`} />
+          <InputCard
+            label="Interest Rate"
+            value={`${financing.interestRatePercent}%`}
+          />
+          <InputCard
+            label="Repayment Rate"
+            value={`${financing.repaymentRatePercent}%`}
+          />
+          <InputCard
+            label="Incl. Closing Costs"
+            value={financing.includeAcquisitionCosts ? "Yes" : "No"}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+/** CTA footer linking to signup. */
+function SharedFooter() {
+  return (
+    <div className="rounded-lg border bg-muted/50 p-6 text-center">
+      <p className="text-lg font-semibold mb-2">
+        Create your own evaluation on HeimPath
+      </p>
+      <p className="text-sm text-muted-foreground mb-4">
+        Analyze investment properties, track your buying journey, and more.
+      </p>
+      <Button asChild>
+        <Link to="/signup">
+          Get Started
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Link>
+      </Button>
+    </div>
+  )
+}
+
+/** Default component. Shared evaluation page. */
+function SharedEvaluationPage() {
+  const { shareId } = Route.useParams()
+  const { data, isLoading, isError } = usePropertyEvaluationByShareId(shareId)
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="text-center space-y-4">
+          <AlertCircle className="mx-auto h-12 w-12 text-muted-foreground" />
+          <h1 className="text-xl font-semibold">Evaluation not found</h1>
+          <p className="text-muted-foreground">
+            This shared evaluation link may be invalid or expired.
+          </p>
+          <Button variant="outline" asChild>
+            <Link to="/">Go to Home</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const evaluation = data
+  const isOwnerOccupier =
+    evaluation.results.totalColdRentMonthly === 0 &&
+    evaluation.results.warmRentMonthly === 0
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-5xl space-y-6 p-6 md:p-8">
+        {/* Header */}
+        <div>
+          <h1 className="text-xl font-bold sm:text-2xl">
+            {evaluation.name || "Property Evaluation"}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Shared property evaluation — read-only view
+          </p>
+        </div>
+
+        {/* Input Summary */}
+        <SharedInputSummary evaluation={evaluation} />
+
+        {/* Results */}
+        <EvaluationSection
+          results={evaluation.results}
+          isOwnerOccupier={isOwnerOccupier}
+        />
+
+        {/* Annual Cashflow Table */}
+        {!isOwnerOccupier && evaluation.results.annualRows.length > 0 && (
+          <AnnualCashflowTable rows={evaluation.results.annualRows} />
+        )}
+
+        {/* CTA Footer */}
+        <SharedFooter />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add public route `/shared/evaluation/:shareId` for viewing shared property evaluations without login
- Show share URL with copy button after saving a property evaluation
- Add share icon button on each saved evaluation in the list for quick link copying

## Test plan
- [ ] Save a property evaluation — confirm share URL appears below the save button
- [ ] Copy the share URL, open in incognito (no auth) — confirm read-only view loads with input summary, evaluation results, and annual cashflow table
- [ ] Verify invalid shareId shows "Evaluation not found" error page
- [ ] Verify share button on saved evaluations list copies link with toast notification
- [ ] Verify no edit controls on the shared view (no save/calculate/reset buttons)