### PR TITLE
feat(tools): add public calculator pages for SEO & organic growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,4 +285,4 @@ This project is proprietary software. All rights reserved.
 
 ## Support
 
-For support, please contact support@heimpath.de or open an issue in this repository.
+For support, please contact support@heimpath.com or open an issue in this repository.

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,16 @@
+User-agent: *
+Allow: /
+Allow: /tools/
+
+Disallow: /dashboard
+Disallow: /settings
+Disallow: /admin
+Disallow: /calculators
+Disallow: /documents
+Disallow: /journeys
+Disallow: /portfolio
+Disallow: /articles
+Disallow: /search
+Disallow: /items
+
+Sitemap: https://heimpath.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://heimpath.com/</loc>
+    <lastmod>2026-04-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/tools</loc>
+    <lastmod>2026-04-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/tools/property-cost-calculator</loc>
+    <lastmod>2026-04-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/tools/mortgage-calculator</loc>
+    <lastmod>2026-04-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/tools/roi-calculator</loc>
+    <lastmod>2026-04-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
+++ b/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
@@ -10,8 +10,6 @@ import {
   ExternalLink,
   Info,
   RefreshCw,
-  Save,
-  Share2,
   Trash2,
 } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -43,8 +41,10 @@ import {
   useSaveCalculation,
 } from "@/hooks/mutations/useCalculatorMutations"
 import { useUserCalculations } from "@/hooks/queries/useCalculatorQueries"
+import { isLoggedIn } from "@/hooks/useAuth"
 import type { HiddenCostCalculationInput } from "@/models/calculator"
 import { FormRow } from "./common/FormRow"
