### PR TITLE
feat(onboarding): add guided first-session onboarding wizard

### DIFF
--- a/backend/app/_models_sqlmodel.py
+++ b/backend/app/_models_sqlmodel.py
@@ -50,6 +50,8 @@ class UserUpdateMe(SQLModel):
     full_name: str | None = Field(default=None, max_length=255)
     email: EmailStr | None = Field(default=None, max_length=255)
     citizenship: str | None = Field(default=None, max_length=50)
+    onboarding_completed: bool | None = None
+    onboarding_persona: str | None = Field(default=None, max_length=50)
 
 
 class UpdatePassword(SQLModel):
@@ -62,6 +64,8 @@ class User(UserBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     hashed_password: str
     email_verified: bool = Field(default=False)
+    onboarding_completed: bool = Field(default=False)
+    onboarding_persona: str | None = Field(default=None, max_length=50)
     subscription_tier: SubscriptionTier = Field(
         default=SubscriptionTier.FREE,
         sa_column=Column(
@@ -85,6 +89,8 @@ class User(UserBase, table=True):
 class UserPublic(UserBase):
     id: uuid.UUID
     email_verified: bool = False
+    onboarding_completed: bool = False
+    onboarding_persona: str | None = None
     subscription_tier: SubscriptionTier = SubscriptionTier.FREE
     created_at: datetime | None = None
 

--- a/backend/app/alembic/versions/z2v3w4x5y6a7_add_onboarding_fields_to_user.py
+++ b/backend/app/alembic/versions/z2v3w4x5y6a7_add_onboarding_fields_to_user.py
@@ -1,0 +1,39 @@
+"""Add onboarding fields to user
+
+Revision ID: z2v3w4x5y6a7
+Revises: y1u2v3w4x5z6
+Create Date: 2026-04-19 18:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "z2v3w4x5y6a7"
+down_revision = "y1u2v3w4x5z6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column(
+            "onboarding_completed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "user",
+        sa.Column("onboarding_persona", sa.String(50), nullable=True),
+    )
+    # Mark existing users as onboarded — they've already been using the app
+    op.execute("UPDATE \"user\" SET onboarding_completed = true")
+
+
+def downgrade() -> None:
+    op.drop_column("user", "onboarding_persona")
+    op.drop_column("user", "onboarding_completed")

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -33,6 +33,9 @@ def init_db(session: Session) -> None:
             is_superuser=True,
         )
         user = crud.create_user(session=session, user_create=user_in)
+        user.onboarding_completed = True
+        session.add(user)
+        session.commit()
 
     seed_laws(session)
     seed_professionals(session)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -47,6 +47,8 @@ class UserUpdateMe(BaseModel):
     full_name: str | None = Field(default=None, max_length=255)
     email: EmailStr | None = Field(default=None, max_length=255)
     citizenship: str | None = Field(default=None, max_length=50)
+    onboarding_completed: bool | None = None
+    onboarding_persona: str | None = Field(default=None, max_length=50)
 
 
 class UpdatePassword(BaseModel):
@@ -64,6 +66,8 @@ class UserPublic(UserBase):
     id: uuid.UUID
     created_at: datetime
     email_verified: bool = False
+    onboarding_completed: bool = False
+    onboarding_persona: str | None = None
 
 
 class UsersPublic(BaseModel):
@@ -131,6 +135,8 @@ class UserDataExport(BaseModel):
     citizenship: str | None = None
     is_active: bool
     email_verified: bool
+    onboarding_completed: bool = False
+    onboarding_persona: str | None = None
     subscription_tier: str
     created_at: datetime
     updated_at: datetime | None = None

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -221,6 +221,53 @@ def test_update_user_me(
     assert user_db.full_name == full_name
 
 
+def test_user_onboarding_defaults(client: TestClient, db: Session) -> None:
+    """New users should have onboarding_completed=False by default."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    crud.create_user(session=db, user_create=user_in)
+
+    login_data = {"username": username, "password": password}
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    headers = {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+    r = client.get(f"{settings.API_V1_STR}/users/me", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["onboarding_completed"] is False
+    assert r.json()["onboarding_persona"] is None
+
+
+def test_update_onboarding_status(client: TestClient, db: Session) -> None:
+    """Users can update their onboarding status via PATCH /me."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    crud.create_user(session=db, user_create=user_in)
+
+    login_data = {"username": username, "password": password}
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    headers = {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+    data = {"onboarding_completed": True, "onboarding_persona": "explorer"}
+    r = client.patch(
+        f"{settings.API_V1_STR}/users/me",
+        headers=headers,
+        json=data,
+    )
+    assert r.status_code == 200
+    updated_user = r.json()
+    assert updated_user["onboarding_completed"] is True
+    assert updated_user["onboarding_persona"] == "explorer"
+
+    # Verify persisted in DB
+    user_query = select(User).where(User.email == username)
+    user_db = db.exec(user_query).first()
+    assert user_db
+    assert user_db.onboarding_completed is True
+    assert user_db.onboarding_persona == "explorer"
+
+
 def test_update_password_me(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8377,6 +8377,22 @@ export const UserDataExportSchema = {
             type: 'boolean',
             title: 'Email Verified'
         },
+        onboarding_completed: {
+            type: 'boolean',
+            title: 'Onboarding Completed',
+            default: false
+        },
+        onboarding_persona: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Onboarding Persona'
+        },
         subscription_tier: {
             type: 'string',
             title: 'Subscription Tier'
@@ -8467,6 +8483,22 @@ export const UserPublicSchema = {
             type: 'boolean',
             title: 'Email Verified',
             default: false
+        },
+        onboarding_completed: {
+            type: 'boolean',
+            title: 'Onboarding Completed',
+            default: false
+        },
+        onboarding_persona: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Onboarding Persona'
         },
         subscription_tier: {
             '$ref': '#/components/schemas/SubscriptionTier',
@@ -8627,6 +8659,29 @@ export const UserUpdateMeSchema = {
                 }
             ],
             title: 'Citizenship'
+        },
+        onboarding_completed: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Onboarding Completed'
+        },
+        onboarding_persona: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 50
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Onboarding Persona'
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2360,6 +2360,8 @@ export type UserDataExport = {
     citizenship?: (string | null);
     is_active: boolean;
     email_verified: boolean;
+    onboarding_completed?: boolean;
+    onboarding_persona?: (string | null);
     subscription_tier: string;
     created_at: string;
     updated_at?: (string | null);
@@ -2374,6 +2376,8 @@ export type UserPublic = {
     citizenship?: (string | null);
     id: string;
     email_verified?: boolean;
+    onboarding_completed?: boolean;
+    onboarding_persona?: (string | null);
     subscription_tier?: SubscriptionTier;
     created_at?: (string | null);
 };
@@ -2402,6 +2406,8 @@ export type UserUpdateMe = {
     full_name?: (string | null);
     email?: (string | null);
     citizenship?: (string | null);
+    onboarding_completed?: (boolean | null);
+    onboarding_persona?: (string | null);
 };
 
 export type ValidationError = {

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -18,6 +18,7 @@ import {
 
 import { cn } from "@/common/utils"
 import { ProgressBar } from "@/components/Journey/ProgressBar"
+import { GettingStartedChecklist } from "@/components/Onboarding"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -509,7 +510,7 @@ function DashboardSkeleton() {
 }
 
 /** Default component. Main dashboard layout. */
-function DashboardPage(props: IProps) {
+function DashboardPage(props: Readonly<IProps>) {
   const { data, isLoading, userName } = props
 
   if (isLoading || !data) {
@@ -540,6 +541,7 @@ function DashboardPage(props: IProps) {
 
         {/* Right column: 1/3 width */}
         <div className="space-y-6">
+          <GettingStartedChecklist data={data} />
           <QuickActions journeyId={data.journey?.id} />
           <ActivityTimeline activities={data.recentActivity} />
           <UsageStats

--- a/frontend/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/frontend/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -1,0 +1,177 @@
+/**
+ * Getting Started Checklist Component
+ * Dashboard widget guiding new users through key first actions
+ */
+
+import { Link } from "@tanstack/react-router"
+import {
+  ArrowRight,
+  BookOpen,
+  Calculator,
+  CheckCircle2,
+  Circle,
+  MapIcon,
+  Upload,
+} from "lucide-react"
+
+import { cn } from "@/common/utils"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import type { DashboardOverview } from "@/models/dashboard"
+
+interface IProps {
+  data: DashboardOverview
+  className?: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+interface ChecklistItem {
+  id: string
+  label: string
+  icon: typeof MapIcon
+  to: string
+  search?: Record<string, string>
+}
+
+const CHECKLIST_ITEMS: ReadonlyArray<ChecklistItem> = [
+  {
+    id: "journey",
+    label: "Start a property journey",
+    icon: MapIcon,
+    to: "/journeys/new",
+  },
+  {
+    id: "calculator",
+    label: "Calculate hidden costs",
+    icon: Calculator,
+    to: "/calculators",
+    search: { tab: "hidden-costs" },
+  },
+  {
+    id: "document",
+    label: "Upload a document",
+    icon: Upload,
+    to: "/documents",
+  },
+  {
+    id: "laws",
+    label: "Browse German property laws",
+    icon: BookOpen,
+    to: "/laws",
+  },
+]
+
+/******************************************************************************
+                              Functions
+******************************************************************************/
+
+function getCompletedItems(data: DashboardOverview): Set<string> {
+  const completed = new Set<string>()
+  if (data.hasJourney) completed.add("journey")
+  if (data.totalCalculations > 0) completed.add("calculator")
+  if (data.recentDocuments.length > 0) completed.add("document")
+  if (data.totalBookmarks > 0) completed.add("laws")
+  return completed
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Single checklist row. */
+function ChecklistRow(
+  props: Readonly<{
+    item: ChecklistItem
+    completed: boolean
+  }>,
+) {
+  const { item, completed } = props
+  const Icon = item.icon
+
+  return (
+    <Link
+      to={item.to}
+      {...(item.search ? { search: item.search } : {})}
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors",
+        completed ? "text-muted-foreground" : "hover:bg-muted/50",
+      )}
+    >
+      {completed ? (
+        <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
+      ) : (
+        <Circle className="h-5 w-5 shrink-0 text-muted-foreground/40" />
+      )}
+      <Icon
+        className={cn(
+          "h-4 w-4 shrink-0",
+          completed ? "text-muted-foreground" : "text-foreground",
+        )}
+      />
+      <span className={cn("flex-1 text-sm", completed && "line-through")}>
+        {item.label}
+      </span>
+      {!completed && (
+        <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+      )}
+    </Link>
+  )
+}
+
+/** Default component. Getting started checklist widget. */
+function GettingStartedChecklist(props: Readonly<IProps>) {
+  const { data, className } = props
+  const completedItems = getCompletedItems(data)
+  const completedCount = completedItems.size
+  const totalCount = CHECKLIST_ITEMS.length
+  const allComplete = completedCount >= totalCount
+
+  if (allComplete) return null
+
+  const progressPercent = Math.round((completedCount / totalCount) * 100)
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">Getting Started</CardTitle>
+          <span className="text-xs text-muted-foreground">
+            {completedCount}/{totalCount}
+          </span>
+        </div>
+        <CardDescription>
+          Complete these steps to get the most out of HeimPath
+        </CardDescription>
+        <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-0.5 pt-0">
+        {CHECKLIST_ITEMS.map((item) => (
+          <ChecklistRow
+            key={item.id}
+            item={item}
+            completed={completedItems.has(item.id)}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { GettingStartedChecklist }

--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -1,0 +1,416 @@
+/**
+ * Onboarding Wizard Component
+ * 3-step modal wizard for new users to set goals and get a recommended first action
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import {
+  ArrowRight,
+  BookOpen,
+  Building2,
+  Calculator,
+  Check,
+  Compass,
+  DollarSign,
+  Landmark,
+  MapIcon,
+  TrendingUp,
+} from "lucide-react"
+import { useState } from "react"
+
+import { UsersService, type UserUpdateMe } from "@/client"
+import { cn } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import useCustomToast from "@/hooks/useCustomToast"
+import { handleError } from "@/utils"
+
+interface IProps {
+  open: boolean
+  onComplete: () => void
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+type Persona = "explorer" | "settler" | "investor"
+type Priority =
+  | "understand_costs"
+  | "find_financing"
+  | "start_journey"
+  | "evaluate_property"
+
+const PERSONAS: ReadonlyArray<{
+  id: Persona
+  label: string
+  description: string
+  icon: typeof Compass
+}> = [
+  {
+    id: "explorer",
+    label: "Explorer",
+    description:
+      "Researching German property from abroad — just getting started",
+    icon: Compass,
+  },
+  {
+    id: "settler",
+    label: "Settler",
+    description: "Already in Germany, ready to buy my first property",
+    icon: Building2,
+  },
+  {
+    id: "investor",
+    label: "Investor",
+    description: "Looking to invest in German real estate for returns",
+    icon: TrendingUp,
+  },
+]
+
+const PRIORITIES: ReadonlyArray<{
+  id: Priority
+  label: string
+  description: string
+  icon: typeof Calculator
+}> = [
+  {
+    id: "understand_costs",
+    label: "Understand Costs",
+    description: "Learn about hidden costs, taxes, and fees",
+    icon: DollarSign,
+  },
+  {
+    id: "find_financing",
+    label: "Find Financing",
+    description: "Check mortgage eligibility as a foreign buyer",
+    icon: Landmark,
+  },
+  {
+    id: "start_journey",
+    label: "Start My Journey",
+    description: "Get a personalized step-by-step buying guide",
+    icon: MapIcon,
+  },
+  {
+    id: "evaluate_property",
+    label: "Evaluate a Property",
+    description: "Analyze a property's costs and potential returns",
+    icon: Calculator,
+  },
+]
+
+const PRIORITY_CONFIG: Record<
+  Priority,
+  {
+    route: string
+    search?: Record<string, string>
+    cta: string
+    detail: string
+  }
+> = {
+  understand_costs: {
+    route: "/calculators",
+    search: { tab: "hidden-costs" },
+    cta: "Calculate Hidden Costs",
+    detail:
+      "Use our Hidden Costs Calculator to see the real total cost of buying property in any German state — including taxes, notary fees, and agent commissions.",
+  },
+  find_financing: {
+    route: "/calculators",
+    search: { tab: "financing" },
+    cta: "Check Financing Eligibility",
+    detail:
+      "Check your mortgage eligibility as a foreign buyer. We'll assess your situation and show which banks are most likely to approve your application.",
+  },
+  start_journey: {
+    route: "/journeys/new",
+    cta: "Start My Journey",
+    detail:
+      "Get a personalised step-by-step guide tailored to your citizenship and situation. We'll walk you through every phase from research to closing.",
+  },
+  evaluate_property: {
+    route: "/calculators",
+    search: { tab: "property-evaluation" },
+    cta: "Evaluate a Property",
+    detail:
+      "Found a listing? Enter the details and we'll calculate your monthly costs, cashflow projections, and expected return on investment.",
+  },
+}
+
+const STEP_TITLES = [
+  "What best describes your situation?",
+  "What's your top priority right now?",
+  "Here's your recommended first step",
+] as const
+
+const STEP_DESCRIPTIONS = [
+  "This helps us personalise your experience.",
+  "We'll point you to the best starting point.",
+  "You can always explore other features from the dashboard.",
+] as const
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Step indicator dots. */
+function StepIndicator(props: Readonly<{ current: number; total: number }>) {
+  const { current, total } = props
+
+  return (
+    <div className="flex items-center justify-center gap-2">
+      {Array.from({ length: total }).map((_, i) => (
+        <div
+          key={`step-${i + 1}`}
+          className={cn(
+            "h-2 w-2 rounded-full transition-colors",
+            i <= current ? "bg-primary" : "bg-muted",
+          )}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** Selectable option card. */
+function OptionCard(
+  props: Readonly<{
+    icon: typeof Compass
+    label: string
+    description: string
+    selected: boolean
+    onClick: () => void
+  }>,
+) {
+  const { icon: Icon, label, description, selected, onClick } = props
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-lg border p-4 text-left transition-colors",
+        selected
+          ? "border-primary bg-primary/5 ring-1 ring-primary"
+          : "hover:border-muted-foreground/30 hover:bg-muted/50",
+      )}
+    >
+      <div
+        className={cn(
+          "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+          selected ? "bg-primary text-primary-foreground" : "bg-muted",
+        )}
+      >
+        <Icon className="h-5 w-5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">{label}</p>
+        <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+      </div>
+      {selected && <Check className="mt-1 h-5 w-5 shrink-0 text-primary" />}
+    </button>
+  )
+}
+
+/** Step 1: Choose persona. */
+function PersonaStep(
+  props: Readonly<{
+    selected: Persona | null
+    onSelect: (persona: Persona) => void
+  }>,
+) {
+  const { selected, onSelect } = props
+
+  return (
+    <div className="space-y-3">
+      {PERSONAS.map((persona) => (
+        <OptionCard
+          key={persona.id}
+          icon={persona.icon}
+          label={persona.label}
+          description={persona.description}
+          selected={selected === persona.id}
+          onClick={() => onSelect(persona.id)}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** Step 2: Choose priority. */
+function PriorityStep(
+  props: Readonly<{
+    selected: Priority | null
+    onSelect: (priority: Priority) => void
+  }>,
+) {
+  const { selected, onSelect } = props
+
+  return (
+    <div className="space-y-3">
+      {PRIORITIES.map((priority) => (
+        <OptionCard
+          key={priority.id}
+          icon={priority.icon}
+          label={priority.label}
+          description={priority.description}
+          selected={selected === priority.id}
+          onClick={() => onSelect(priority.id)}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** Step 3: Recommended action. */
+function RecommendationStep(props: Readonly<{ priority: Priority }>) {
+  const { priority } = props
+  const Icon = PRIORITIES.find((p) => p.id === priority)?.icon ?? BookOpen
+  const config = PRIORITY_CONFIG[priority]
+
+  return (
+    <div className="space-y-4 text-center">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+        <Icon className="h-8 w-8 text-primary" />
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold">{config.cta}</h3>
+        <p className="text-sm text-muted-foreground">{config.detail}</p>
+      </div>
+    </div>
+  )
+}
+
+/** Default component. 3-step onboarding wizard modal. */
+function OnboardingWizard(props: Readonly<IProps>) {
+  const { open, onComplete } = props
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { showErrorToast } = useCustomToast()
+
+  const [step, setStep] = useState(0)
+  const [persona, setPersona] = useState<Persona | null>(null)
+  const [priority, setPriority] = useState<Priority | null>(null)
+  const [navigateTo, setNavigateTo] = useState<Priority | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: (data: UserUpdateMe) =>
+      UsersService.updateUserMe({ requestBody: data }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["currentUser"] })
+      onComplete()
+      if (navigateTo) {
+        const config = PRIORITY_CONFIG[navigateTo]
+        navigate({
+          to: config.route,
+          ...(config.search ? { search: config.search } : {}),
+        })
+      }
+    },
+    onError: handleError.bind(showErrorToast),
+  })
+
+  const handleNext = () => {
+    if (step < 2) {
+      setStep(step + 1)
+    }
+  }
+
+  const handleBack = () => {
+    if (step > 0) {
+      setStep(step - 1)
+    }
+  }
+
+  const handleComplete = () => {
+    setNavigateTo(null)
+    mutation.mutate({
+      onboarding_completed: true,
+      onboarding_persona: persona,
+    })
+  }
+
+  const handleGoToAction = () => {
+    if (!priority) return
+    setNavigateTo(priority)
+    mutation.mutate({
+      onboarding_completed: true,
+      onboarding_persona: persona,
+    })
+  }
+
+  const canProceed =
+    (step === 0 && persona !== null) ||
+    (step === 1 && priority !== null) ||
+    step === 2
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        className="sm:max-w-md [&>button]:hidden"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>{STEP_TITLES[step]}</DialogTitle>
+          <DialogDescription>{STEP_DESCRIPTIONS[step]}</DialogDescription>
+        </DialogHeader>
+
+        <div className="py-2">
+          {step === 0 && (
+            <PersonaStep selected={persona} onSelect={setPersona} />
+          )}
+          {step === 1 && (
+            <PriorityStep selected={priority} onSelect={setPriority} />
+          )}
+          {step === 2 && priority && <RecommendationStep priority={priority} />}
+        </div>
+
+        <div className="flex items-center justify-between pt-2">
+          <div className="flex items-center gap-2">
+            {step > 0 && (
+              <Button variant="ghost" size="sm" onClick={handleBack}>
+                Back
+              </Button>
+            )}
+            {step === 0 && (
+              <Button variant="ghost" size="sm" onClick={handleComplete}>
+                Skip
+              </Button>
+            )}
+          </div>
+
+          <StepIndicator current={step} total={3} />
+
+          <div>
+            {step < 2 ? (
+              <Button size="sm" onClick={handleNext} disabled={!canProceed}>
+                Next
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Button>
+            ) : (
+              <Button size="sm" onClick={handleGoToAction}>
+                Let's Go
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { OnboardingWizard }

--- a/frontend/src/components/Onboarding/index.ts
+++ b/frontend/src/components/Onboarding/index.ts
@@ -1,0 +1,2 @@
+export { GettingStartedChecklist } from "./GettingStartedChecklist"
+export { OnboardingWizard } from "./OnboardingWizard"

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -13,6 +13,8 @@ export interface UserPublic {
   isActive: boolean
   isSuperuser: boolean
   emailVerified: boolean
+  onboardingCompleted: boolean
+  onboardingPersona: string | null
   subscriptionTier: SubscriptionTier
   createdAt: string
   updatedAt: string

--- a/frontend/src/routes/_layout/dashboard.tsx
+++ b/frontend/src/routes/_layout/dashboard.tsx
@@ -1,5 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+
 import DashboardPage from "@/components/Dashboard/DashboardPage"
+import { OnboardingWizard } from "@/components/Onboarding"
 import { useDashboardOverview } from "@/hooks/queries/useDashboardQueries"
 import useAuth from "@/hooks/useAuth"
 
@@ -18,7 +21,17 @@ function Dashboard() {
   const { user: currentUser } = useAuth()
   const { data, isLoading } = useDashboardOverview()
 
+  const showWizard = currentUser?.onboarding_completed === false
+  const [wizardDismissed, setWizardDismissed] = useState(false)
+
   const userName = currentUser?.full_name || currentUser?.email || "there"
 
-  return <DashboardPage data={data} isLoading={isLoading} userName={userName} />
+  return (
+    <>
+      {showWizard && !wizardDismissed && (
+        <OnboardingWizard open onComplete={() => setWizardDismissed(true)} />
+      )}
+      <DashboardPage data={data} isLoading={isLoading} userName={userName} />
+    </>
+  )
 }


### PR DESCRIPTION
## Summary
- Adds a 3-step onboarding wizard modal for new users on first login: choose persona (Explorer/Settler/Investor), pick priority (costs/financing/journey/evaluation), get recommended action with deep link
- Adds a Getting Started checklist widget on the dashboard that tracks 5 key first actions and auto-hides when all complete
- Backend: `onboarding_completed` and `onboarding_persona` fields on user model with migration, schema updates, and 2 new tests

## Test plan
- [ ] New user sees onboarding wizard on first dashboard visit
- [ ] Wizard can be skipped (marks onboarding complete)
- [ ] Completing wizard navigates to recommended feature
- [ ] Getting Started checklist shows on dashboard with progress tracking
- [ ] Checklist hides when all 5 items are completed
- [ ] Existing users (migrated) do not see the wizard
- [ ] `PATCH /api/v1/users/me` accepts `onboarding_completed` and `onboarding_persona`
- [ ] All backend tests pass (35/35 including 2 new onboarding tests)