### PR TITLE
feat(journey): add post-purchase ownership onboarding phase

### DIFF
--- a/backend/app/alembic/versions/v3r4s5t6u7w8_add_ownership_phase.py
+++ b/backend/app/alembic/versions/v3r4s5t6u7w8_add_ownership_phase.py
@@ -1,0 +1,25 @@
+"""Add ownership phase
+
+Revision ID: v3r4s5t6u7w8
+Revises: u2q3r4s5t6v7
+Create Date: 2026-04-18 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "v3r4s5t6u7w8"
+down_revision = "u2q3r4s5t6v7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE journeyphase ADD VALUE IF NOT EXISTS 'ownership'")
+
+
+def downgrade() -> None:
+    # Note: PostgreSQL does not support removing enum values directly.
+    # The 'ownership' value will remain in the enum but be unused.
+    pass

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -26,6 +26,7 @@ class JourneyPhase(str, PyEnum):
     PREPARATION = "preparation"
     BUYING = "buying"
     CLOSING = "closing"
+    OWNERSHIP = "ownership"
     RENTAL_SETUP = "rental_setup"
 
 
@@ -62,6 +63,7 @@ _journey_phase_enum = PgEnum(
     "preparation",
     "buying",
     "closing",
+    "ownership",
     "rental_setup",
     name="journeyphase",
     create_type=False,

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -497,7 +497,10 @@ STEP_TEMPLATES: list[StepTemplate] = [
             {"title": "Notary submits for land registry update", "is_required": True},
             {"title": "Receive updated Grundbuchauszug", "is_required": True},
             {"title": "Collect keys from seller", "is_required": True},
-            {"title": "Transfer utilities to your name", "is_required": True},
+            {
+                "title": "Arrange utility transfer with seller (Übergabe)",
+                "is_required": True,
+            },
         ],
         related_laws=["GBO §13 (Eintragungsgrundsatz)"],
     ),
@@ -630,6 +633,150 @@ STEP_TEMPLATES: list[StepTemplate] = [
             "EStG §7 (AfA — Absetzung für Abnutzung)",
         ],
     ),
+    # OWNERSHIP PHASE (post-purchase onboarding — all buyers)
+    StepTemplate(
+        step_number=25,
+        phase=JourneyPhase.OWNERSHIP,
+        title="Complete Property Registration",
+        description="Finalize ownership records, complete the handover, and transfer all utilities and registrations to your name.",
+        estimated_duration_days=7,
+        content_key="ownership_registration",
+        prerequisites=[17],
+        tasks=[
+            {
+                "title": "Confirm Grundbuch (land register) transfer is complete with notary",
+                "is_required": True,
+            },
+            {
+                "title": "Obtain all property keys and complete Übergabeprotokoll (handover protocol)",
+                "is_required": True,
+            },
+            {
+                "title": "Transfer utilities (electricity, gas, water, internet) to your name",
+                "is_required": True,
+            },
+            {
+                "title": "Register new address at Bürgeramt (Anmeldung)",
+                "is_required": True,
+                "conditions": {"property_use": ["live_in"]},
+            },
+            {
+                "title": "Set up mail forwarding (Nachsendeauftrag) via Deutsche Post",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=26,
+        phase=JourneyPhase.OWNERSHIP,
+        title="Arrange Property Insurance",
+        description="Secure essential insurance coverage for your property, including building, liability, and contents insurance.",
+        estimated_duration_days=5,
+        content_key="ownership_insurance",
+        prerequisites=[25],
+        tasks=[
+            {
+                "title": "Arrange Wohngebäudeversicherung (building insurance)",
+                "is_required": True,
+            },
+            {
+                "title": "Consider Haus- und Grundbesitzerhaftpflicht (property liability insurance)",
+                "is_required": True,
+            },
+            {
+                "title": "Evaluate Elementarschadenversicherung (natural disaster) coverage for your region",
+                "is_required": False,
+            },
+            {
+                "title": "Set up Hausratversicherung (contents insurance)",
+                "is_required": True,
+                "conditions": {"property_use": ["live_in"]},
+            },
+            {
+                "title": "Verify WEG building insurance policy covers your unit",
+                "is_required": False,
+                "conditions": {"property_type": ["apartment"]},
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=27,
+        phase=JourneyPhase.OWNERSHIP,
+        title="Set Up Property Management",
+        description="Establish ongoing management for your property — from condo administration to maintenance planning.",
+        estimated_duration_days=7,
+        content_key="ownership_management",
+        prerequisites=[25],
+        tasks=[
+            {
+                "title": "Contact WEG-Verwaltung and register as new owner",
+                "is_required": True,
+                "conditions": {"property_type": ["apartment"]},
+            },
+            {
+                "title": "Set up Hausgeld (condo fees) payment via Dauerauftrag",
+                "is_required": True,
+                "conditions": {"property_type": ["apartment"]},
+            },
+            {
+                "title": "Review Teilungserklärung and Hausordnung (house rules)",
+                "is_required": False,
+                "conditions": {"property_type": ["apartment"]},
+            },
+            {
+                "title": "Plan annual maintenance budget (Instandhaltungsrücklage)",
+                "is_required": True,
+                "conditions": {"property_type": ["house"]},
+            },
+            {
+                "title": "Identify local tradespeople for repairs (plumber, electrician, heating)",
+                "is_required": False,
+                "conditions": {"property_type": ["house"]},
+            },
+            {
+                "title": "Register for waste collection (Müllabfuhr) service",
+                "is_required": True,
+            },
+            {
+                "title": "Schedule heating system inspection (Heizungswartung)",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=28,
+        phase=JourneyPhase.OWNERSHIP,
+        title="Handle Property Tax & Finance",
+        description="Set up property tax payments, track mortgage costs, and prepare for tax filing obligations.",
+        estimated_duration_days=5,
+        content_key="ownership_tax_finance",
+        prerequisites=[25],
+        tasks=[
+            {
+                "title": "Register for Grundsteuer (property tax) at local Finanzamt",
+                "is_required": True,
+            },
+            {
+                "title": "Set up Grundsteuer payment via Dauerauftrag (quarterly or annual)",
+                "is_required": True,
+            },
+            {
+                "title": "Track mortgage payments and request annual interest statement",
+                "is_required": True,
+                "conditions": {"financing_type": ["mortgage", "mixed"]},
+            },
+            {
+                "title": "Prepare for Anlage V rental income tax filing",
+                "is_required": True,
+                "conditions": {"property_use": ["rent_out"]},
+            },
+            {
+                "title": "Keep records of all property expenses for tax deduction",
+                "is_required": True,
+            },
+        ],
+    ),
+    # RENTAL SETUP PHASE (rent-out investors only)
     StepTemplate(
         step_number=24,
         phase=JourneyPhase.RENTAL_SETUP,
@@ -638,7 +785,7 @@ STEP_TEMPLATES: list[StepTemplate] = [
         estimated_duration_days=14,
         content_key="rental_operations_setup",
         conditions={"property_use": ["rent_out"]},
-        prerequisites=[17],
+        prerequisites=[25],
         tasks=[
             {
                 "title": "Prepare a Mietvertrag (lease agreement) using a standard template",

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -417,8 +417,8 @@ class TestStepTemplates:
     """Tests for step template ordering and content."""
 
     def test_step_templates_total_count(self) -> None:
-        """Test that there are 24 step templates (19 base + 5 rental investor)."""
-        assert len(STEP_TEMPLATES) == 24
+        """Test that there are 28 step templates (19 base + 4 ownership + 5 rental investor)."""
+        assert len(STEP_TEMPLATES) == 28
 
     def test_find_property_is_step_3(self) -> None:
         """Test that Find a Property (property_search) is step 3."""
@@ -1396,6 +1396,22 @@ class TestRentalInvestorSteps:
             assert title in steps_with_tasks
             assert len(steps_with_tasks[title]) >= 3
 
+    def test_rental_setup_prerequisite_is_ownership_registration(self) -> None:
+        """Test that rental_operations_setup depends on ownership registration (step 25)."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "rental_operations_setup"
+        )
+        assert template.prerequisites == [25]
+
+    def test_rental_setup_after_ownership_in_generated_journey(
+        self, rent_out_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that Set Up Rental Operations comes after Complete Property Registration."""
+        steps = _generate_steps(rent_out_answers)
+        reg_step = next(s for s in steps if s.title == "Complete Property Registration")
+        rental_step = next(s for s in steps if s.title == "Set Up Rental Operations")
+        assert rental_step.step_number > reg_step.step_number
+
 
 class TestPersonalizeBuyingCosts:
     """Tests for _personalize_buying_costs helper."""
@@ -1528,3 +1544,359 @@ class TestPersonalizeBuyingCosts:
 
         assert "total_estimated" not in costs
         assert "6.0%" in costs["grunderwerbsteuer"]
+
+
+class TestOwnershipPhaseSteps:
+    """Tests for the OWNERSHIP phase step templates and generation."""
+
+    @pytest.fixture
+    def live_in_apartment_answers(self) -> QuestionnaireAnswers:
+        """Answers for a live-in apartment buyer (mortgage)."""
+        return QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="Berlin",
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=300000,
+            property_use="live_in",
+        )
+
+    @pytest.fixture
+    def rent_out_house_answers(self) -> QuestionnaireAnswers:
+        """Answers for a rent-out house buyer (mortgage)."""
+        return QuestionnaireAnswers(
+            property_type=PropertyType.HOUSE,
+            property_location="Berlin",
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=500000,
+            property_use="rent_out",
+        )
+
+    @pytest.fixture
+    def rent_out_apartment_cash_answers(self) -> QuestionnaireAnswers:
+        """Answers for a rent-out apartment buyer (cash)."""
+        return QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="Berlin",
+            financing_type=FinancingType.CASH,
+            is_first_time_buyer=False,
+            has_german_residency=True,
+            budget_euros=400000,
+            property_use="rent_out",
+        )
+
+    # --- Template existence tests ---
+
+    def test_ownership_templates_exist(self) -> None:
+        """Test that all 4 ownership step templates exist with correct content_keys."""
+        ownership_keys = {
+            "ownership_registration",
+            "ownership_insurance",
+            "ownership_management",
+            "ownership_tax_finance",
+        }
+        found_keys = {
+            t.content_key for t in STEP_TEMPLATES if t.phase == JourneyPhase.OWNERSHIP
+        }
+        assert found_keys == ownership_keys
+
+    def test_ownership_templates_have_no_step_level_conditions(self) -> None:
+        """Test that ownership steps have no step-level conditions (included for all)."""
+        ownership_templates = [
+            t for t in STEP_TEMPLATES if t.phase == JourneyPhase.OWNERSHIP
+        ]
+        for template in ownership_templates:
+            assert template.conditions is None
+
+    # --- Step inclusion tests ---
+
+    def test_ownership_steps_included_for_live_in(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that ownership steps are included for live-in buyers."""
+        steps = _generate_steps(live_in_apartment_answers)
+        step_titles = [s.title for s in steps]
+        assert "Complete Property Registration" in step_titles
+        assert "Arrange Property Insurance" in step_titles
+        assert "Set Up Property Management" in step_titles
+        assert "Handle Property Tax & Finance" in step_titles
+
+    def test_ownership_steps_included_for_rent_out(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that ownership steps are included for rent-out buyers."""
+        steps = _generate_steps(rent_out_house_answers)
+        step_titles = [s.title for s in steps]
+        assert "Complete Property Registration" in step_titles
+        assert "Arrange Property Insurance" in step_titles
+        assert "Set Up Property Management" in step_titles
+        assert "Handle Property Tax & Finance" in step_titles
+
+    def test_ownership_steps_included_when_property_use_none(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that ownership steps are included when property_use is None (backward compat)."""
+        steps = _generate_steps(sample_answers)
+        step_titles = [s.title for s in steps]
+        assert "Complete Property Registration" in step_titles
+        assert "Arrange Property Insurance" in step_titles
+        assert "Set Up Property Management" in step_titles
+        assert "Handle Property Tax & Finance" in step_titles
+
+    # --- Phase ordering tests ---
+
+    def test_ownership_phase_before_rental_setup(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that OWNERSHIP steps appear before RENTAL_SETUP in rent-out journeys."""
+        steps = _generate_steps(rent_out_house_answers)
+        ownership_steps = [s for s in steps if s.phase == JourneyPhase.OWNERSHIP]
+        rental_steps = [s for s in steps if s.phase == JourneyPhase.RENTAL_SETUP]
+        assert len(ownership_steps) == 4
+        assert len(rental_steps) == 1
+        max_ownership_num = max(s.step_number for s in ownership_steps)
+        min_rental_num = min(s.step_number for s in rental_steps)
+        assert max_ownership_num < min_rental_num
+
+    def test_ownership_phase_after_closing(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that OWNERSHIP steps appear after CLOSING steps."""
+        steps = _generate_steps(live_in_apartment_answers)
+        closing_steps = [s for s in steps if s.phase == JourneyPhase.CLOSING]
+        ownership_steps = [s for s in steps if s.phase == JourneyPhase.OWNERSHIP]
+        assert len(closing_steps) > 0
+        assert len(ownership_steps) == 4
+        max_closing_num = max(s.step_number for s in closing_steps)
+        min_ownership_num = min(s.step_number for s in ownership_steps)
+        assert max_closing_num < min_ownership_num
+
+    def test_live_in_journey_ends_with_ownership(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that live-in journeys end with OWNERSHIP (no RENTAL_SETUP)."""
+        steps = _generate_steps(live_in_apartment_answers)
+        last_step = steps[-1]
+        assert last_step.phase == JourneyPhase.OWNERSHIP
+
+    # --- Task-level condition tests ---
+
+    def test_anmeldung_task_included_for_live_in(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that Anmeldung task is included for live-in buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+        reg_tasks = steps_with_tasks["Complete Property Registration"]
+        task_titles = [t.title for t in reg_tasks]
+        assert "Register new address at Bürgeramt (Anmeldung)" in task_titles
+
+    def test_anmeldung_task_excluded_for_rent_out(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that Anmeldung task is excluded for rent-out buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
+        reg_tasks = steps_with_tasks["Complete Property Registration"]
+        task_titles = [t.title for t in reg_tasks]
+        assert "Register new address at Bürgeramt (Anmeldung)" not in task_titles
+
+    def test_contents_insurance_included_for_live_in(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that Hausratversicherung task is included for live-in buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
+        task_titles = [t.title for t in ins_tasks]
+        assert "Set up Hausratversicherung (contents insurance)" in task_titles
+
+    def test_contents_insurance_excluded_for_rent_out(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that Hausratversicherung task is excluded for rent-out buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
+        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
+        task_titles = [t.title for t in ins_tasks]
+        assert "Set up Hausratversicherung (contents insurance)" not in task_titles
+
+    def test_weg_tasks_included_for_apartment(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that WEG/Hausgeld tasks are included for apartment buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        task_titles = [t.title for t in mgmt_tasks]
+        assert "Contact WEG-Verwaltung and register as new owner" in task_titles
+        assert "Set up Hausgeld (condo fees) payment via Dauerauftrag" in task_titles
+
+    def test_weg_tasks_excluded_for_house(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that WEG/Hausgeld tasks are excluded for house buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
+        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        task_titles = [t.title for t in mgmt_tasks]
+        assert "Contact WEG-Verwaltung and register as new owner" not in task_titles
+        assert (
+            "Set up Hausgeld (condo fees) payment via Dauerauftrag" not in task_titles
+        )
+
+    def test_house_maintenance_tasks_included_for_house(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that house maintenance tasks are included for house buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
+        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        task_titles = [t.title for t in mgmt_tasks]
+        assert "Plan annual maintenance budget (Instandhaltungsrücklage)" in task_titles
+
+    def test_house_maintenance_tasks_excluded_for_apartment(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that house maintenance tasks are excluded for apartment buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        task_titles = [t.title for t in mgmt_tasks]
+        assert (
+            "Plan annual maintenance budget (Instandhaltungsrücklage)"
+            not in task_titles
+        )
+
+    def test_weg_insurance_included_for_apartment(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that WEG insurance verification task is included for apartment buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
+        task_titles = [t.title for t in ins_tasks]
+        assert "Verify WEG building insurance policy covers your unit" in task_titles
+
+    def test_weg_insurance_excluded_for_house(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that WEG insurance verification task is excluded for house buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
+        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
+        task_titles = [t.title for t in ins_tasks]
+        assert (
+            "Verify WEG building insurance policy covers your unit" not in task_titles
+        )
+
+    def test_mortgage_tracking_included_for_mortgage(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that mortgage tracking task is included for mortgage buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
+        task_titles = [t.title for t in tax_tasks]
+        assert (
+            "Track mortgage payments and request annual interest statement"
+            in task_titles
+        )
+
+    def test_mortgage_tracking_excluded_for_cash(
+        self, rent_out_apartment_cash_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that mortgage tracking task is excluded for cash buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_apartment_cash_answers)
+        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
+        task_titles = [t.title for t in tax_tasks]
+        assert (
+            "Track mortgage payments and request annual interest statement"
+            not in task_titles
+        )
+
+    def test_anlage_v_included_for_rent_out(
+        self, rent_out_house_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that Anlage V task is included for rent-out buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
+        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
+        task_titles = [t.title for t in tax_tasks]
+        assert "Prepare for Anlage V rental income tax filing" in task_titles
+
+    def test_anlage_v_excluded_for_live_in(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that Anlage V task is excluded for live-in buyers."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
+        task_titles = [t.title for t in tax_tasks]
+        assert "Prepare for Anlage V rental income tax filing" not in task_titles
+
+    def test_universal_tasks_always_present(
+        self, live_in_apartment_answers: QuestionnaireAnswers
+    ) -> None:
+        """Test that unconditional tasks are always present in ownership steps."""
+        steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
+
+        # Registration universal tasks
+        reg_titles = [
+            t.title for t in steps_with_tasks["Complete Property Registration"]
+        ]
+        assert (
+            "Confirm Grundbuch (land register) transfer is complete with notary"
+            in reg_titles
+        )
+        assert (
+            "Transfer utilities (electricity, gas, water, internet) to your name"
+            in reg_titles
+        )
+
+        # Management universal tasks
+        mgmt_titles = [t.title for t in steps_with_tasks["Set Up Property Management"]]
+        assert "Register for waste collection (Müllabfuhr) service" in mgmt_titles
+
+        # Tax universal tasks
+        tax_titles = [
+            t.title for t in steps_with_tasks["Handle Property Tax & Finance"]
+        ]
+        assert (
+            "Register for Grundsteuer (property tax) at local Finanzamt" in tax_titles
+        )
+        assert "Keep records of all property expenses for tax deduction" in tax_titles
+
+    def test_step17_utility_task_distinct_from_step25(self) -> None:
+        """Test that Step 17 and Step 25 utility tasks have distinct wording."""
+        step17 = next(
+            t for t in STEP_TEMPLATES if t.content_key == "ownership_transfer"
+        )
+        step25 = next(
+            t for t in STEP_TEMPLATES if t.content_key == "ownership_registration"
+        )
+        step17_titles = {t["title"] for t in step17.tasks}
+        step25_titles = {t["title"] for t in step25.tasks}
+        assert step17_titles.isdisjoint(step25_titles)
+
+    # --- Prerequisite tests ---
+
+    def test_ownership_registration_prerequisite_is_ownership_transfer(
+        self,
+    ) -> None:
+        """Test that ownership_registration template has prerequisite [17] (ownership transfer)."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "ownership_registration"
+        )
+        assert template.prerequisites == [17]
+
+    def test_ownership_insurance_prerequisite_is_registration(self) -> None:
+        """Test that ownership_insurance template has prerequisite [25] (registration)."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "ownership_insurance"
+        )
+        assert template.prerequisites == [25]
+
+    def test_ownership_management_prerequisite_is_registration(self) -> None:
+        """Test that ownership_management template has prerequisite [25] (registration)."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "ownership_management"
+        )
+        assert template.prerequisites == [25]
+
+    def test_ownership_tax_prerequisite_is_registration(self) -> None:
+        """Test that ownership_tax_finance template has prerequisite [25] (registration)."""
+        template = next(
+            t for t in STEP_TEMPLATES if t.content_key == "ownership_tax_finance"
+        )
+        assert template.prerequisites == [25]

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2678,7 +2678,7 @@ export const JourneyOverviewSchema = {
 
 export const JourneyPhaseSchema = {
     type: 'string',
-    enum: ['research', 'preparation', 'buying', 'closing', 'rental_setup'],
+    enum: ['research', 'preparation', 'buying', 'closing', 'ownership', 'rental_setup'],
     title: 'JourneyPhase',
     description: 'Phases of the property buying journey.'
 } as const;

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -794,7 +794,7 @@ export type JourneyOverview = {
 /**
  * Phases of the property buying journey.
  */
-export type JourneyPhase = 'research' | 'preparation' | 'buying' | 'closing' | 'rental_setup';
+export type JourneyPhase = 'research' | 'preparation' | 'buying' | 'closing' | 'ownership' | 'rental_setup';
 
 /**
  * Schema for journey progress.

--- a/frontend/src/common/constants/index.ts
+++ b/frontend/src/common/constants/index.ts
@@ -52,7 +52,8 @@ export const JOURNEY_PHASES = [
   { key: "preparation", label: "Preparation", order: 2 },
   { key: "buying", label: "Buying", order: 3 },
   { key: "closing", label: "Closing", order: 4 },
-  { key: "rental_setup", label: "Rental Setup", order: 5 },
+  { key: "ownership", label: "Ownership", order: 5 },
+  { key: "rental_setup", label: "Rental Setup", order: 6 },
 ] as const
 
 // Journey phase colors (used for phase badges across components)
@@ -64,6 +65,8 @@ export const PHASE_COLORS: Record<string, string> = {
     "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
   closing:
     "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  ownership:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
   rental_setup:
     "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400",
 }

--- a/frontend/src/components/Journey/JourneyGenerating.tsx
+++ b/frontend/src/components/Journey/JourneyGenerating.tsx
@@ -33,6 +33,7 @@ const PHASE_LABELS: Record<JourneyPhase, string> = {
   preparation: "Preparation",
   buying: "Buying",
   closing: "Closing",
+  ownership: "Ownership",
   rental_setup: "Rental Setup",
 }
 
@@ -74,6 +75,7 @@ function JourneyGenerating(props: IProps) {
       preparation: 0,
       buying: 0,
       closing: 0,
+      ownership: 0,
       rental_setup: 0,
     }
     for (const step of journey.steps) {

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -72,6 +72,10 @@ const STEP_CONTENT_REGISTRY: Record<
   rental_property_management: () => null,
   rental_tax_strategy: () => null,
   rental_operations_setup: () => null,
+  ownership_registration: () => null,
+  ownership_insurance: () => null,
+  ownership_management: () => null,
+  ownership_tax_finance: () => null,
 }
 
 /******************************************************************************

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -36,6 +36,7 @@ function StepTabView(props: IProps) {
     preparation: [],
     buying: [],
     closing: [],
+    ownership: [],
     rental_setup: [],
   }
   for (const step of steps) {

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -9,6 +9,7 @@ export type JourneyPhase =
   | "preparation"
   | "buying"
   | "closing"
+  | "ownership"
   | "rental_setup"
 
 export type StepStatus = "not_started" | "in_progress" | "completed" | "skipped"


### PR DESCRIPTION
## Summary
- Add new `OWNERSHIP` journey phase with 4 step templates (registration, insurance, management, tax/finance) that guide buyers through post-purchase tasks
- Steps are included for all users (no step-level conditions), but individual tasks are personalized by `property_use`, `property_type`, and `financing_type`
- Phase ordering: CLOSING → OWNERSHIP → RENTAL_SETUP, so live-in journeys end at OWNERSHIP and rent-out journeys continue to RENTAL_SETUP

## Test plan
- [x] 27 new tests in `TestOwnershipPhaseSteps` — step inclusion, task-level conditions, phase ordering, prerequisites
- [x] All 912 backend tests pass
- [x] TypeScript compiles with no errors (`bunx tsc --noEmit`)
- [x] All pre-commit hooks pass (biome, ruff, SDK generation)
- [ ] Manual: create journeys with different profiles (live-in apartment, rent-out house, etc.) and verify ownership steps appear with correct task personalization