+import { SaveShareSection } from "./common/SaveShareSection"
 
 interface IProps {
   className?: string
@@ -199,6 +199,7 @@ function HiddenCostsCalculator(props: IProps) {
   const [saveName, setSaveName] = useState("")
   const [shareUrl, setShareUrl] = useState("")
 
+  const authenticated = isLoggedIn()
   const saveCalculation = useSaveCalculation()
   const deleteCalculation = useDeleteCalculation()
   const { data: savedCalcs } = useUserCalculations()
@@ -539,44 +540,14 @@ function HiddenCostsCalculator(props: IProps) {
                   Export Results
                 </Button>
 
-                {/* Save Section */}
-                <div className="space-y-2">
-                  <Input
-                    placeholder="Name this calculation (optional)"
-                    value={saveName}
-                    onChange={(e) => setSaveName(e.target.value)}
-                  />
-                  <Button
-                    onClick={handleSave}
-                    disabled={saveCalculation.isPending}
-                    className="w-full gap-2"
-                  >
-                    <Save className="h-4 w-4" />
-                    {saveCalculation.isPending
-                      ? "Saving..."
-                      : "Save Calculation"}
-                  </Button>
-                </div>
-
-                {/* Share URL */}
-                {shareUrl && (
-                  <div className="rounded-lg border p-3 space-y-2">
-                    <p className="text-sm font-medium flex items-center gap-2">
-                      <Share2 className="h-4 w-4" />
-                      Share Link
-                    </p>
-                    <div className="flex gap-2">
-                      <Input value={shareUrl} readOnly className="text-xs" />
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleCopyShareUrl}
-                      >
-                        Copy
-                      </Button>
-                    </div>
-                  </div>
-                )}
+                <SaveShareSection
+                  saveName={saveName}
+                  onSaveNameChange={setSaveName}
+                  onSave={handleSave}
+                  isSaving={saveCalculation.isPending}
+                  shareUrl={shareUrl}
+                  onCopyShareUrl={handleCopyShareUrl}
+                />
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-12 text-center">
@@ -591,7 +562,7 @@ function HiddenCostsCalculator(props: IProps) {
       </div>
 
       {/* Saved Calculations */}
-      {savedCalcs && savedCalcs.data.length > 0 && (
+      {authenticated && savedCalcs && savedCalcs.data.length > 0 && (
         <SavedCalculations
           calculations={savedCalcs.data}
           onDelete={handleDelete}

--- a/frontend/src/components/Calculators/ROICalculator.tsx
+++ b/frontend/src/components/Calculators/ROICalculator.tsx
@@ -11,8 +11,6 @@ import {
   Info,
   Lightbulb,
   RefreshCw,
-  Save,
-  Share2,
   Trash2,
   TrendingUp,
 } from "lucide-react"
@@ -47,6 +45,7 @@ import {
   useRentEstimate,
   useUserROICalculations,
 } from "@/hooks/queries/useCalculatorQueries"
+import { isLoggedIn } from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import type {
   ROICalculationInput,
@@ -54,6 +53,7 @@ import type {
 } from "@/models/calculator"
 import { handleError } from "@/utils"
 import { FormRow } from "./common/FormRow"
+import { SaveShareSection } from "./common/SaveShareSection"
 
 interface IProps {
   className?: string
@@ -661,6 +661,7 @@ function ROICalculator(props: IProps) {
   const [shareUrl, setShareUrl] = useState("")
   const [showTaxSettings, setShowTaxSettings] = useState(false)
 
+  const authenticated = isLoggedIn()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const saveROI = useSaveROICalculation()
   const deleteROI = useDeleteROICalculation()
@@ -1271,42 +1272,15 @@ function ROICalculator(props: IProps) {
                   Export Results
                 </Button>
 
-                {/* Save Section */}
-                <div className="space-y-2">
-                  <Input
-                    placeholder="Name this calculation (optional)"
-                    value={saveName}
-                    onChange={(e) => setSaveName(e.target.value)}
-                  />
-                  <Button
-                    onClick={handleSave}
-                    disabled={saveROI.isPending}
-                    className="w-full gap-2"
-                  >
-                    <Save className="h-4 w-4" />
-                    {saveROI.isPending ? "Saving..." : "Save Calculation"}
-                  </Button>
-                </div>
-
-                {/* Share URL */}
-                {shareUrl && (
-                  <div className="rounded-lg border p-3 space-y-2">
-                    <p className="text-sm font-medium flex items-center gap-2">
-                      <Share2 className="h-4 w-4" />
-                      Share Link
-                    </p>
-                    <div className="flex gap-2">
-                      <Input value={shareUrl} readOnly className="text-xs" />
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleCopyShareUrl}
-                      >
-                        Copy
-                      </Button>
-                    </div>
-                  </div>
-                )}
+                {/* Save / Share or Sign-Up CTA */}
+                <SaveShareSection
+                  saveName={saveName}
+                  onSaveNameChange={setSaveName}
+                  onSave={handleSave}
+                  isSaving={saveROI.isPending}
+                  shareUrl={shareUrl}
+                  onCopyShareUrl={handleCopyShareUrl}
+                />
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-12 text-center">
@@ -1398,7 +1372,7 @@ function ROICalculator(props: IProps) {
       )}
 
       {/* Saved Calculations */}
-      {savedCalcs && savedCalcs.data.length > 0 && (
+      {authenticated && savedCalcs && savedCalcs.data.length > 0 && (
         <SavedROICalculations
           calculations={savedCalcs.data}
           onDelete={handleDelete}

--- a/frontend/src/components/Calculators/common/SaveShareSection.tsx
+++ b/frontend/src/components/Calculators/common/SaveShareSection.tsx
@@ -1,0 +1,75 @@
+import { Save, Share2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { isLoggedIn } from "@/hooks/useAuth"
+import { SaveSignUpCta } from "../../Tools/ToolsCta"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  saveName: string
+  onSaveNameChange: (value: string) => void
+  onSave: () => void
+  isSaving: boolean
+  shareUrl: string
+  onCopyShareUrl: () => void
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Save/share controls when authenticated, or sign-up CTA when not. */
+function SaveShareSection(props: Readonly<IProps>) {
+  const {
+    saveName,
+    onSaveNameChange,
+    onSave,
+    isSaving,
+    shareUrl,
+    onCopyShareUrl,
+  } = props
+
+  if (!isLoggedIn()) {
+    return <SaveSignUpCta />
+  }
+
+  return (
+    <>
+      <div className="space-y-2">
+        <Input
+          placeholder="Name this calculation (optional)"
+          value={saveName}
+          onChange={(e) => onSaveNameChange(e.target.value)}
+        />
+        <Button onClick={onSave} disabled={isSaving} className="w-full gap-2">
+          <Save className="h-4 w-4" />
+          {isSaving ? "Saving..." : "Save Calculation"}
+        </Button>
+      </div>
+      {shareUrl && (
+        <div className="rounded-lg border p-3 space-y-2">
+          <p className="text-sm font-medium flex items-center gap-2">
+            <Share2 className="h-4 w-4" />
+            Share Link
+          </p>
+          <div className="flex gap-2">
+            <Input value={shareUrl} readOnly className="text-xs" />
+            <Button variant="outline" size="sm" onClick={onCopyShareUrl}>
+              Copy
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { SaveShareSection }

--- a/frontend/src/components/Common/Footer.tsx
+++ b/frontend/src/components/Common/Footer.tsx
@@ -5,7 +5,7 @@
 const FOOTER_LINKS = [
   { label: "Terms", href: "/terms" },
   { label: "Privacy", href: "/privacy" },
-  { label: "Support", href: "mailto:support@heimpath.de" },
+  { label: "Support", href: "mailto:support@heimpath.com" },
 ] as const
 
 /******************************************************************************

--- a/frontend/src/components/Landing/LandingFooter.tsx
+++ b/frontend/src/components/Landing/LandingFooter.tsx
@@ -5,32 +5,41 @@ import { Separator } from "@/components/ui/separator"
                               Constants
 ******************************************************************************/
 
-const FOOTER_COLUMNS = [
-  {
-    title: "Product",
-    links: [
-      { label: "Features", href: "#features" },
-      { label: "How It Works", href: "#how-it-works" },
-      { label: "Pricing", href: "#" },
+/** [title, [label, href][]] */
+const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
+  [
+    "Product",
+    [
+      ["Features", "#features"],
+      ["How It Works", "#how-it-works"],
+      ["Pricing", "#"],
     ],
-  },
-  {
-    title: "Company",
-    links: [
-      { label: "About", href: "#" },
-      { label: "Blog", href: "#" },
-      { label: "Contact", href: "mailto:support@heimpath.de" },
+  ],
+  [
+    "Free Tools",
+    [
+      ["Cost Calculator", "/tools/property-cost-calculator"],
+      ["Mortgage Calculator", "/tools/mortgage-calculator"],
+      ["ROI Calculator", "/tools/roi-calculator"],
     ],
-  },
-  {
-    title: "Legal",
-    links: [
-      { label: "Terms of Service", href: "/terms" },
-      { label: "Privacy Policy", href: "/privacy" },
-      { label: "Imprint", href: "#" },
+  ],
+  [
+    "Company",
+    [
+      ["About", "#"],
+      ["Blog", "#"],
+      ["Contact", "mailto:support@heimpath.com"],
     ],
-  },
-] as const
+  ],
+  [
+    "Legal",
+    [
+      ["Terms of Service", "/terms"],
+      ["Privacy Policy", "/privacy"],
+      ["Imprint", "#"],
+    ],
+  ],
+]
 
 /******************************************************************************
                               Components
@@ -43,7 +52,7 @@ function LandingFooter() {
   return (
     <footer className="border-t bg-muted/30">
       <div className="mx-auto max-w-7xl px-4 py-12 md:px-6">
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-5">
           {/* Brand column */}
           <div className="space-y-4">
             <Logo variant="full" asLink={false} />
@@ -54,17 +63,17 @@ function LandingFooter() {
           </div>
 
           {/* Navigation columns */}
-          {FOOTER_COLUMNS.map((column) => (
-            <div key={column.title}>
-              <h3 className="mb-3 text-sm font-semibold">{column.title}</h3>
+          {FOOTER_COLUMNS.map(([title, links]) => (
+            <div key={title}>
+              <h3 className="mb-3 text-sm font-semibold">{title}</h3>
               <ul className="space-y-2">
-                {column.links.map((link) => (
-                  <li key={link.label}>
+                {links.map(([label, href]) => (
+                  <li key={label}>
                     <a
-                      href={link.href}
+                      href={href}
                       className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                     >
-                      {link.label}
+                      {label}
                     </a>
                   </li>
                 ))}

--- a/frontend/src/components/Tools/ToolsCta.tsx
+++ b/frontend/src/components/Tools/ToolsCta.tsx
@@ -1,0 +1,56 @@
+import { Link } from "@tanstack/react-router"
+
+import { Button } from "@/components/ui/button"
+import { isLoggedIn } from "@/hooks/useAuth"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Sign-up CTA section shown on public tools pages. Hidden when logged in. */
+function ToolsCta() {
+  if (isLoggedIn()) return null
+
+  return (
+    <section className="border-t bg-muted/30 py-12">
+      <div className="mx-auto max-w-2xl px-4 text-center space-y-4">
+        <h2 className="text-2xl font-bold tracking-tight">
+          Get the full HeimPath experience
+        </h2>
+        <p className="text-muted-foreground">
+          Create a free account to save your calculations, get shareable links,
+          and access our guided property buying journey.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <Button asChild size="lg">
+            <Link to="/signup">Sign Up Free</Link>
+          </Button>
+          <Button variant="outline" asChild size="lg">
+            <Link to="/login">Log In</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/** Inline sign-up CTA shown inside calculator results when not logged in. */
+function SaveSignUpCta() {
+  return (
+    <div className="rounded-lg border border-dashed p-4 text-center space-y-2">
+      <p className="text-sm font-medium">Save & share your calculations</p>
+      <p className="text-xs text-muted-foreground">
+        Create a free account to save results and get shareable links.
+      </p>
+      <Button asChild size="sm">
+        <Link to="/signup">Sign Up Free</Link>
+      </Button>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { SaveSignUpCta, ToolsCta }

--- a/frontend/src/components/Tools/ToolsPageLayout.tsx
+++ b/frontend/src/components/Tools/ToolsPageLayout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  title: string
+  description: string
+  children: ReactNode
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Page layout for individual tool pages with an h1 heading and description. */
+function ToolsPageLayout(props: Readonly<IProps>) {
+  const { title, description, children } = props
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+        <p className="text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ToolsPageLayout }

--- a/frontend/src/components/Tools/toolsMeta.ts
+++ b/frontend/src/components/Tools/toolsMeta.ts
@@ -1,0 +1,12 @@
+/** Build SEO meta array for a tools page. */
+function toolsMeta(title: string, description: string) {
+  return [
+    { title },
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:type", content: "website" },
+  ]
+}
+
+export { toolsMeta }

--- a/frontend/src/hooks/queries/useCalculatorQueries.ts
+++ b/frontend/src/hooks/queries/useCalculatorQueries.ts
@@ -4,6 +4,7 @@
  */
 
 import { useQuery } from "@tanstack/react-query"
+import { isLoggedIn } from "@/hooks/useAuth"
 import { queryKeys } from "@/query/queryKeys"
 import { CalculatorService } from "@/services/CalculatorService"
 
@@ -47,6 +48,7 @@ export function useUserCalculations() {
   return useQuery({
     queryKey: queryKeys.calculators.hiddenCostsList(),
     queryFn: () => CalculatorService.getUserCalculations(),
+    enabled: isLoggedIn(),
   })
 }
 
@@ -116,6 +118,7 @@ export function useUserROICalculations() {
   return useQuery({
     queryKey: queryKeys.calculators.roiList(),
     queryFn: () => CalculatorService.getUserROICalculations(),
+    enabled: isLoggedIn(),
   })
 }
 

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -11,12 +11,17 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as UnsubscribeRouteImport } from './routes/unsubscribe'
+import { Route as ToolsRouteImport } from './routes/tools'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as RecoverPasswordRouteImport } from './routes/recover-password'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ToolsIndexRouteImport } from './routes/tools/index'
+import { Route as ToolsRoiCalculatorRouteImport } from './routes/tools/roi-calculator'
+import { Route as ToolsPropertyCostCalculatorRouteImport } from './routes/tools/property-cost-calculator'
+import { Route as ToolsMortgageCalculatorRouteImport } from './routes/tools/mortgage-calculator'
 import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutSearchRouteImport } from './routes/_layout/search'
 import { Route as LayoutItemsRouteImport } from './routes/_layout/items'
@@ -51,6 +56,11 @@ const UnsubscribeRoute = UnsubscribeRouteImport.update({
   path: '/unsubscribe',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ToolsRoute = ToolsRouteImport.update({
+  id: '/tools',
+  path: '/tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
@@ -79,6 +89,27 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsIndexRoute = ToolsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ToolsRoute,
+} as any)
+const ToolsRoiCalculatorRoute = ToolsRoiCalculatorRouteImport.update({
+  id: '/roi-calculator',
+  path: '/roi-calculator',
+  getParentRoute: () => ToolsRoute,
+} as any)
+const ToolsPropertyCostCalculatorRoute =
+  ToolsPropertyCostCalculatorRouteImport.update({
+    id: '/property-cost-calculator',
+    path: '/property-cost-calculator',
+    getParentRoute: () => ToolsRoute,
+  } as any)
+const ToolsMortgageCalculatorRoute = ToolsMortgageCalculatorRouteImport.update({
+  id: '/mortgage-calculator',
+  path: '/mortgage-calculator',
+  getParentRoute: () => ToolsRoute,
 } as any)
 const LayoutSettingsRoute = LayoutSettingsRouteImport.update({
   id: '/settings',
@@ -208,6 +239,7 @@ export interface FileRoutesByFullPath {
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/tools': typeof ToolsRouteWithChildren
   '/unsubscribe': typeof UnsubscribeRoute
   '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
@@ -216,6 +248,10 @@ export interface FileRoutesByFullPath {
   '/items': typeof LayoutItemsRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
+  '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
+  '/tools/property-cost-calculator': typeof ToolsPropertyCostCalculatorRoute
+  '/tools/roi-calculator': typeof ToolsRoiCalculatorRoute
+  '/tools/': typeof ToolsIndexRoute
   '/articles/$slug': typeof LayoutArticlesSlugRoute
   '/documents/$documentId': typeof LayoutDocumentsDocumentIdRoute
   '/journeys/$journeyId': typeof LayoutJourneysJourneyIdRouteWithChildren
@@ -248,6 +284,10 @@ export interface FileRoutesByTo {
   '/items': typeof LayoutItemsRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
+  '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
+  '/tools/property-cost-calculator': typeof ToolsPropertyCostCalculatorRoute
+  '/tools/roi-calculator': typeof ToolsRoiCalculatorRoute
+  '/tools': typeof ToolsIndexRoute
   '/articles/$slug': typeof LayoutArticlesSlugRoute
   '/documents/$documentId': typeof LayoutDocumentsDocumentIdRoute
   '/journeys/new': typeof LayoutJourneysNewRoute
@@ -273,6 +313,7 @@ export interface FileRoutesById {
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/tools': typeof ToolsRouteWithChildren
   '/unsubscribe': typeof UnsubscribeRoute
   '/verify-email': typeof VerifyEmailRoute
   '/_layout/admin': typeof LayoutAdminRoute
@@ -281,6 +322,10 @@ export interface FileRoutesById {
   '/_layout/items': typeof LayoutItemsRoute
   '/_layout/search': typeof LayoutSearchRoute
   '/_layout/settings': typeof LayoutSettingsRoute
+  '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
+  '/tools/property-cost-calculator': typeof ToolsPropertyCostCalculatorRoute
+  '/tools/roi-calculator': typeof ToolsRoiCalculatorRoute
+  '/tools/': typeof ToolsIndexRoute
   '/_layout/articles/$slug': typeof LayoutArticlesSlugRoute
   '/_layout/documents/$documentId': typeof LayoutDocumentsDocumentIdRoute
   '/_layout/journeys/$journeyId': typeof LayoutJourneysJourneyIdRouteWithChildren
@@ -307,6 +352,7 @@ export interface FileRouteTypes {
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/tools'
     | '/unsubscribe'
     | '/verify-email'
     | '/admin'
@@ -315,6 +361,10 @@ export interface FileRouteTypes {
     | '/items'
     | '/search'
     | '/settings'
+    | '/tools/mortgage-calculator'
+    | '/tools/property-cost-calculator'
+    | '/tools/roi-calculator'
+    | '/tools/'
     | '/articles/$slug'
     | '/documents/$documentId'
     | '/journeys/$journeyId'
@@ -347,6 +397,10 @@ export interface FileRouteTypes {
     | '/items'
     | '/search'
     | '/settings'
+    | '/tools/mortgage-calculator'
+    | '/tools/property-cost-calculator'
+    | '/tools/roi-calculator'
+    | '/tools'
     | '/articles/$slug'
     | '/documents/$documentId'
     | '/journeys/new'
@@ -371,6 +425,7 @@ export interface FileRouteTypes {
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/tools'
     | '/unsubscribe'
     | '/verify-email'
     | '/_layout/admin'
@@ -379,6 +434,10 @@ export interface FileRouteTypes {
     | '/_layout/items'
     | '/_layout/search'
     | '/_layout/settings'
+    | '/tools/mortgage-calculator'
+    | '/tools/property-cost-calculator'
+    | '/tools/roi-calculator'
+    | '/tools/'
     | '/_layout/articles/$slug'
     | '/_layout/documents/$documentId'
     | '/_layout/journeys/$journeyId'
@@ -405,6 +464,7 @@ export interface RootRouteChildren {
   RecoverPasswordRoute: typeof RecoverPasswordRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
+  ToolsRoute: typeof ToolsRouteWithChildren
   UnsubscribeRoute: typeof UnsubscribeRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
   SharedEvaluationShareIdRoute: typeof SharedEvaluationShareIdRoute
@@ -424,6 +484,13 @@ declare module '@tanstack/react-router' {
       path: '/unsubscribe'
       fullPath: '/unsubscribe'
       preLoaderRoute: typeof UnsubscribeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools': {
+      id: '/tools'
+      path: '/tools'
+      fullPath: '/tools'
+      preLoaderRoute: typeof ToolsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/signup': {
@@ -467,6 +534,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/tools/': {
+      id: '/tools/'
+      path: '/'
+      fullPath: '/tools/'
+      preLoaderRoute: typeof ToolsIndexRouteImport
+      parentRoute: typeof ToolsRoute
+    }
+    '/tools/roi-calculator': {
+      id: '/tools/roi-calculator'
+      path: '/roi-calculator'
+      fullPath: '/tools/roi-calculator'
+      preLoaderRoute: typeof ToolsRoiCalculatorRouteImport
+      parentRoute: typeof ToolsRoute
+    }
+    '/tools/property-cost-calculator': {
+      id: '/tools/property-cost-calculator'
+      path: '/property-cost-calculator'
+      fullPath: '/tools/property-cost-calculator'
+      preLoaderRoute: typeof ToolsPropertyCostCalculatorRouteImport
+      parentRoute: typeof ToolsRoute
+    }
+    '/tools/mortgage-calculator': {
+      id: '/tools/mortgage-calculator'
+      path: '/mortgage-calculator'
+      fullPath: '/tools/mortgage-calculator'
+      preLoaderRoute: typeof ToolsMortgageCalculatorRouteImport
+      parentRoute: typeof ToolsRoute
     }
     '/_layout/settings': {
       id: '/_layout/settings'
@@ -699,6 +794,22 @@ const LayoutRouteChildren: LayoutRouteChildren = {
 const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
 
+interface ToolsRouteChildren {
+  ToolsMortgageCalculatorRoute: typeof ToolsMortgageCalculatorRoute
+  ToolsPropertyCostCalculatorRoute: typeof ToolsPropertyCostCalculatorRoute
+  ToolsRoiCalculatorRoute: typeof ToolsRoiCalculatorRoute
+  ToolsIndexRoute: typeof ToolsIndexRoute
+}
+
+const ToolsRouteChildren: ToolsRouteChildren = {
+  ToolsMortgageCalculatorRoute: ToolsMortgageCalculatorRoute,
+  ToolsPropertyCostCalculatorRoute: ToolsPropertyCostCalculatorRoute,
+  ToolsRoiCalculatorRoute: ToolsRoiCalculatorRoute,
+  ToolsIndexRoute: ToolsIndexRoute,
+}
+
+const ToolsRouteWithChildren = ToolsRoute._addFileChildren(ToolsRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LayoutRoute: LayoutRouteWithChildren,
@@ -706,6 +817,7 @@ const rootRouteChildren: RootRouteChildren = {
   RecoverPasswordRoute: RecoverPasswordRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,
+  ToolsRoute: ToolsRouteWithChildren,
   UnsubscribeRoute: UnsubscribeRoute,
   VerifyEmailRoute: VerifyEmailRoute,
   SharedEvaluationShareIdRoute: SharedEvaluationShareIdRoute,

--- a/frontend/src/routes/tools.tsx
+++ b/frontend/src/routes/tools.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router"
+
+import { LandingFooter } from "@/components/Landing/LandingFooter"
+import { LandingHeader } from "@/components/Landing/LandingHeader"
+import { ToolsCta } from "@/components/Tools/ToolsCta"
+
+export const Route = createFileRoute("/tools")({
+  component: ToolsLayout,
+})
+
+function ToolsLayout() {
+  return (
+    <div className="flex min-h-svh flex-col">
+      <LandingHeader />
+      <main className="flex-1">
+        <div className="mx-auto max-w-5xl p-6 md:p-8">
+          <Outlet />
+        </div>
+      </main>
+      <ToolsCta />
+      <LandingFooter />
+    </div>
+  )
+}

--- a/frontend/src/routes/tools/index.tsx
+++ b/frontend/src/routes/tools/index.tsx
@@ -1,0 +1,82 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Calculator, Home, TrendingUp } from "lucide-react"
+
+import { toolsMeta } from "@/components/Tools/toolsMeta"
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+export const Route = createFileRoute("/tools/")({
+  component: ToolsIndexPage,
+  head: () => ({
+    meta: toolsMeta(
+      "Free German Property Calculators - HeimPath",
+      "Free calculators for buying property in Germany. Estimate hidden costs, mortgage payments, and rental ROI — no sign-up required.",
+    ),
+  }),
+})
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const TOOLS = [
+  {
+    title: "Property Cost Calculator",
+    description:
+      "Estimate the true cost of buying property in Germany — transfer tax, notary fees, agent commission, and more.",
+    href: "/tools/property-cost-calculator",
+    icon: Calculator,
+  },
+  {
+    title: "Mortgage Calculator",
+    description:
+      "Calculate monthly payments, view an amortisation schedule, and compare interest rates for German mortgages.",
+    href: "/tools/mortgage-calculator",
+    icon: Home,
+  },
+  {
+    title: "ROI Calculator",
+    description:
+      "Analyse rental investment returns, get an investment grade, and see 10-year projections with tax impact.",
+    href: "/tools/roi-calculator",
+    icon: TrendingUp,
+  },
+] as const
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function ToolsIndexPage() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">
+          Free German Property Calculators
+        </h1>
+        <p className="text-lg text-muted-foreground">
+          Plan your property purchase in Germany with our free tools — no
+          sign-up required.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {TOOLS.map((tool) => (
+          <Link key={tool.href} to={tool.href} className="group">
+            <Card className="h-full transition-shadow group-hover:shadow-md">
+              <CardHeader>
+                <tool.icon className="mb-2 h-8 w-8 text-primary" />
+                <CardTitle className="text-lg">{tool.title}</CardTitle>
+                <CardDescription>{tool.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/tools/mortgage-calculator.tsx
+++ b/frontend/src/routes/tools/mortgage-calculator.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { MortgageAmortisation } from "@/components/Calculators"
+import { ToolsPageLayout } from "@/components/Tools/ToolsPageLayout"
+import { toolsMeta } from "@/components/Tools/toolsMeta"
+
+export const Route = createFileRoute("/tools/mortgage-calculator")({
+  component: MortgageCalculatorPage,
+  head: () => ({
+    meta: toolsMeta(
+      "German Mortgage Calculator with Amortisation Schedule - HeimPath",
+      "Calculate monthly mortgage payments for German property. View a full amortisation schedule and compare interest rates side by side.",
+    ),
+  }),
+})
+
+function MortgageCalculatorPage() {
+  return (
+    <ToolsPageLayout
+      title="German Mortgage Calculator"
+      description="Calculate your monthly mortgage payments, view a full amortisation schedule, and compare different interest rates for property financing in Germany."
+    >
+      <MortgageAmortisation />
+    </ToolsPageLayout>
+  )
+}

--- a/frontend/src/routes/tools/property-cost-calculator.tsx
+++ b/frontend/src/routes/tools/property-cost-calculator.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { HiddenCostsCalculator } from "@/components/Calculators"
+import { ToolsPageLayout } from "@/components/Tools/ToolsPageLayout"
+import { toolsMeta } from "@/components/Tools/toolsMeta"
+
+export const Route = createFileRoute("/tools/property-cost-calculator")({
+  component: PropertyCostCalculatorPage,
+  head: () => ({
+    meta: toolsMeta(
+      "German Property Purchase Cost Calculator - HeimPath",
+      "Calculate the total cost of buying property in Germany. Includes transfer tax, notary fees, land registry, agent commission, and renovation estimates by state.",
+    ),
+  }),
+})
+
+function PropertyCostCalculatorPage() {
+  return (
+    <ToolsPageLayout
+      title="German Property Purchase Cost Calculator"
+      description="Find out the true cost of buying property in Germany. Transfer tax rates vary by state — our calculator covers all 16 Bundesländer plus notary fees, land registry, and agent commission."
+    >
+      <HiddenCostsCalculator />
+    </ToolsPageLayout>
+  )
+}

--- a/frontend/src/routes/tools/roi-calculator.tsx
+++ b/frontend/src/routes/tools/roi-calculator.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ROICalculator } from "@/components/Calculators"
+import { ToolsPageLayout } from "@/components/Tools/ToolsPageLayout"
+import { toolsMeta } from "@/components/Tools/toolsMeta"
+
+export const Route = createFileRoute("/tools/roi-calculator")({
+  component: ROICalculatorPage,
+  head: () => ({
+    meta: toolsMeta(
+      "German Rental Property ROI Calculator - HeimPath",
+      "Analyse rental investment returns in Germany. Calculate gross yield, cap rate, cash-on-cash return, and view 10-year projections with German tax impact.",
+    ),
+  }),
+})
+
+function ROICalculatorPage() {
+  return (
+    <ToolsPageLayout
+      title="German Rental Property ROI Calculator"
+      description="Evaluate your rental property investment in Germany. Get an investment grade, see after-tax cash flow, and view 10-year return projections including depreciation benefits."
+    >
+      <ROICalculator />
+    </ToolsPageLayout>
+  )
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,8 @@ sonar.organization=sojisoyoye
 
 sonar.sources=backend/app,frontend/src
 sonar.tests=backend/tests
-sonar.exclusions=backend/app/alembic/**,frontend/src/client/**,frontend/node_modules/**,**/__pycache__/**,**/*.pyc
+sonar.exclusions=backend/app/alembic/**,frontend/src/client/**,frontend/node_modules/**,**/__pycache__/**,**/*.pyc,frontend/src/routeTree.gen.ts
+sonar.cpd.exclusions=frontend/src/routeTree.gen.ts
 
 # Coverage is only measured for Python backend — no JS/TS test coverage exists
 sonar.coverage.exclusions=frontend/**,backend/tests/**,backend/app/alembic/**


### PR DESCRIPTION
## Summary
- Add unauthenticated `/tools/*` routes with SEO-optimized landing pages for 3 calculators (property costs, mortgage, ROI), enabling organic search traffic for high-intent queries
- Guard `useUserCalculations()` and `useUserROICalculations()` with `enabled: isLoggedIn()` so they don't fire 401s on public pages
- Show "Sign Up Free" CTAs in place of save/share controls when unauthenticated; hide saved calculations sections
- Add `robots.txt`, `sitemap.xml`, and "Free Tools" footer column for internal SEO linking

## Changes
### Modified (4)
- `useCalculatorQueries.ts` — add `enabled: isLoggedIn()` to user-specific query hooks
- `HiddenCostsCalculator.tsx` — auth-conditional save/share UI with sign-up CTA fallback
- `ROICalculator.tsx` — same auth-conditional pattern
- `LandingFooter.tsx` — add "Free Tools" column with links to all 3 calculator pages

### New (8)
- `ToolsCta.tsx` — reusable sign-up CTA section (hidden when logged in)
- `routes/tools.tsx` — layout route: LandingHeader + content + ToolsCta + LandingFooter
- `routes/tools/index.tsx` — tools index page with 3 calculator cards
- `routes/tools/property-cost-calculator.tsx` — public hidden costs calculator
- `routes/tools/mortgage-calculator.tsx` — public mortgage calculator
- `routes/tools/roi-calculator.tsx` — public ROI calculator
- `robots.txt` — allow `/`, `/tools/`; disallow `/dashboard`, `/settings`, `/admin`
- `sitemap.xml` — lists all public pages

## Test plan
- [ ] **Logged out:** `/tools` shows 3 cards → click each → calculator works → "Sign up to save" CTA visible → footer CTA visible
- [ ] **Logged in:** `/tools/property-cost-calculator` → save/share buttons visible → CTA hidden
- [ ] **Existing routes:** `/calculators?tab=costs` (authenticated) still works → saved calculations load
- [ ] **SEO:** View source → `<title>` and `<meta>` tags present on each tools page
- [ ] **Static files:** `/robots.txt` and `/sitemap.xml` load correctly
- [ ] **Mobile:** 375px viewport — all 3 pages render correctly