### PR TITLE
fix(documents): replace array index key in notary checklist

### DIFF
--- a/frontend/src/components/Documents/ClauseAnalysis.tsx
+++ b/frontend/src/components/Documents/ClauseAnalysis.tsx
@@ -84,7 +84,7 @@ function NotaryChecklist(props: Readonly<INotaryChecklistProps>) {
           const isChecked = checkedQuestions.has(i)
           return (
             <button
-              key={i}
+              key={item.question}
               type="button"
               className="flex items-start gap-3 w-full text-left p-2 rounded-md hover:bg-muted/50 transition-colors"
               onClick={() => toggleQuestion(i)}


### PR DESCRIPTION
## Summary
- Fix SonarCloud issue S6479 from PR #106: replace `key={i}` with `key={item.question}` in NotaryChecklist component
- Array index keys can cause React reconciliation issues; question text is a stable unique identifier

## Test plan
- [x] `tsc --noEmit` passes
- [x] Pre-commit hooks pass
- [ ] SonarCloud issue resolves on this PR