### PR TITLE
feat(documents): add ai-powered kaufvertrag clause analyzer

### DIFF
--- a/backend/app/alembic/versions/x5t6u7v8w9y0_add_kaufvertrag_analysis.py
+++ b/backend/app/alembic/versions/x5t6u7v8w9y0_add_kaufvertrag_analysis.py
@@ -1,0 +1,28 @@
+"""Add kaufvertrag_analysis column to document_translation
+
+Revision ID: x5t6u7v8w9y0
+Revises: w4s5t6u7v8x9
+Create Date: 2026-04-19 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "x5t6u7v8w9y0"
+down_revision = "w4s5t6u7v8x9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document_translation",
+        sa.Column("kaufvertrag_analysis", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("document_translation", "kaufvertrag_analysis")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -153,6 +153,16 @@ class Settings(BaseSettings):
     def translator_enabled(self) -> bool:
         return bool(self.AZURE_TRANSLATOR_KEY)
 
+    # Anthropic (Claude) configuration for AI analysis
+    ANTHROPIC_API_KEY: str | None = None
+    ANTHROPIC_MODEL: str = "claude-sonnet-4-20250514"
+    ANTHROPIC_MAX_TOKENS: int = 4096
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def anthropic_enabled(self) -> bool:
+        return bool(self.ANTHROPIC_API_KEY)
+
     # Document upload settings
     UPLOAD_DIR: str = "./uploads/documents"
     MAX_FILE_SIZE_MB: int = 20

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -150,6 +150,9 @@ class DocumentTranslation(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     risk_warnings = Column(MutableList.as_mutable(JSONB), nullable=False, default=list)
 
+    # AI analysis (Kaufvertrag only)
+    kaufvertrag_analysis = Column(JSONB, nullable=True, default=None)
+
     # Timing
     processing_started_at = Column(DateTime(timezone=True), nullable=True)
     processing_completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import datetime
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -99,6 +100,39 @@ class DocumentRiskWarning(BaseModel):
     page_number: int | None = None
 
 
+class AnalyzedClause(BaseModel):
+    """AI-analyzed clause from a Kaufvertrag."""
+
+    section_name: str
+    section_name_en: str
+    original_text: str
+    plain_english_explanation: str
+    risk_level: Literal["low", "medium", "high"]
+    risk_reason: str
+    is_unusual: bool = False
+    unusual_terms: list[str] = Field(default_factory=list)
+    page_number: int | None = None
+
+
+class NotaryQuestion(BaseModel):
+    """Question to ask a notary about a contract clause."""
+
+    question: str
+    related_clause: str
+    priority: Literal["essential", "recommended", "optional"]
+
+
+class KaufvertragAnalysis(BaseModel):
+    """Full AI analysis of a Kaufvertrag (purchase contract)."""
+
+    summary: str
+    analyzed_clauses: list[AnalyzedClause]
+    notary_checklist: list[NotaryQuestion]
+    overall_risk_assessment: Literal["low", "medium", "high"]
+    overall_risk_explanation: str
+    is_ai_generated: bool = True
+
+
 class DocumentTranslationResponse(BaseModel):
     """Full translation result for a document."""
 
@@ -111,6 +145,7 @@ class DocumentTranslationResponse(BaseModel):
     translated_pages: list[TranslatedPage]
     clauses_detected: list[DetectedClause]
     risk_warnings: list[DocumentRiskWarning]
+    kaufvertrag_analysis: KaufvertragAnalysis | None = None
     processing_started_at: datetime | None = None
     processing_completed_at: datetime | None = None
 

--- a/backend/app/services/clause_analyzer_service.py
+++ b/backend/app/services/clause_analyzer_service.py
@@ -1,0 +1,148 @@
+"""AI-powered Kaufvertrag clause analysis service.
+
+Uses the Anthropic Claude API to analyze German purchase contracts
+clause-by-clause, producing risk ratings, plain-English explanations,
+and a notary checklist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from app.core.config import settings
+
+if TYPE_CHECKING:
+    import anthropic
+
+logger = logging.getLogger(__name__)
+
+_client: anthropic.Anthropic | None = None
+
+SYSTEM_PROMPT = """You are a German real estate legal expert helping foreign buyers understand a Kaufvertrag (purchase contract). Analyze the contract text and return a JSON object with:
+
+1. **summary**: A 2-3 sentence plain-English overview of the contract.
+2. **analyzed_clauses**: An array of clause objects for each major section found. Standard Kaufvertrag sections include (but are not limited to): Kaufgegenstand (Subject of Sale), Kaufpreis (Purchase Price), Zahlung (Payment Terms), Gewährleistung (Warranty/Liability), Übergabe (Handover), Grundbuch (Land Registry), Finanzierungsvollmacht (Financing Power of Attorney), Rücktrittsrecht (Right of Withdrawal), Auflassung (Conveyance), Erschließungskosten (Development Costs), Besondere Vereinbarungen (Special Agreements). Each clause object must have:
+   - "section_name": German section title as found in the contract
+   - "section_name_en": English translation of the section title
+   - "original_text": The original German text (first 500 chars if longer)
+   - "plain_english_explanation": Clear explanation for a non-lawyer
+   - "risk_level": "high" (warranty exclusions, penalty clauses, tight deadlines, unusual obligations), "medium" (standard important clauses needing attention), or "low" (standard boilerplate)
+   - "risk_reason": Why this risk level was assigned
+   - "is_unusual": true if the clause contains non-standard or unusual terms
+   - "unusual_terms": array of specific unusual terms found (empty array if none)
+   - "page_number": page number where the clause appears (from PAGE markers), or null
+3. **notary_checklist**: Array of questions to ask the notary, each with:
+   - "question": The question in plain English
+   - "related_clause": Which contract section it relates to
+   - "priority": "essential" (must ask), "recommended" (should ask), or "optional" (nice to know)
+4. **overall_risk_assessment**: "low", "medium", or "high"
+5. **overall_risk_explanation**: 1-2 sentence explanation of the overall risk level.
+
+Return ONLY valid JSON. No markdown, no explanation outside the JSON."""
+
+
+def _get_anthropic_client() -> anthropic.Anthropic | None:
+    """Get a lazily-initialized Anthropic client. Returns None if not configured."""
+    global _client  # noqa: PLW0603
+    if _client is not None:
+        return _client
+    if not settings.anthropic_enabled:
+        return None
+    import anthropic as anthropic_mod
+
+    _client = anthropic_mod.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+    return _client
+
+
+def _build_contract_text(pages: list[dict]) -> str:
+    """Join page texts with page markers for the AI to reference."""
+    parts = []
+    for page in pages:
+        text = page.get("original_text", "").strip()
+        if text:
+            parts.append(f"--- PAGE {page['page_number']} ---\n{text}")
+    return "\n\n".join(parts)
+
+
+def _call_claude(client: anthropic.Anthropic, contract_text: str) -> str:
+    """Make a synchronous API call to Claude for contract analysis."""
+    message = client.messages.create(
+        model=settings.ANTHROPIC_MODEL,
+        max_tokens=settings.ANTHROPIC_MAX_TOKENS,
+        system=SYSTEM_PROMPT,
+        messages=[
+            {
+                "role": "user",
+                "content": f"Analyze this German Kaufvertrag:\n\n{contract_text}",
+            }
+        ],
+    )
+    if not message.content:
+        raise ValueError("Empty response from Anthropic API")
+    return message.content[0].text
+
+
+def _parse_analysis_response(text: str) -> dict | None:
+    """Parse Claude's JSON response, handling optional markdown code blocks."""
+    # Strip markdown code fences if present
+    cleaned = re.sub(r"^```(?:json)?\s*\n?", "", text.strip())
+    cleaned = re.sub(r"\n?```\s*$", "", cleaned)
+
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse clause analysis JSON: %s", text[:200])
+        return None
+
+    # Validate required top-level keys
+    required_keys = {
+        "summary",
+        "analyzed_clauses",
+        "notary_checklist",
+        "overall_risk_assessment",
+        "overall_risk_explanation",
+    }
+    if not required_keys.issubset(data.keys()):
+        missing = required_keys - data.keys()
+        logger.error("Clause analysis missing keys: %s", missing)
+        return None
+
+    # Add AI attribution flag
+    data["is_ai_generated"] = True
+    return data
+
+
+async def analyze_kaufvertrag(pages: list[dict], document_type: str) -> dict | None:
+    """Analyze a Kaufvertrag using Claude AI.
+
+    Args:
+        pages: List of page dicts with 'page_number' and 'original_text'.
+        document_type: The document type string.
+
+    Returns:
+        Analysis dict matching KaufvertragAnalysis schema, or None if
+        analysis is unavailable (wrong doc type, missing API key, or error).
+    """
+    if document_type != "kaufvertrag":
+        return None
+
+    client = _get_anthropic_client()
+    if client is None:
+        logger.info("Anthropic not configured — skipping Kaufvertrag analysis")
+        return None
+
+    contract_text = _build_contract_text(pages)
+    if not contract_text.strip():
+        logger.warning("No text extracted from Kaufvertrag — skipping analysis")
+        return None
+
+    try:
+        raw_response = await asyncio.to_thread(_call_claude, client, contract_text)
+        return _parse_analysis_response(raw_response)
+    except Exception:
+        logger.exception("Kaufvertrag AI analysis failed")
+        return None

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -25,6 +25,7 @@ from app.models.document import (
     DocumentType,
 )
 from app.schemas.translation import SupportedLanguage
