### PR TITLE
feat(journey): add rental-investor specific journey path

### DIFF
--- a/backend/app/alembic/versions/t1p2q3r4s5u6_add_rental_setup_phase.py
+++ b/backend/app/alembic/versions/t1p2q3r4s5u6_add_rental_setup_phase.py
@@ -1,0 +1,33 @@
+"""Add rental_setup phase and property_use column
+
+Revision ID: t1p2q3r4s5u6
+Revises: s0o1p2q3r4t5
+Create Date: 2026-04-17 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "t1p2q3r4s5u6"
+down_revision = "s0o1p2q3r4t5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add 'rental_setup' value to the journeyphase enum
+    op.execute("ALTER TYPE journeyphase ADD VALUE IF NOT EXISTS 'rental_setup'")
+
+    # Add property_use column to journey table
+    op.add_column(
+        "journey",
+        sa.Column("property_use", sa.String(20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("journey", "property_use")
+    # Note: PostgreSQL does not support removing enum values directly.
+    # The 'rental_setup' value will remain in the enum but be unused.

--- a/backend/app/api/routes/journeys.py
+++ b/backend/app/api/routes/journeys.py
@@ -102,6 +102,7 @@ def _build_journey_response(journey: Journey) -> JourneyResponse:
         has_german_residency=journey.has_german_residency,
         budget_euros=journey.budget_euros,
         target_purchase_date=journey.target_purchase_date,
+        property_use=journey.property_use,
         property_goals=PropertyGoals(**journey.property_goals)
         if journey.property_goals
         else None,
@@ -201,6 +202,7 @@ async def get_journey(
         has_german_residency=journey.has_german_residency,
         budget_euros=journey.budget_euros,
         target_purchase_date=journey.target_purchase_date,
+        property_use=journey.property_use,
         property_goals=PropertyGoals(**journey.property_goals)
         if journey.property_goals
         else None,

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -26,6 +26,7 @@ class JourneyPhase(str, PyEnum):
     PREPARATION = "preparation"
     BUYING = "buying"
     CLOSING = "closing"
+    RENTAL_SETUP = "rental_setup"
 
 
 class StepStatus(str, PyEnum):
@@ -61,6 +62,7 @@ _journey_phase_enum = PgEnum(
     "preparation",
     "buying",
     "closing",
+    "rental_setup",
     name="journeyphase",
     create_type=False,
 )
@@ -115,6 +117,9 @@ class Journey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     has_german_residency = Column(Boolean, default=False, nullable=False)
     budget_euros = Column(Integer, nullable=True)
     target_purchase_date = Column(DateTime(timezone=True), nullable=True)
+
+    # Property use intent (live_in or rent_out)
+    property_use = Column(String(20), nullable=True)
 
     # Property goals (Step 1 user input)
     property_goals = Column(MutableDict.as_mutable(JSONB), nullable=True)

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -113,6 +113,7 @@ class QuestionnaireAnswers(BaseModel):
     budget_euros: int | None = Field(default=None, ge=0)  # max budget
     budget_min_euros: int | None = Field(default=None, ge=0)  # min budget
     target_purchase_date: datetime | None = None
+    property_use: Literal["live_in", "rent_out"] | None = None
 
 
 # Task schemas
@@ -241,6 +242,7 @@ class JourneyResponse(BaseModel):
     has_german_residency: bool
     budget_euros: int | None = None
     target_purchase_date: datetime | None = None
+    property_use: str | None = None
     property_goals: PropertyGoals | None = None
     market_insights: MarketInsightsData | None = None
     started_at: datetime | None = None

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -501,6 +501,172 @@ STEP_TEMPLATES: list[StepTemplate] = [
         ],
         related_laws=["GBO §13 (Eintragungsgrundsatz)"],
     ),
+    # RENTAL INVESTOR STEPS (conditional on property_use = rent_out)
+    StepTemplate(
+        step_number=20,
+        phase=JourneyPhase.RESEARCH,
+        title="Understand Landlord Obligations",
+        description="Learn about German landlord duties, tenant protections, and rental regulations before purchasing an investment property.",
+        estimated_duration_days=5,
+        content_key="rental_landlord_law",
+        conditions={"property_use": ["rent_out"]},
+        prerequisites=[2],
+        tasks=[
+            {
+                "title": "Study BGB Mietrecht (§535-580a) tenant protection basics",
+                "is_required": True,
+            },
+            {
+                "title": "Understand Mietpreisbremse (rent control) rules in your target area",
+                "is_required": True,
+            },
+            {
+                "title": "Learn Kaution (deposit) regulations — max 3 months' cold rent",
+                "is_required": True,
+            },
+            {
+                "title": "Review Kündigungsschutz (eviction protection) requirements",
+                "is_required": True,
+            },
+            {
+                "title": "Check local Zweckentfremdungsverbot (prohibition of misuse) rules",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "BGB §535-580a (Mietrecht)",
+            "MietpreisbremseVO (Rent Control Ordinance)",
+        ],
+    ),
+    StepTemplate(
+        step_number=21,
+        phase=JourneyPhase.RESEARCH,
+        title="Analyze Rental Yield",
+        description="Calculate expected rental returns, compare with local Mietspiegel, and assess the investment viability.",
+        estimated_duration_days=5,
+        content_key="rental_yield_analysis",
+        conditions={"property_use": ["rent_out"]},
+        prerequisites=[4],
+        tasks=[
+            {
+                "title": "Look up local Mietspiegel (rent index) for your target area",
+                "is_required": True,
+            },
+            {
+                "title": "Calculate gross Mietrendite (rental yield) for the property",
+                "is_required": True,
+            },
+            {
+                "title": "Estimate net yield after costs (Hausgeld, maintenance, vacancy)",
+                "is_required": True,
+            },
+            {
+                "title": "Compare yields with market averages using the ROI calculator",
+                "is_required": True,
+            },
+            {
+                "title": "Research comparable rental listings in the neighborhood",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=22,
+        phase=JourneyPhase.PREPARATION,
+        title="Plan Property Management",
+        description="Decide between self-management and hiring a Hausverwaltung, and understand the associated costs.",
+        estimated_duration_days=7,
+        content_key="rental_property_management",
+        conditions={"property_use": ["rent_out"]},
+        prerequisites=[5],
+        tasks=[
+            {
+                "title": "Compare self-management vs Hausverwaltung (property management agency)",
+                "is_required": True,
+            },
+            {
+                "title": "Get quotes from local Hausverwaltung companies (typically 20-30 EUR/unit/month)",
+                "is_required": True,
+            },
+            {
+                "title": "Understand WEG-Verwaltung vs Mietverwaltung responsibilities",
+                "is_required": True,
+            },
+            {
+                "title": "Plan for maintenance reserve (Instandhaltungsrücklage)",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=23,
+        phase=JourneyPhase.BUYING,
+        title="Prepare Rental Tax Strategy",
+        description="Understand tax obligations for rental income in Germany, including deductions and depreciation.",
+        estimated_duration_days=7,
+        content_key="rental_tax_strategy",
+        conditions={"property_use": ["rent_out"]},
+        prerequisites=[10],
+        tasks=[
+            {
+                "title": "Learn about Anlage V (income from renting) tax filing",
+                "is_required": True,
+            },
+            {
+                "title": "Identify deductible expenses (mortgage interest, repairs, Hausverwaltung fees)",
+                "is_required": True,
+            },
+            {
+                "title": "Understand AfA (Absetzung für Abnutzung) — 2% linear depreciation over 50 years",
+                "is_required": True,
+            },
+            {
+                "title": "Consider consulting a Steuerberater (tax advisor) for rental income",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "EStG §21 (Einkünfte aus Vermietung und Verpachtung)",
+            "EStG §7 (AfA — Absetzung für Abnutzung)",
+        ],
+    ),
+    StepTemplate(
+        step_number=24,
+        phase=JourneyPhase.RENTAL_SETUP,
+        title="Set Up Rental Operations",
+        description="Prepare everything needed to start renting out your property: lease template, tenant screening, and utility accounting.",
+        estimated_duration_days=14,
+        content_key="rental_operations_setup",
+        conditions={"property_use": ["rent_out"]},
+        prerequisites=[17],
+        tasks=[
+            {
+                "title": "Prepare a Mietvertrag (lease agreement) using a standard template",
+                "is_required": True,
+            },
+            {
+                "title": "Set up tenant screening process (SCHUFA check, income verification)",
+                "is_required": True,
+            },
+            {
+                "title": "Plan Nebenkostenabrechnung (utility cost accounting) for tenants",
+                "is_required": True,
+            },
+            {
+                "title": "Arrange landlord insurance (Haus- und Grundbesitzerhaftpflicht)",
+                "is_required": True,
+            },
+            {
+                "title": "Create a Wohnungsübergabeprotokoll (handover protocol) template",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "BGB §535 (Mietvertrag)",
+            "BetrKV (Betriebskostenverordnung)",
+            "HeizkostenV (Heizkostenverordnung)",
+        ],
+    ),
 ]
 
 
@@ -624,7 +790,7 @@ def _matches_conditions(
     for field, valid_values in conditions.items():
         answer_value = getattr(answers, field, None)
         if answer_value is None:
-            continue
+            return False
 
         # Handle enum values
         if hasattr(answer_value, "value"):
@@ -676,11 +842,13 @@ def generate_journey(
         has_german_residency=answers.has_german_residency,
         budget_euros=answers.budget_euros,
         target_purchase_date=answers.target_purchase_date,
+        property_use=answers.property_use,
         started_at=datetime.now(timezone.utc),
         property_goals={
             "preferred_property_type": answers.property_type.value,
             "budget_min_euros": answers.budget_min_euros,
             "budget_max_euros": answers.budget_euros,
+            "property_use": answers.property_use,
         },
     )
     session.add(journey)

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -789,6 +789,10 @@ def _matches_conditions(
 
     for field, valid_values in conditions.items():
         answer_value = getattr(answers, field, None)
+        # If the answer is None, the condition cannot be satisfied — exclude
+        # the step/task. Every conditioned field (financing_type, property_use,
+        # has_german_residency) is always provided for new journeys; None only
+        # occurs for legacy journeys that predate the field.
         if answer_value is None:
             return False
 

--- a/backend/tests/api/routes/test_journeys.py
+++ b/backend/tests/api/routes/test_journeys.py
@@ -912,6 +912,89 @@ def test_preferred_area_case_insensitive_match(client: TestClient, db: Session) 
     assert insights["avg_price_per_sqm"] == 6500  # city-level data used
 
 
+def test_create_journey_with_property_use_rent_out(
+    client: TestClient, db: Session
+) -> None:
+    """Test creating a journey with property_use=rent_out includes investor steps."""
+    headers, _ = get_auth_headers(client, db)
+
+    journey_data = {
+        "title": "Investor Journey",
+        "questionnaire": {
+            "property_type": "apartment",
+            "property_location": "Berlin",
+            "financing_type": "mortgage",
+            "is_first_time_buyer": True,
+            "has_german_residency": True,
+            "budget_euros": 300000,
+            "property_use": "rent_out",
+        },
+    }
+
+    r = client.post(
+        f"{settings.API_V1_STR}/journeys/",
+        headers=headers,
+        json=journey_data,
+    )
+
+    assert r.status_code == 201
+    data = r.json()
+    assert data["property_use"] == "rent_out"
+
+    step_titles = [step["title"] for step in data["steps"]]
+    assert "Understand Landlord Obligations" in step_titles
+    assert "Analyze Rental Yield" in step_titles
+    assert "Plan Property Management" in step_titles
+    assert "Prepare Rental Tax Strategy" in step_titles
+    assert "Set Up Rental Operations" in step_titles
+
+
+def test_create_journey_with_property_use_live_in_excludes_investor_steps(
+    client: TestClient, db: Session
+) -> None:
+    """Test creating a journey with property_use=live_in excludes investor steps."""
+    headers, _ = get_auth_headers(client, db)
+
+    journey_data = {
+        "title": "Live In Journey",
+        "questionnaire": {
+            "property_type": "apartment",
+            "property_location": "Berlin",
+            "financing_type": "mortgage",
+            "is_first_time_buyer": True,
+            "has_german_residency": True,
+            "budget_euros": 300000,
+            "property_use": "live_in",
+        },
+    }
+
+    r = client.post(
+        f"{settings.API_V1_STR}/journeys/",
+        headers=headers,
+        json=journey_data,
+    )
+
+    assert r.status_code == 201
+    data = r.json()
+    assert data["property_use"] == "live_in"
+
+    step_titles = [step["title"] for step in data["steps"]]
+    assert "Understand Landlord Obligations" not in step_titles
+    assert "Set Up Rental Operations" not in step_titles
+
+
+def test_create_journey_without_property_use_excludes_investor_steps(
+    client: TestClient, db: Session
+) -> None:
+    """Test that journey created without property_use excludes investor steps (backward compat)."""
+    headers, _ = get_auth_headers(client, db)
+    journey = create_journey(client, headers)  # default has no property_use
+
+    step_titles = [step["title"] for step in journey["steps"]]
+    assert "Understand Landlord Obligations" not in step_titles
+    assert "Set Up Rental Operations" not in step_titles
+
+
 def test_property_use_invalid_value_returns_422(
     client: TestClient, db: Session
 ) -> None:

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -417,8 +417,8 @@ class TestStepTemplates:
     """Tests for step template ordering and content."""
 
     def test_step_templates_total_count(self) -> None:
-        """Test that there are 19 step templates."""
-        assert len(STEP_TEMPLATES) == 19
+        """Test that there are 24 step templates (19 base + 5 rental investor)."""
+        assert len(STEP_TEMPLATES) == 24
 
     def test_find_property_is_step_3(self) -> None:
         """Test that Find a Property (property_search) is step 3."""
@@ -586,7 +586,7 @@ class TestStepTemplates:
         assert template.prerequisites == [13, 19]
 
     def test_research_phase_steps_order(self) -> None:
-        """Test that steps 1-5 are RESEARCH phase with correct content_keys."""
+        """Test that base RESEARCH steps (1-5) have correct content_keys."""
         expected = [
             (1, "research_goals"),
             (2, "market_research"),
@@ -595,9 +595,11 @@ class TestStepTemplates:
             (5, "buying_costs"),
         ]
         research_steps = [t for t in STEP_TEMPLATES if t.phase == JourneyPhase.RESEARCH]
-        assert len(research_steps) == 5
+        # 5 base + 2 rental investor (landlord law, yield analysis)
+        assert len(research_steps) == 7
+        # First 5 should be the base steps
         for template, (expected_num, expected_key) in zip(
-            research_steps, expected, strict=True
+            research_steps[:5], expected, strict=True
         ):
             assert template.step_number == expected_num
             assert template.content_key == expected_key
@@ -1229,6 +1231,170 @@ class TestStep4StatusTransitions:
         assert tasks[3].is_completed is False
         assert mock_step.status == StepStatus.NOT_STARTED
         assert mock_step.started_at is None
+
+
+class TestRentalInvestorSteps:
+    """Tests for rental investor-specific journey steps."""
+
+    @pytest.fixture
+    def rent_out_answers(self) -> QuestionnaireAnswers:
+        """Create questionnaire answers for a rental investor."""
+        return QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="Berlin",
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=300000,
+            property_use="rent_out",
+        )
+
+    @pytest.fixture
+    def live_in_answers(self) -> QuestionnaireAnswers:
+        """Create questionnaire answers for a live-in buyer."""
+        return QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="Berlin",
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=300000,
+            property_use="live_in",
+        )
+
+    def test_investor_steps_included_for_rent_out(
+        self, rent_out_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that rental investor steps are included when property_use is rent_out."""
+        steps = _generate_steps(rent_out_answers)
+        step_titles = [s.title for s in steps]
+
+        assert "Understand Landlord Obligations" in step_titles
+        assert "Analyze Rental Yield" in step_titles
+        assert "Plan Property Management" in step_titles
+        assert "Prepare Rental Tax Strategy" in step_titles
+        assert "Set Up Rental Operations" in step_titles
+
+    def test_investor_steps_excluded_for_live_in(
+        self, live_in_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that rental investor steps are excluded when property_use is live_in."""
+        steps = _generate_steps(live_in_answers)
+        step_titles = [s.title for s in steps]
+
+        assert "Understand Landlord Obligations" not in step_titles
+        assert "Analyze Rental Yield" not in step_titles
+        assert "Plan Property Management" not in step_titles
+        assert "Prepare Rental Tax Strategy" not in step_titles
+        assert "Set Up Rental Operations" not in step_titles
+
+    def test_investor_steps_excluded_when_property_use_none(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that rental investor steps are excluded when property_use is None (backward compat)."""
+        # sample_answers has no property_use (defaults to None)
+        steps = _generate_steps(sample_answers)
+        step_titles = [s.title for s in steps]
+
+        assert "Understand Landlord Obligations" not in step_titles
+        assert "Analyze Rental Yield" not in step_titles
+        assert "Plan Property Management" not in step_titles
+        assert "Prepare Rental Tax Strategy" not in step_titles
+        assert "Set Up Rental Operations" not in step_titles
+
+    def test_rental_setup_phase_in_progress(
+        self, rent_out_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that progress calculation includes RENTAL_SETUP phase for investor journeys."""
+        steps = _generate_steps(rent_out_answers)
+        rental_setup_steps = [s for s in steps if s.phase == JourneyPhase.RENTAL_SETUP]
+        assert len(rental_setup_steps) == 1
+        assert rental_setup_steps[0].title == "Set Up Rental Operations"
+
+    def test_property_use_stored_on_journey(
+        self, rent_out_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that property_use is persisted on the Journey model."""
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = None
+
+        journey = generate_journey(
+            session=mock_session,
+            user_id=uuid.uuid4(),
+            title="Test Investor Journey",
+            answers=rent_out_answers,
+        )
+
+        assert journey.property_use == "rent_out"
+
+    def test_property_use_none_when_not_provided(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that property_use is None when not in questionnaire (backward compat)."""
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = None
+
+        journey = generate_journey(
+            session=mock_session,
+            user_id=uuid.uuid4(),
+            title="Test Journey",
+            answers=sample_answers,
+        )
+
+        assert journey.property_use is None
+
+    def test_investor_step_templates_have_correct_phases(
+        self,
+    ) -> None:
+        """Test that investor step templates use the correct phases."""
+        rental_templates = [
+            t for t in STEP_TEMPLATES if t.conditions and "property_use" in t.conditions
+        ]
+        assert len(rental_templates) == 5
+
+        content_keys = [t.content_key for t in rental_templates]
+        assert "rental_landlord_law" in content_keys
+        assert "rental_yield_analysis" in content_keys
+        assert "rental_property_management" in content_keys
+        assert "rental_tax_strategy" in content_keys
+        assert "rental_operations_setup" in content_keys
+
+    def test_investor_step_phases_distribution(
+        self,
+    ) -> None:
+        """Test that investor steps are distributed across the correct phases."""
+        rental_templates = {
+            t.content_key: t
+            for t in STEP_TEMPLATES
+            if t.conditions and "property_use" in t.conditions
+        }
+        assert rental_templates["rental_landlord_law"].phase == JourneyPhase.RESEARCH
+        assert rental_templates["rental_yield_analysis"].phase == JourneyPhase.RESEARCH
+        assert (
+            rental_templates["rental_property_management"].phase
+            == JourneyPhase.PREPARATION
+        )
+        assert rental_templates["rental_tax_strategy"].phase == JourneyPhase.BUYING
+        assert (
+            rental_templates["rental_operations_setup"].phase
+            == JourneyPhase.RENTAL_SETUP
+        )
+
+    def test_investor_steps_each_have_tasks(
+        self, rent_out_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that each investor step has tasks."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_answers)
+        investor_titles = [
+            "Understand Landlord Obligations",
+            "Analyze Rental Yield",
+            "Plan Property Management",
+            "Prepare Rental Tax Strategy",
+            "Set Up Rental Operations",
+        ]
+        for title in investor_titles:
+            assert title in steps_with_tasks
+            assert len(steps_with_tasks[title]) >= 3
 
 
 class TestPersonalizeBuyingCosts:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2488,6 +2488,17 @@ export const JourneyDetailResponseSchema = {
             ],
             title: 'Target Purchase Date'
         },
+        property_use: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Property Use'
+        },
         property_goals: {
             anyOf: [
                 {
@@ -2667,7 +2678,7 @@ export const JourneyOverviewSchema = {
 
 export const JourneyPhaseSchema = {
     type: 'string',
-    enum: ['research', 'preparation', 'buying', 'closing'],
+    enum: ['research', 'preparation', 'buying', 'closing', 'rental_setup'],
     title: 'JourneyPhase',
     description: 'Phases of the property buying journey.'
 } as const;
@@ -2805,6 +2816,17 @@ export const JourneyResponseSchema = {
                 }
             ],
             title: 'Target Purchase Date'
+        },
+        property_use: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Property Use'
         },
         property_goals: {
             anyOf: [
@@ -5303,6 +5325,18 @@ export const QuestionnaireAnswersSchema = {
                 }
             ],
             title: 'Target Purchase Date'
+        },
+        property_use: {
+            anyOf: [
+                {
+                    type: 'string',
+                    enum: ['live_in', 'rent_out']
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Property Use'
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -756,6 +756,7 @@ export type JourneyDetailResponse = {
     has_german_residency: boolean;
     budget_euros?: (number | null);
     target_purchase_date?: (string | null);
+    property_use?: (string | null);
     property_goals?: (PropertyGoals | null);
     market_insights?: (MarketInsightsData | null);
     started_at?: (string | null);
@@ -793,7 +794,7 @@ export type JourneyOverview = {
 /**
  * Phases of the property buying journey.
  */
-export type JourneyPhase = 'research' | 'preparation' | 'buying' | 'closing';
+export type JourneyPhase = 'research' | 'preparation' | 'buying' | 'closing' | 'rental_setup';
 
 /**
  * Schema for journey progress.
@@ -828,6 +829,7 @@ export type JourneyResponse = {
     has_german_residency: boolean;
     budget_euros?: (number | null);
     target_purchase_date?: (string | null);
+    property_use?: (string | null);
     property_goals?: (PropertyGoals | null);
     market_insights?: (MarketInsightsData | null);
     started_at?: (string | null);
@@ -1459,6 +1461,7 @@ export type QuestionnaireAnswers = {
     budget_euros?: (number | null);
     budget_min_euros?: (number | null);
     target_purchase_date?: (string | null);
+    property_use?: ('live_in' | 'rent_out' | null);
 };
 
 /**

--- a/frontend/src/common/constants/index.ts
+++ b/frontend/src/common/constants/index.ts
@@ -52,6 +52,7 @@ export const JOURNEY_PHASES = [
   { key: "preparation", label: "Preparation", order: 2 },
   { key: "buying", label: "Buying", order: 3 },
   { key: "closing", label: "Closing", order: 4 },
+  { key: "rental_setup", label: "Rental Setup", order: 5 },
 ] as const
 
 // Journey phase colors (used for phase badges across components)
@@ -63,6 +64,8 @@ export const PHASE_COLORS: Record<string, string> = {
     "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
   closing:
     "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  rental_setup:
+    "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400",
 }
 
 // Law categories

--- a/frontend/src/components/Journey/JourneyGenerating.tsx
+++ b/frontend/src/components/Journey/JourneyGenerating.tsx
@@ -5,7 +5,6 @@
 
 import { CheckCircle2, Sparkles } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
-import { cn } from "@/common/utils"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import type { JourneyPhase, JourneyPublic } from "@/models/journey"
@@ -34,6 +33,7 @@ const PHASE_LABELS: Record<JourneyPhase, string> = {
   preparation: "Preparation",
   buying: "Buying",
   closing: "Closing",
+  rental_setup: "Rental Setup",
 }
 
 /******************************************************************************
@@ -74,6 +74,7 @@ function JourneyGenerating(props: IProps) {
       preparation: 0,
       buying: 0,
       closing: 0,
+      rental_setup: 0,
     }
     for (const step of journey.steps) {
       counts[step.phase]++
@@ -109,22 +110,16 @@ function JourneyGenerating(props: IProps) {
       </div>
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        {(Object.entries(PHASE_LABELS) as [JourneyPhase, string][]).map(
-          ([phaseKey, label]) => (
-            <Card
-              key={phaseKey}
-              className={cn(
-                "text-center",
-                phaseCounts[phaseKey] === 0 && "opacity-50",
-              )}
-            >
+        {(Object.entries(PHASE_LABELS) as [JourneyPhase, string][])
+          .filter(([phaseKey]) => phaseCounts[phaseKey] > 0)
+          .map(([phaseKey, label]) => (
+            <Card key={phaseKey} className="text-center">
               <CardContent className="p-4">
                 <p className="text-2xl font-bold">{phaseCounts[phaseKey]}</p>
                 <p className="text-xs text-muted-foreground">{label}</p>
               </CardContent>
             </Card>
-          ),
-        )}
+          ))}
       </div>
 
       <Button size="lg" onClick={onViewJourney}>

--- a/frontend/src/components/Journey/JourneySummary.tsx
+++ b/frontend/src/components/Journey/JourneySummary.tsx
@@ -67,7 +67,7 @@ function JourneySummary(props: IProps) {
         </p>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <div className="rounded-lg border p-4">
           <p className="text-sm text-muted-foreground">Property Type</p>
           <p className="font-medium capitalize">

--- a/frontend/src/components/Journey/JourneySummary.tsx
+++ b/frontend/src/components/Journey/JourneySummary.tsx
@@ -14,6 +14,7 @@ import type { ResidencyStatus } from "@/models/journey"
 
 export interface WizardState {
   propertyType?: string
+  propertyUse?: "live_in" | "rent_out"
   targetState?: string
   financingType?: string
   budgetMin?: number
@@ -35,6 +36,11 @@ const RESIDENCY_LABELS: Record<ResidencyStatus, string> = {
   eu_citizen: "EU/EEA citizen",
   non_eu_resident: "Non-EU resident in Germany",
   non_resident: "Non-resident",
+}
+
+const PROPERTY_USE_LABELS: Record<string, string> = {
+  live_in: "Live in it",
+  rent_out: "Rent it out",
 }
 
 /******************************************************************************
@@ -66,6 +72,14 @@ function JourneySummary(props: IProps) {
           <p className="text-sm text-muted-foreground">Property Type</p>
           <p className="font-medium capitalize">
             {state.propertyType?.replace("_", " ")}
+          </p>
+        </div>
+        <div className="rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Purpose</p>
+          <p className="font-medium">
+            {state.propertyUse
+              ? PROPERTY_USE_LABELS[state.propertyUse]
+              : "Not specified"}
           </p>
         </div>
         <div className="rounded-lg border p-4">

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -23,6 +23,7 @@ import { JourneyGenerating } from "./JourneyGenerating"
 import { JourneySummary } from "./JourneySummary"
 import { LocationSelector } from "./LocationSelector"
 import { PropertyTypeSelector } from "./PropertyTypeSelector"
+import { PropertyUseSelector } from "./PropertyUseSelector"
 import { ResidencySelector } from "./ResidencySelector"
 import { TimelineSelector } from "./TimelineSelector"
 import { WizardStepIndicator } from "./WizardStepIndicator"
@@ -37,11 +38,12 @@ interface IProps {
 
 const WIZARD_STEPS = [
   { id: 1, title: "Property" },
-  { id: 2, title: "Location" },
-  { id: 3, title: "Financing" },
-  { id: 4, title: "Budget" },
-  { id: 5, title: "Timeline" },
-  { id: 6, title: "Status" },
+  { id: 2, title: "Purpose" },
+  { id: 3, title: "Location" },
+  { id: 4, title: "Financing" },
+  { id: 5, title: "Budget" },
+  { id: 6, title: "Timeline" },
+  { id: 7, title: "Status" },
 ] as const
 
 const STORAGE_STATE_KEY = "heimpath-wizard-state"
@@ -53,6 +55,7 @@ const STORAGE_STEP_KEY = "heimpath-wizard-step"
 
 interface WizardState {
   propertyType?: PropertyType
+  propertyUse?: "live_in" | "rent_out"
   targetState?: string
   financingType?: FinancingType
   budgetMin?: number
@@ -121,19 +124,21 @@ function JourneyWizard(props: IProps) {
       case 1:
         return !!state.propertyType
       case 2:
-        return !!state.targetState
+        return !!state.propertyUse
       case 3:
-        return !!state.financingType
+        return !!state.targetState
       case 4:
+        return !!state.financingType
+      case 5:
         // Budget is optional, but if provided, max should be >= min
         if (state.budgetMin && state.budgetMax) {
           return state.budgetMax >= state.budgetMin
         }
         return true
-      case 5:
+      case 6:
         // Timeline is optional
         return true
-      case 6:
+      case 7:
         return !!state.residencyStatus
       default:
         return false
@@ -192,6 +197,7 @@ function JourneyWizard(props: IProps) {
         budget_euros: state.budgetMax || state.budgetMin,
         budget_min_euros: state.budgetMin,
         target_purchase_date: state.targetDate,
+        property_use: state.propertyUse,
       },
     }
 
@@ -209,12 +215,13 @@ function JourneyWizard(props: IProps) {
   const completedSteps = useMemo((): Set<number> => {
     const done = new Set<number>()
     if (state.propertyType) done.add(1)
-    if (state.targetState) done.add(2)
-    if (state.financingType) done.add(3)
+    if (state.propertyUse) done.add(2)
+    if (state.targetState) done.add(3)
+    if (state.financingType) done.add(4)
     // Budget and Timeline are optional; mark done once the user moves past them
-    if (currentStep > 4) done.add(4)
     if (currentStep > 5) done.add(5)
-    if (state.residencyStatus) done.add(6)
+    if (currentStep > 6) done.add(6)
+    if (state.residencyStatus) done.add(7)
     return done
   }, [state, currentStep])
 
@@ -248,19 +255,26 @@ function JourneyWizard(props: IProps) {
         )
       case 2:
         return (
+          <PropertyUseSelector
+            value={state.propertyUse}
+            onChange={(v) => updateState({ propertyUse: v })}
+          />
+        )
+      case 3:
+        return (
           <LocationSelector
             value={state.targetState}
             onChange={(v) => updateState({ targetState: v })}
           />
         )
-      case 3:
+      case 4:
         return (
           <FinancingSelector
             value={state.financingType}
             onChange={(v) => updateState({ financingType: v })}
           />
         )
-      case 4:
+      case 5:
         return (
           <BudgetInput
             budgetMin={state.budgetMin}
@@ -269,14 +283,14 @@ function JourneyWizard(props: IProps) {
             onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
           />
         )
-      case 5:
+      case 6:
         return (
           <TimelineSelector
             value={state.targetDate}
             onChange={(v) => updateState({ targetDate: v })}
           />
         )
-      case 6:
+      case 7:
         return (
           <ResidencySelector
             value={state.residencyStatus}

--- a/frontend/src/components/Journey/PropertyUseSelector.tsx
+++ b/frontend/src/components/Journey/PropertyUseSelector.tsx
@@ -1,0 +1,114 @@
+/**
+ * Property Use Selector Component
+ * Allows user to select whether they plan to live in or rent out the property
+ */
+
+import { Building2, Home } from "lucide-react"
+import { cn } from "@/common/utils"
+
+interface IProps {
+  value?: "live_in" | "rent_out"
+  onChange: (value: "live_in" | "rent_out") => void
+  className?: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const PROPERTY_USE_OPTIONS = [
+  {
+    value: "live_in" as const,
+    label: "Live in it",
+    description:
+      "You plan to move in and use the property as your primary or secondary residence.",
+    Icon: Home,
+  },
+  {
+    value: "rent_out" as const,
+    label: "Rent it out",
+    description:
+      "You plan to rent the property to tenants as an investment. We'll add landlord-specific guidance to your journey.",
+    Icon: Building2,
+  },
+]
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Single property use option card. */
+function PropertyUseOption(props: {
+  option: (typeof PROPERTY_USE_OPTIONS)[number]
+  isSelected: boolean
+  onSelect: () => void
+}) {
+  const { option, isSelected, onSelect } = props
+  const { Icon } = option
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "flex flex-col items-start gap-3 rounded-lg border-2 p-6 transition-all hover:border-blue-400 hover:bg-blue-50/50 dark:hover:bg-blue-950/20 text-left",
+        isSelected
+          ? "border-blue-600 bg-blue-50 dark:bg-blue-950/30"
+          : "border-muted",
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <Icon
+          className={cn(
+            "h-8 w-8",
+            isSelected ? "text-blue-600" : "text-muted-foreground",
+          )}
+        />
+        <span
+          className={cn(
+            "text-lg font-medium",
+            isSelected ? "text-blue-600" : "text-foreground",
+          )}
+        >
+          {option.label}
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground">{option.description}</p>
+    </button>
+  )
+}
+
+/** Default component. Property use intent selector. */
+function PropertyUseSelector(props: IProps) {
+  const { value, onChange, className } = props
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div>
+        <h3 className="text-lg font-semibold">
+          What do you plan to do with the property?
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          This helps us customize your journey with relevant guidance
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {PROPERTY_USE_OPTIONS.map((option) => (
+          <PropertyUseOption
+            key={option.value}
+            option={option}
+            isSelected={value === option.value}
+            onSelect={() => onChange(option.value)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { PropertyUseSelector }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -67,6 +67,11 @@ const STEP_CONTENT_REGISTRY: Record<
   ),
   due_diligence: (p) => <StepDocumentReview stepId={p.step.id} />,
   review_contract: (p) => <StepDocumentReview stepId={p.step.id} />,
+  rental_landlord_law: () => null,
+  rental_yield_analysis: () => null,
+  rental_property_management: () => null,
+  rental_tax_strategy: () => null,
+  rental_operations_setup: () => null,
 }
 
 /******************************************************************************

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -47,10 +47,9 @@ function StepTabView(props: IProps) {
   )
 
   // If the selected phase was filtered out (no steps), fall back to the first visible phase
-  const effectivePhase =
-    visiblePhases.some((p) => p.key === selectedPhase)
-      ? selectedPhase
-      : ((visiblePhases[0]?.key ?? "research") as JourneyPhase)
+  const effectivePhase = visiblePhases.some((p) => p.key === selectedPhase)
+    ? selectedPhase
+    : ((visiblePhases[0]?.key ?? "research") as JourneyPhase)
 
   const phaseSteps = stepsByPhase[effectivePhase]
 

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -42,25 +42,33 @@ function StepTabView(props: IProps) {
     stepsByPhase[step.phase].push(step)
   }
 
-  const phaseSteps = stepsByPhase[selectedPhase]
+  const visiblePhases = JOURNEY_PHASES.filter(
+    (phase) => stepsByPhase[phase.key as JourneyPhase].length > 0,
+  )
+
+  // If the selected phase was filtered out (no steps), fall back to the first visible phase
+  const effectivePhase =
+    visiblePhases.some((p) => p.key === selectedPhase)
+      ? selectedPhase
+      : ((visiblePhases[0]?.key ?? "research") as JourneyPhase)
+
+  const phaseSteps = stepsByPhase[effectivePhase]
 
   return (
     <div className="space-y-4">
       {/* Phase pills */}
       <Tabs
-        value={selectedPhase}
+        value={effectivePhase}
         onValueChange={(v) => setSelectedPhase(v as JourneyPhase)}
       >
         <TabsList className="flex w-full flex-wrap gap-1">
-          {JOURNEY_PHASES.filter(
-            (phase) => stepsByPhase[phase.key as JourneyPhase].length > 0,
-          ).map((phase) => (
+          {visiblePhases.map((phase) => (
             <TabsTrigger
               key={phase.key}
               value={phase.key}
               className={cn(
                 "text-xs sm:text-sm",
-                selectedPhase === phase.key && PHASE_COLORS[phase.key],
+                effectivePhase === phase.key && PHASE_COLORS[phase.key],
               )}
             >
               {phase.label}

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -36,6 +36,7 @@ function StepTabView(props: IProps) {
     preparation: [],
     buying: [],
     closing: [],
+    rental_setup: [],
   }
   for (const step of steps) {
     stepsByPhase[step.phase].push(step)
@@ -51,7 +52,9 @@ function StepTabView(props: IProps) {
         onValueChange={(v) => setSelectedPhase(v as JourneyPhase)}
       >
         <TabsList className="flex w-full flex-wrap gap-1">
-          {JOURNEY_PHASES.map((phase) => (
+          {JOURNEY_PHASES.filter(
+            (phase) => stepsByPhase[phase.key as JourneyPhase].length > 0,
+          ).map((phase) => (
             <TabsTrigger
               key={phase.key}
               value={phase.key}

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -4,7 +4,12 @@
  * Note: Uses snake_case to match backend API response
  */
 
-export type JourneyPhase = "research" | "preparation" | "buying" | "closing"
+export type JourneyPhase =
+  | "research"
+  | "preparation"
+  | "buying"
+  | "closing"
+  | "rental_setup"
 
 export type StepStatus = "not_started" | "in_progress" | "completed" | "skipped"
 
@@ -59,6 +64,7 @@ export interface JourneyPublic {
   property_type?: PropertyType
   property_location?: string
   financing_type?: FinancingType
+  property_use?: "live_in" | "rent_out"
   is_first_time_buyer: boolean
   has_german_residency: boolean
   budget_euros?: number
@@ -96,6 +102,7 @@ export interface QuestionnaireAnswers {
   budget_euros?: number
   budget_min_euros?: number
   target_purchase_date?: string
+  property_use?: "live_in" | "rent_out"
 }
 
 /** Backend-compatible journey creation request */


### PR DESCRIPTION
## Summary
- Add `property_use` field (`live_in` / `rent_out`) to the journey questionnaire, captured at wizard step 2 ("Purpose")
- Add 5 new investor-specific step templates (landlord obligations, rental yield analysis, property management, rental tax strategy, rental operations setup) conditionally included when `property_use = "rent_out"`
- Add new `RENTAL_SETUP` journey phase for post-closing rental operations, with Alembic migration for the enum value and `property_use` column

## Test plan
- [x] 9 new unit tests for investor step inclusion/exclusion logic, phase distribution, and backward compatibility (property_use=None)
- [x] 3 new integration tests for API journey creation with rent_out, live_in, and without property_use
- [x] Full backend suite passes (849 tests)
- [x] Frontend TypeScript type check passes (no errors)
- [ ] Manual test: create journey with "rent_out" → verify 5 extra investor steps appear across RESEARCH, PREPARATION, BUYING, and RENTAL_SETUP phases
- [ ] Manual test: create journey with "live_in" → verify no investor steps appear
- [ ] Manual test: verify existing journeys (no property_use) are unaffected