+from app.services.clause_analyzer_service import analyze_kaufvertrag
 from app.services.translation_service import get_translation_service
 
 logger = logging.getLogger(__name__)
@@ -357,6 +358,13 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                     seen_terms.add(w["original_term"])
                     unique_warnings.append(w)
 
+            # AI analysis for Kaufvertrag documents
+            kaufvertrag_analysis_data = None
+            if document.document_type == DocumentType.KAUFVERTRAG.value:
+                kaufvertrag_analysis_data = await analyze_kaufvertrag(
+                    pages, document.document_type
+                )
+
             # Save translation record
             translation = DocumentTranslation(
                 document_id=document_id,
@@ -365,6 +373,7 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                 translated_pages=pages,
                 clauses_detected=all_clauses,
                 risk_warnings=unique_warnings,
+                kaufvertrag_analysis=kaufvertrag_analysis_data,
                 processing_started_at=processing_started_at,
                 processing_completed_at=datetime.now(timezone.utc),
             )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "starlette>=0.47.2",
     "redis>=5.0.0",
     "sendgrid>=6.11.0",
+    "anthropic>=0.49.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/services/test_clause_analyzer_service.py
+++ b/backend/tests/services/test_clause_analyzer_service.py
@@ -1,0 +1,183 @@
+"""Tests for AI-powered Kaufvertrag clause analysis service."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.clause_analyzer_service import (
+    _build_contract_text,
+    _parse_analysis_response,
+    analyze_kaufvertrag,
+)
+
+# --- Sample data ---
+
+VALID_ANALYSIS = {
+    "summary": "Standard purchase contract for a Berlin apartment.",
+    "analyzed_clauses": [
+        {
+            "section_name": "Kaufpreis",
+            "section_name_en": "Purchase Price",
+            "original_text": "Der Kaufpreis beträgt EUR 350.000.",
+            "plain_english_explanation": "The purchase price is 350,000 EUR.",
+            "risk_level": "medium",
+            "risk_reason": "Standard clause, but verify amount matches agreement.",
+            "is_unusual": False,
+            "unusual_terms": [],
+            "page_number": 2,
+        }
+    ],
+    "notary_checklist": [
+        {
+            "question": "Can you confirm the payment deadline is realistic?",
+            "related_clause": "Kaufpreis",
+            "priority": "essential",
+        }
+    ],
+    "overall_risk_assessment": "medium",
+    "overall_risk_explanation": "Contract contains standard terms with some clauses needing review.",
+}
+
+SAMPLE_PAGES = [
+    {"page_number": 1, "original_text": "Kaufvertrag\nzwischen Herrn Müller"},
+    {"page_number": 2, "original_text": "Der Kaufpreis beträgt EUR 350.000."},
+    {"page_number": 3, "original_text": ""},
+]
+
+
+# --- _build_contract_text ---
+
+
+class TestBuildContractText:
+    def test_joins_pages_with_markers(self) -> None:
+        result = _build_contract_text(SAMPLE_PAGES)
+        assert "--- PAGE 1 ---" in result
+        assert "--- PAGE 2 ---" in result
+        assert "Kaufvertrag" in result
+        assert "EUR 350.000" in result
+
+    def test_skips_empty_pages(self) -> None:
+        result = _build_contract_text(SAMPLE_PAGES)
+        assert "--- PAGE 3 ---" not in result
+
+    def test_empty_pages_list(self) -> None:
+        result = _build_contract_text([])
+        assert result == ""
+
+    def test_all_empty_text(self) -> None:
+        pages = [{"page_number": 1, "original_text": "   "}]
+        result = _build_contract_text(pages)
+        assert result == ""
+
+
+# --- _parse_analysis_response ---
+
+
+class TestParseAnalysisResponse:
+    def test_parses_valid_json(self) -> None:
+        raw = json.dumps(VALID_ANALYSIS)
+        result = _parse_analysis_response(raw)
+        assert result is not None
+        assert result["summary"] == VALID_ANALYSIS["summary"]
+        assert result["is_ai_generated"] is True
+
+    def test_parses_json_with_markdown_fences(self) -> None:
+        raw = f"```json\n{json.dumps(VALID_ANALYSIS)}\n```"
+        result = _parse_analysis_response(raw)
+        assert result is not None
+        assert result["summary"] == VALID_ANALYSIS["summary"]
+
+    def test_parses_json_with_plain_fences(self) -> None:
+        raw = f"```\n{json.dumps(VALID_ANALYSIS)}\n```"
+        result = _parse_analysis_response(raw)
+        assert result is not None
+
+    def test_returns_none_for_invalid_json(self) -> None:
+        result = _parse_analysis_response("not json at all")
+        assert result is None
+
+    def test_returns_none_for_missing_keys(self) -> None:
+        incomplete = {"summary": "Only a summary"}
+        result = _parse_analysis_response(json.dumps(incomplete))
+        assert result is None
+
+    def test_adds_is_ai_generated(self) -> None:
+        raw = json.dumps(VALID_ANALYSIS)
+        result = _parse_analysis_response(raw)
+        assert result is not None
+        assert result["is_ai_generated"] is True
+
+
+# --- analyze_kaufvertrag ---
+
+
+class TestAnalyzeKaufvertrag:
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_kaufvertrag(self) -> None:
+        result = await analyze_kaufvertrag(SAMPLE_PAGES, "mietvertrag")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_anthropic_not_configured(self) -> None:
+        with patch(
+            "app.services.clause_analyzer_service._get_anthropic_client",
+            return_value=None,
+        ):
+            result = await analyze_kaufvertrag(SAMPLE_PAGES, "kaufvertrag")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_empty_text(self) -> None:
+        empty_pages = [{"page_number": 1, "original_text": ""}]
+        with patch(
+            "app.services.clause_analyzer_service._get_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            result = await analyze_kaufvertrag(empty_pages, "kaufvertrag")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_successful_analysis(self) -> None:
+        mock_client = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=json.dumps(VALID_ANALYSIS))]
+        mock_client.messages.create.return_value = mock_message
+
+        with patch(
+            "app.services.clause_analyzer_service._get_anthropic_client",
+            return_value=mock_client,
+        ):
+            result = await analyze_kaufvertrag(SAMPLE_PAGES, "kaufvertrag")
+
+        assert result is not None
+        assert result["summary"] == VALID_ANALYSIS["summary"]
+        assert len(result["analyzed_clauses"]) == 1
+        assert len(result["notary_checklist"]) == 1
+        assert result["is_ai_generated"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self) -> None:
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = RuntimeError("API error")
+
+        with patch(
+            "app.services.clause_analyzer_service._get_anthropic_client",
+            return_value=mock_client,
+        ):
+            result = await analyze_kaufvertrag(SAMPLE_PAGES, "kaufvertrag")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_invalid_response(self) -> None:
+        mock_client = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text="not valid json")]
+        mock_client.messages.create.return_value = mock_message
+
+        with patch(
+            "app.services.clause_analyzer_service._get_anthropic_client",
+            return_value=mock_client,
+        ):
+            result = await analyze_kaufvertrag(SAMPLE_PAGES, "kaufvertrag")
+            assert result is None

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -37,6 +37,63 @@ export const ActivityTypeSchema = {
     description: 'Types of user activity tracked on the dashboard.'
 } as const;
 
+export const AnalyzedClauseSchema = {
+    properties: {
+        section_name: {
+            type: 'string',
+            title: 'Section Name'
+        },
+        section_name_en: {
+            type: 'string',
+            title: 'Section Name En'
+        },
+        original_text: {
+            type: 'string',
+            title: 'Original Text'
+        },
+        plain_english_explanation: {
+            type: 'string',
+            title: 'Plain English Explanation'
+        },
+        risk_level: {
+            type: 'string',
+            enum: ['low', 'medium', 'high'],
+            title: 'Risk Level'
+        },
+        risk_reason: {
+            type: 'string',
+            title: 'Risk Reason'
+        },
+        is_unusual: {
+            type: 'boolean',
+            title: 'Is Unusual',
+            default: false
+        },
+        unusual_terms: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Unusual Terms'
+        },
+        page_number: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Page Number'
+        }
+    },
+    type: 'object',
+    required: ['section_name', 'section_name_en', 'original_text', 'plain_english_explanation', 'risk_level', 'risk_reason'],
+    title: 'AnalyzedClause',
+    description: 'AI-analyzed clause from a Kaufvertrag.'
+} as const;
+
 export const AnnualCashflowRowResponseSchema = {
     properties: {
         year: {
@@ -1707,6 +1764,16 @@ export const DocumentTranslationResponseSchema = {
             },
             type: 'array',
             title: 'Risk Warnings'
+        },
+        kaufvertrag_analysis: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/KaufvertragAnalysis'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         processing_started_at: {
             anyOf: [
@@ -3458,6 +3525,47 @@ export const JourneysListResponseSchema = {
     description: 'Schema for list of journeys.'
 } as const;
 
+export const KaufvertragAnalysisSchema = {
+    properties: {
+        summary: {
+            type: 'string',
+            title: 'Summary'
+        },
+        analyzed_clauses: {
+            items: {
+                '$ref': '#/components/schemas/AnalyzedClause'
+            },
+            type: 'array',
+            title: 'Analyzed Clauses'
+        },
+        notary_checklist: {
+            items: {
+                '$ref': '#/components/schemas/NotaryQuestion'
+            },
+            type: 'array',
+            title: 'Notary Checklist'
+        },
+        overall_risk_assessment: {
+            type: 'string',
+            enum: ['low', 'medium', 'high'],
+            title: 'Overall Risk Assessment'
+        },
+        overall_risk_explanation: {
+            type: 'string',
+            title: 'Overall Risk Explanation'
+        },
+        is_ai_generated: {
+            type: 'boolean',
+            title: 'Is Ai Generated',
+            default: true
+        }
+    },
+    type: 'object',
+    required: ['summary', 'analyzed_clauses', 'notary_checklist', 'overall_risk_assessment', 'overall_risk_explanation'],
+    title: 'KaufvertragAnalysis',
+    description: 'Full AI analysis of a Kaufvertrag (purchase contract).'
+} as const;
+
 export const LanguageDetectionRequestSchema = {
     properties: {
         text: {
@@ -4059,6 +4167,28 @@ export const NextStepResponseSchema = {
     required: ['has_next'],
     title: 'NextStepResponse',
     description: 'Schema for next recommended step.'
+} as const;
+
+export const NotaryQuestionSchema = {
+    properties: {
+        question: {
+            type: 'string',
+            title: 'Question'
+        },
+        related_clause: {
+            type: 'string',
+            title: 'Related Clause'
+        },
+        priority: {
+            type: 'string',
+            enum: ['essential', 'recommended', 'optional'],
+            title: 'Priority'
+        }
+    },
+    type: 'object',
+    required: ['question', 'related_clause', 'priority'],
+    title: 'NotaryQuestion',
+    description: 'Question to ask a notary about a contract clause.'
 } as const;
 
 export const NotificationListResponseSchema = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -16,6 +16,23 @@ export type ActivityItem = {
  */
 export type ActivityType = 'journey_started' | 'step_completed' | 'document_uploaded' | 'calculation_saved' | 'roi_calculated' | 'financing_assessed' | 'law_bookmarked';
 
+/**
+ * AI-analyzed clause from a Kaufvertrag.
+ */
+export type AnalyzedClause = {
+    section_name: string;
+    section_name_en: string;
+    original_text: string;
+    plain_english_explanation: string;
+    risk_level: 'low' | 'medium' | 'high';
+    risk_reason: string;
+    is_unusual?: boolean;
+    unusual_terms?: Array<(string)>;
+    page_number?: (number | null);
+};
+
+export type risk_level = 'low' | 'medium' | 'high';
+
 export type AnnualCashflowRowResponse = {
     year?: number;
     cold_rent?: number;
@@ -508,6 +525,7 @@ export type DocumentTranslationResponse = {
     translated_pages: Array<TranslatedPage>;
     clauses_detected: Array<DetectedClause>;
     risk_warnings: Array<DocumentRiskWarning>;
+    kaufvertrag_analysis?: (KaufvertragAnalysis | null);
     processing_started_at?: (string | null);
     processing_completed_at?: (string | null);
 };
@@ -988,6 +1006,20 @@ export type JourneyUpdate = {
 };
 
 /**
+ * Full AI analysis of a Kaufvertrag (purchase contract).
+ */
+export type KaufvertragAnalysis = {
+    summary: string;
+    analyzed_clauses: Array<AnalyzedClause>;
+    notary_checklist: Array<NotaryQuestion>;
+    overall_risk_assessment: 'low' | 'medium' | 'high';
+    overall_risk_explanation: string;
+    is_ai_generated?: boolean;
+};
+
+export type overall_risk_assessment = 'low' | 'medium' | 'high';
+
+/**
  * Request schema for language detection.
  */
 export type LanguageDetectionRequest = {
@@ -1175,6 +1207,17 @@ export type NextStepResponse = {
     step?: (JourneyStepResponse | null);
     message?: (string | null);
 };
+
+/**
+ * Question to ask a notary about a contract clause.
+ */
+export type NotaryQuestion = {
+    question: string;
+    related_clause: string;
+    priority: 'essential' | 'recommended' | 'optional';
+};
+
+export type priority = 'essential' | 'recommended' | 'optional';
 
 /**
  * Paginated list of notifications.

--- a/frontend/src/components/Documents/ClauseAnalysis.tsx
+++ b/frontend/src/components/Documents/ClauseAnalysis.tsx
@@ -1,0 +1,299 @@
+/**
+ * Clause Analysis Component
+ * AI-analyzed Kaufvertrag clauses with risk ratings, explanations, and notary checklist
+ */
+
+import {
+  AlertTriangle,
+  Bot,
+  CheckSquare,
+  ChevronDown,
+  ChevronRight,
+  Square,
+} from "lucide-react"
+import { useCallback, useState } from "react"
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type {
+  KaufvertragAnalysis,
+  NotaryQuestion as NotaryQuestionModel,
+} from "@/models/document"
+
+interface IProps {
+  analysis: KaufvertragAnalysis
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const RISK_LEVEL_STYLES: Record<string, string> = {
+  high: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  medium:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+}
+
+const PRIORITY_STYLES: Record<string, string> = {
+  essential: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  recommended:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  optional: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+interface INotaryChecklistProps {
+  questions: NotaryQuestionModel[]
+}
+
+/** Notary checklist with interactive checkboxes. */
+function NotaryChecklist(props: Readonly<INotaryChecklistProps>) {
+  const { questions } = props
+  const [checkedQuestions, setCheckedQuestions] = useState<Set<number>>(
+    new Set(),
+  )
+
+  const toggleQuestion = useCallback((index: number) => {
+    setCheckedQuestions((prev) => {
+      const next = new Set(prev)
+      if (next.has(index)) {
+        next.delete(index)
+      } else {
+        next.add(index)
+      }
+      return next
+    })
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium">
+          What to Ask Your Notary
+          <Badge variant="outline" className="ml-2 text-xs">
+            {checkedQuestions.size}/{questions.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {questions.map((item, i) => {
+          const isChecked = checkedQuestions.has(i)
+          return (
+            <button
+              key={i}
+              type="button"
+              className="flex items-start gap-3 w-full text-left p-2 rounded-md hover:bg-muted/50 transition-colors"
+              onClick={() => toggleQuestion(i)}
+            >
+              {isChecked ? (
+                <CheckSquare className="h-4 w-4 shrink-0 mt-0.5 text-primary" />
+              ) : (
+                <Square className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" />
+              )}
+              <div className="min-w-0 flex-1">
+                <p
+                  className={cn(
+                    "text-sm",
+                    isChecked && "line-through text-muted-foreground",
+                  )}
+                >
+                  {item.question}
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  <Badge
+                    variant="outline"
+                    className={cn("text-xs", PRIORITY_STYLES[item.priority])}
+                  >
+                    {item.priority}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {item.relatedClause}
+                  </span>
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Default component. AI-analyzed Kaufvertrag clauses and notary checklist. */
+function ClauseAnalysis(props: Readonly<IProps>) {
+  const { analysis } = props
+  const [expandedClauses, setExpandedClauses] = useState<Set<number>>(new Set())
+
+  const toggleClause = useCallback((index: number) => {
+    setExpandedClauses((prev) => {
+      const next = new Set(prev)
+      if (next.has(index)) {
+        next.delete(index)
+      } else {
+        next.add(index)
+      }
+      return next
+    })
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      {/* AI attribution + overall risk */}
+      <Card>
+        <CardContent className="pt-4">
+          <div className="flex items-center gap-2 mb-3">
+            <Bot className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">
+              AI-generated analysis — always verify with your notary
+            </span>
+          </div>
+          <div className="flex items-start gap-3">
+            <Badge
+              variant="outline"
+              className={cn(
+                "text-sm shrink-0",
+                RISK_LEVEL_STYLES[analysis.overallRiskAssessment],
+              )}
+            >
+              {analysis.overallRiskAssessment} risk
+            </Badge>
+            <p className="text-sm text-muted-foreground">
+              {analysis.overallRiskExplanation}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Contract summary */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">
+            Contract Summary
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm">{analysis.summary}</p>
+        </CardContent>
+      </Card>
+
+      {/* Analyzed clauses */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">
+            Analyzed Clauses
+            <Badge variant="outline" className="ml-2 text-xs">
+              {analysis.analyzedClauses.length}
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {analysis.analyzedClauses.map((clause, i) => {
+            const isExpanded = expandedClauses.has(i)
+            return (
+              <div key={clause.sectionName} className="border rounded-md">
+                <button
+                  type="button"
+                  className="flex items-center justify-between w-full p-3 text-left hover:bg-muted/50 transition-colors"
+                  onClick={() => toggleClause(i)}
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    {isExpanded ? (
+                      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="text-sm font-medium truncate">
+                      {clause.sectionNameEn}
+                    </span>
+                    <span className="text-xs text-muted-foreground truncate">
+                      ({clause.sectionName})
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0 ml-2">
+                    {clause.pageNumber && (
+                      <span className="text-xs text-muted-foreground">
+                        p.{clause.pageNumber}
+                      </span>
+                    )}
+                    {clause.isUnusual && (
+                      <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+                    )}
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "text-xs",
+                        RISK_LEVEL_STYLES[clause.riskLevel],
+                      )}
+                    >
+                      {clause.riskLevel}
+                    </Badge>
+                  </div>
+                </button>
+
+                {isExpanded && (
+                  <div className="px-3 pb-3 space-y-3 border-t pt-3">
+                    <div>
+                      <p className="text-xs text-muted-foreground mb-1">
+                        Original German
+                      </p>
+                      <p className="text-sm bg-muted/50 rounded p-2">
+                        {clause.originalText}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground mb-1">
+                        Plain English Explanation
+                      </p>
+                      <p className="text-sm">
+                        {clause.plainEnglishExplanation}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground mb-1">
+                        Risk Assessment
+                      </p>
+                      <p className="text-sm">{clause.riskReason}</p>
+                    </div>
+                    {clause.unusualTerms.length > 0 && (
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">
+                          Unusual Terms
+                        </p>
+                        <div className="flex flex-wrap gap-1">
+                          {clause.unusualTerms.map((term) => (
+                            <Badge
+                              key={term}
+                              variant="outline"
+                              className="text-xs bg-amber-50 text-amber-800 dark:bg-amber-900/20 dark:text-amber-400"
+                            >
+                              {term}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+
+      {/* Notary checklist */}
+      {analysis.notaryChecklist.length > 0 && (
+        <NotaryChecklist questions={analysis.notaryChecklist} />
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ClauseAnalysis }

--- a/frontend/src/components/Documents/index.ts
+++ b/frontend/src/components/Documents/index.ts
@@ -2,6 +2,7 @@
  * Documents component barrel exports
  */
 
+export { ClauseAnalysis } from "./ClauseAnalysis"
 export { ClauseHighlights } from "./ClauseHighlights"
 export { DocumentCard } from "./DocumentCard"
 export { DocumentList } from "./DocumentList"

--- a/frontend/src/models/document.ts
+++ b/frontend/src/models/document.ts
@@ -49,6 +49,33 @@ export interface DocumentRiskWarning {
   pageNumber: number | null
 }
 
+export interface AnalyzedClause {
+  sectionName: string
+  sectionNameEn: string
+  originalText: string
+  plainEnglishExplanation: string
+  riskLevel: string
+  riskReason: string
+  isUnusual: boolean
+  unusualTerms: string[]
+  pageNumber: number | null
+}
+
+export interface NotaryQuestion {
+  question: string
+  relatedClause: string
+  priority: string
+}
+
+export interface KaufvertragAnalysis {
+  summary: string
+  analyzedClauses: AnalyzedClause[]
+  notaryChecklist: NotaryQuestion[]
+  overallRiskAssessment: string
+  overallRiskExplanation: string
+  isAiGenerated: boolean
+}
+
 export interface DocumentTranslation {
   id: string
   documentId: string
@@ -57,6 +84,7 @@ export interface DocumentTranslation {
   translatedPages: TranslatedPage[]
   clausesDetected: DetectedClause[]
   riskWarnings: DocumentRiskWarning[]
+  kaufvertragAnalysis: KaufvertragAnalysis | null
   processingStartedAt: string | null
   processingCompletedAt: string | null
 }

--- a/frontend/src/routes/_layout/documents/$documentId.tsx
+++ b/frontend/src/routes/_layout/documents/$documentId.tsx
@@ -7,6 +7,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { ArrowLeft, FileText, Share2, Trash2 } from "lucide-react"
 import { useCallback, useState } from "react"
 import {
+  ClauseAnalysis,
   ClauseHighlights,
   ProcessingStatus,
   RiskWarnings,
@@ -174,6 +175,10 @@ function DocumentDetailPage() {
             <TabsTrigger value="warnings">
               Warnings ({translation.riskWarnings.length})
             </TabsTrigger>
+            {doc.documentType === "kaufvertrag" &&
+              translation.kaufvertragAnalysis && (
+                <TabsTrigger value="analysis">AI Analysis</TabsTrigger>
+              )}
           </TabsList>
 
           <TabsContent value="translation" className="mt-4">
@@ -187,6 +192,13 @@ function DocumentDetailPage() {
           <TabsContent value="warnings" className="mt-4">
             <RiskWarnings warnings={translation.riskWarnings} />
           </TabsContent>
+
+          {doc.documentType === "kaufvertrag" &&
+            translation.kaufvertragAnalysis && (
+              <TabsContent value="analysis" className="mt-4">
+                <ClauseAnalysis analysis={translation.kaufvertragAnalysis} />
+              </TabsContent>
+            )}
         </Tabs>
       )}
     </div>

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.96.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -210,6 +229,7 @@ source = { editable = "backend" }
 dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
+    { name = "anthropic" },
     { name = "asyncpg" },
     { name = "azure-ai-translation-text" },
     { name = "email-validator" },
@@ -249,6 +269,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "alembic", specifier = ">=1.12.1,<2.0.0" },
+    { name = "anthropic", specifier = ">=0.49.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "azure-ai-translation-text", specifier = ">=1.0.0" },
     { name = "email-validator", specifier = ">=2.1.0.post1,<3.0.0.0" },
@@ -903,12 +924,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1449,6 +1488,109 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/2e/a9959997739c403378d0a4a3a1c4ed80b60aeace216c4d37b303a9fc60a4/jiter-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:02f36a5c700f105ac04a6556fe664a59037a2c200db3b7e88784fac2ddf02531", size = 316927, upload-time = "2026-04-10T14:25:40.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/72/b6de8a531e0adbadd839bec301165feb1fccf00e9ff55073ba2dd20f0043/jiter-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41eab6c09ceffb6f0fe25e214b3068146edb1eda3649ca2aee2a061029c7ba2e", size = 321181, upload-time = "2026-04-10T14:25:42.621Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d8/2040b9efa13c917f855c40890ae4119fe02c25b7c7677d5b4fa820a851fc/jiter-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cf4d4c109641f9cfaf4a7b6aebd51654e405cd00fa9ebbf87163b8b97b325aa", size = 347387, upload-time = "2026-04-10T14:25:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/655c0ad5ce6a8e90f9068c175b8a236877d753e460762b3183c136db1c5b/jiter-0.14.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b80c7b41a628e6be2213ad0ece763c5f88aa5ee003fa394d58acaaee1f4b8342", size = 373083, upload-time = "2026-04-10T14:25:45.55Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/66/549c40fa068f08710b7570869c306a051eb67a29758bd64f4114f730554c/jiter-0.14.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb3dbf7cc0d4dbe73cce307ebe7eefa7f73a7d3d854dd119ea0c243f03e40927", size = 463639, upload-time = "2026-04-10T14:25:47.452Z" },
+    { url = "https://files.pythonhosted.org/packages/25/2f/97a32a05fed14ed58a18e181fdfb619e05163f3726b54ee6080ec0539c09/jiter-0.14.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7054adcdeb06b46efd17b5734f75817a44a2d06d3748e36c3a023a1bb52af9ec", size = 380735, upload-time = "2026-04-10T14:25:49.305Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/3b/4347e1d6c2a973d653bbb7a2d671a2d2426e54b52ba735b8ff0d0a29b75c/jiter-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d597cd1bf6790376f3fffc7c708766e57301d99a19314824ea0ccc9c3c70e1e2", size = 358632, upload-time = "2026-04-10T14:25:50.931Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/24/ca452fbf2ea33548ed30ce68a39a50442d3f7c9bf0704a7af958a930c057/jiter-0.14.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:df63a14878da754427926281626fd3ee249424a186e25a274e78176d42945264", size = 359969, upload-time = "2026-04-10T14:25:52.381Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a3/94470a0d199287caabeb4da2bb2ae5f6d17f3cf05dfc975d7cb064d58e0f/jiter-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4ea73187627bcc5810e085df715e8a99da8bdfd96a7eb36b4b4df700ba6d4c9c", size = 397529, upload-time = "2026-04-10T14:25:53.801Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/71/6768edc09d7c45c39f093feb3de105fa718a3e982b5208b8a2ed6382b44b/jiter-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9f541eaf7bb8382367a1a23d6fc3d6aad57f8dd8c18c3c17f838bee20f217220", size = 522342, upload-time = "2026-04-10T14:25:55.396Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6b/5c2e17559a0f4e96e934479f7137df46c939e983fa05244e674815befb73/jiter-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:107465250de4fce00fdb47166bcd51df8e634e049541174fe3c71848e44f52ce", size = 556784, upload-time = "2026-04-10T14:25:56.927Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/83/c25f3556a60fc74d11199100f1b6cc0c006b815c8494dea8ca16fe398732/jiter-0.14.0-cp310-cp310-win32.whl", hash = "sha256:ffb2a08a406465bb076b7cc1df41d833106d3cf7905076cc73f0cb90078c7d10", size = 208439, upload-time = "2026-04-10T14:25:58.796Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/99/781a1b413f0989b7f2ea203b094b331685f1a35e52e0a45e5d000ecaab27/jiter-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:cb8b682d10cb0cce7ff4c1af7244af7022c9b01ae16d46c357bdd0df13afb25d", size = 204558, upload-time = "2026-04-10T14:26:00.208Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
 ]
 
 [[package]]
@@ -2979,6 +3121,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Anthropic Claude integration to analyze Kaufvertrag (purchase contract) documents clause-by-clause
- Produce risk ratings (high/medium/low), plain-English explanations, and a "What to ask your notary" checklist
- Analysis runs automatically during document processing when `document_type == kaufvertrag` and `ANTHROPIC_API_KEY` is configured
- Results stored in a new `kaufvertrag_analysis` JSONB column and displayed in a new "AI Analysis" tab on the document detail page
- Gracefully degrades: no API key = no analysis, non-Kaufvertrag docs unaffected

## Changes
### Backend
- Add `anthropic>=0.49.0` dependency
- Add `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`, `ANTHROPIC_MAX_TOKENS` config settings
- Add `AnalyzedClause`, `NotaryQuestion`, `KaufvertragAnalysis` Pydantic schemas
- Add `kaufvertrag_analysis` JSONB column to `DocumentTranslation` model + Alembic migration
- Create `clause_analyzer_service.py` with Claude API integration
- Integrate analysis step into `process_document()` pipeline

### Frontend
- Add `AnalyzedClause`, `NotaryQuestion`, `KaufvertragAnalysis` TypeScript interfaces
- Create `ClauseAnalysis` component with expandable clause cards, risk badges, and interactive notary checklist
- Add "AI Analysis" tab to document detail page (conditional on Kaufvertrag + analysis data)

## Test plan
- [x] 16 unit tests for clause analyzer service (all pass)
- [x] 998 backend tests pass (no regressions)
- [x] TypeScript compiles with no errors
- [x] Pre-commit hooks pass (biome, ruff, SDK generation)
- [x] With API key: upload Kaufvertrag PDF → AI Analysis tab appears with clause cards + notary checklist
- [x] Without API key: upload Kaufvertrag → existing tabs work, no AI Analysis tab
- [x] Non-Kaufvertrag: upload other doc type → no AI Analysis tab