### PR TITLE
feat(calculators): add cross-border tax guide for foreign investors

### DIFF
--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/CountrySelector.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/CountrySelector.tsx
@@ -1,0 +1,73 @@
+/**
+ * Country Selector
+ * Card with dropdown to select investor's home country
+ */
+
+import { Globe } from "lucide-react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { COUNTRY_TAX_DATA } from "./countryTaxData"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  selectedCountry: string | null
+  onSelect: (code: string) => void
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function CountrySelector(props: Readonly<IProps>) {
+  const { selectedCountry, onSelect } = props
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Globe className="h-5 w-5" />
+          Select Your Home Country
+        </CardTitle>
+        <CardDescription>
+          Choose your tax residency country to see how its tax treaty with
+          Germany affects your property investment
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Select value={selectedCountry ?? undefined} onValueChange={onSelect}>
+          <SelectTrigger className="w-full sm:w-80">
+            <SelectValue placeholder="Select a country..." />
+          </SelectTrigger>
+          <SelectContent>
+            {COUNTRY_TAX_DATA.map((country) => (
+              <SelectItem key={country.code} value={country.code}>
+                {country.flag} {country.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { CountrySelector }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/CountryTaxProfile.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/CountryTaxProfile.tsx
@@ -1,0 +1,66 @@
+/**
+ * Country Tax Profile
+ * Detailed per-country tax information: DBA treaty, withholding rates,
+ * filing requirements, deductible expenses, and deadlines
+ */
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  DbaSection,
+  DeadlinesSection,
+  ExpensesSection,
+  FilingSection,
+  NotesSection,
+  WithholdingSection,
+} from "./sections"
+import type { ICountryTaxData } from "./types"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  country: ICountryTaxData
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function CountryTaxProfile(props: Readonly<IProps>) {
+  const { country } = props
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <span className="text-xl">{country.flag}</span>
+          {country.name} — Tax Profile
+        </CardTitle>
+        <CardDescription>
+          Double taxation treaty details and German tax obligations
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <DbaSection dba={country.dba} />
+        <WithholdingSection withholding={country.withholding} />
+        <FilingSection filings={country.filings} />
+        <ExpensesSection expenses={country.expenses} />
+        <DeadlinesSection deadlines={country.deadlines} />
+        {country.notes.length > 0 && <NotesSection notes={country.notes} />}
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { CountryTaxProfile }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/CrossBorderTaxGuide.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/CrossBorderTaxGuide.tsx
@@ -1,0 +1,54 @@
+/**
+ * Cross-Border Tax Guide
+ * Main orchestrator wiring country selector, tax profile, comparison, and educational sections
+ */
+
+import { useState } from "react"
+import { cn } from "@/common/utils"
+import { CountrySelector } from "./CountrySelector"
+import { CountryTaxProfile } from "./CountryTaxProfile"
+import { COUNTRY_TAX_DATA } from "./countryTaxData"
+import { ResidentComparison } from "./ResidentComparison"
+import { TaxEducationalSection } from "./TaxEducationalSection"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  className?: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function CrossBorderTaxGuide(props: Readonly<IProps>) {
+  const { className } = props
+  const [selectedCode, setSelectedCode] = useState<string | null>(null)
+
+  const selectedCountry = selectedCode
+    ? (COUNTRY_TAX_DATA.find((c) => c.code === selectedCode) ?? null)
+    : null
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      <CountrySelector
+        selectedCountry={selectedCode}
+        onSelect={setSelectedCode}
+      />
+
+      {selectedCountry && <CountryTaxProfile country={selectedCountry} />}
+
+      <ResidentComparison />
+
+      <TaxEducationalSection />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { CrossBorderTaxGuide }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/ResidentComparison.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/ResidentComparison.tsx
@@ -1,0 +1,99 @@
+/**
+ * Resident vs Non-Resident Comparison
+ * Table comparing tax treatment for residents and non-residents
+ */
+
+import { ArrowLeftRight } from "lucide-react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { RESIDENT_VS_NON_RESIDENT } from "./countryTaxData"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const FAVORED_STYLES = {
+  resident: "text-blue-700 dark:text-blue-400",
+  "non-resident": "text-purple-700 dark:text-purple-400",
+  neutral: "text-muted-foreground",
+} as const
+
+const FAVORED_LABELS = {
+  resident: "Resident",
+  "non-resident": "Non-resident",
+  neutral: "Equal",
+} as const
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function ResidentComparison() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ArrowLeftRight className="h-5 w-5" />
+          Resident vs. Non-Resident Tax Treatment
+        </CardTitle>
+        <CardDescription>
+          Key differences between full tax residents (unbeschränkt
+          steuerpflichtig) and non-residents (beschränkt steuerpflichtig)
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-1/4">Aspect</TableHead>
+                <TableHead>Resident</TableHead>
+                <TableHead>Non-Resident</TableHead>
+                <TableHead className="text-center">Favored</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {RESIDENT_VS_NON_RESIDENT.map((row) => (
+                <TableRow key={row.aspect}>
+                  <TableCell className="font-medium">{row.aspect}</TableCell>
+                  <TableCell className="text-sm">
+                    {row.residentTreatment}
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    {row.nonResidentTreatment}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <span
+                      className={`text-xs font-medium ${FAVORED_STYLES[row.favored]}`}
+                    >
+                      {FAVORED_LABELS[row.favored]}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ResidentComparison }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/TaxEducationalSection.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/TaxEducationalSection.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tax Educational Section
+ * Collapsible card explaining key German tax concepts for foreign investors
+ */
+
+import { BookOpen, ChevronDown } from "lucide-react"
+import { useState } from "react"
+import { cn } from "@/common/utils"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function TaxEducationalSection() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <Card>
+      <CardHeader
+        className="cursor-pointer"
+        onClick={() => setIsOpen((p) => !p)}
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <BookOpen className="h-5 w-5" />
+              German Tax Concepts for Foreign Investors
+            </CardTitle>
+            <CardDescription>
+              Key terms and rules you need to understand
+            </CardDescription>
+          </div>
+          <ChevronDown
+            className={cn(
+              "h-5 w-5 text-muted-foreground transition-transform",
+              isOpen && "rotate-180",
+            )}
+          />
+        </div>
+      </CardHeader>
+      {isOpen && (
+        <CardContent className="space-y-6 text-sm">
+          {/* Beschränkte vs Unbeschränkte Steuerpflicht */}
+          <div className="space-y-2">
+            <h4 className="font-semibold text-blue-700 dark:text-blue-400">
+              Beschränkte vs. Unbeschränkte Steuerpflicht
+            </h4>
+            <div className="rounded-lg bg-blue-50/50 dark:bg-blue-950/20 p-4 space-y-2">
+              <p>
+                <strong>Unbeschränkte Steuerpflicht</strong> (unlimited tax
+                liability) applies to individuals who are resident in Germany or
+                have their habitual abode here. They are taxed on worldwide
+                income.
+              </p>
+              <p>
+                <strong>Beschränkte Steuerpflicht</strong> (limited tax
+                liability) applies to non-residents who earn income from German
+                sources — such as rental income from German property. Only
+                German-source income is taxed.
+              </p>
+              <p className="text-muted-foreground">
+                Non-residents can apply for treatment as residents (§ 1 Abs. 3
+                EStG) if at least 90% of their worldwide income is
+                German-source, or non-German income is below ~11,604 EUR.
+              </p>
+            </div>
+          </div>
+
+          {/* AfA for Non-Residents */}
+          <div className="space-y-2">
+            <h4 className="font-semibold text-purple-700 dark:text-purple-400">
+              AfA (Absetzung für Abnutzung) for Non-Residents
+            </h4>
+            <div className="rounded-lg bg-purple-50/50 dark:bg-purple-950/20 p-4 space-y-2">
+              <p>
+                <strong>Depreciation</strong> at 2% per year (linear, on the
+                building portion only) is available to non-residents just like
+                residents. For buildings constructed after 2023, the rate is 3%.
+              </p>
+              <p>
+                The land value (typically 20-30% of purchase price) cannot be
+                depreciated. You can use the Bodenrichtwert or a purchase price
+                allocation (Kaufpreisaufteilung) to determine the split.
+              </p>
+              <p className="text-muted-foreground">
+                AfA is one of the most powerful tax tools for property investors
+                — it creates paper losses that reduce your taxable rental
+                income.
+              </p>
+            </div>
+          </div>
+
+          {/* Solidaritätszuschlag */}
+          <div className="space-y-2">
+            <h4 className="font-semibold text-green-700 dark:text-green-400">
+              Solidaritätszuschlag (Solidarity Surcharge)
+            </h4>
+            <div className="rounded-lg bg-green-50/50 dark:bg-green-950/20 p-4 space-y-2">
+              <p>
+                The <strong>Soli</strong> is a 5.5% surcharge on top of income
+                tax. Since 2021, most residents are exempt (Freigrenze), but
+                non-residents with beschränkte Steuerpflicht always pay it.
+              </p>
+              <p>
+                This is why the effective flat rate for non-resident rental
+                income is 15.825% (15% + 5.5% of 15%) rather than a plain 15%.
+              </p>
+              <p className="text-muted-foreground">
+                For corporate structures (GmbH), the Soli is always applied: 15%
+                KSt + 5.5% Soli = 15.825% before trade tax.
+              </p>
+            </div>
+          </div>
+
+          {/* Disclaimer */}
+          <div className="rounded-lg bg-amber-50 dark:bg-amber-950/20 p-3 text-xs text-amber-800 dark:text-amber-300">
+            <strong>Disclaimer:</strong> This guide provides general information
+            based on German tax law and DBA treaties. Tax laws change
+            frequently. Individual circumstances, such as multiple income
+            sources, special deductions, or corporate structures, can
+            significantly affect your tax position. Always consult a qualified
+            Steuerberater (tax advisor) with cross-border expertise before
+            making investment decisions.
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { TaxEducationalSection }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/countryTaxData.ts
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/countryTaxData.ts
@@ -1,0 +1,456 @@
+/**
+ * Cross-Border Tax Guide Data
+ * Static curated tax data for 10 countries with DBA treaty info
+ */
+
+import type {
+  ICountryTaxData,
+  IDbaInfo,
+  IDeductibleExpense,
+  IFilingRequirement,
+  IResidentComparison,
+  ITaxRate,
+  IWithholdingRates,
+} from "./types"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const COMMON_FILINGS: IFilingRequirement[] = [
+  {
+    formName: "ESt 1 C",
+    description:
+      "Income tax return for non-residents (beschränkt Steuerpflichtige)",
+    deadline:
+      "31 July of the following year (with advisor: end of February +1)",
+  },
+  {
+    formName: "Anlage V",
+    description: "Attachment for rental income and expenses",
+    deadline: "Filed together with ESt 1 C",
+  },
+  {
+    formName: "Anlage AUS",
+    description: "Attachment for foreign income / DBA treaty relief",
+    deadline: "Filed together with ESt 1 C",
+  },
+]
+
+const COMMON_EXPENSES: IDeductibleExpense[] = [
+  {
+    category: "Depreciation (AfA)",
+    description: "2% p.a. linear on building value (excluding land)",
+    availableToNonResidents: true,
+  },
+  {
+    category: "Mortgage Interest",
+    description: "Interest on loans used to finance the property",
+    availableToNonResidents: true,
+  },
+  {
+    category: "Property Management",
+    description: "Hausverwaltung fees, property manager costs",
+    availableToNonResidents: true,
+  },
+  {
+    category: "Maintenance & Repairs",
+    description:
+      "Instandhaltungskosten up to 15% of building value in first 3 years",
+    availableToNonResidents: true,
+  },
+  {
+    category: "Travel Expenses",
+    description: "Trips to inspect or manage the property",
+    availableToNonResidents: true,
+  },
+  {
+    category: "Insurance",
+    description: "Building insurance, liability insurance",
+    availableToNonResidents: true,
+  },
+  {
+    category: "Professional Fees",
+    description: "Steuerberater, lawyer fees related to the property",
+    availableToNonResidents: true,
+  },
+  {
+    category: "Personal Allowance",
+    description: "Grundfreibetrag (basic tax-free allowance, ~11,604 EUR)",
+    availableToNonResidents: false,
+  },
+  {
+    category: "Splitting Tariff",
+    description: "Ehegattensplitting for married couples",
+    availableToNonResidents: false,
+  },
+  {
+    category: "Special Expenses",
+    description: "Sonderausgaben (church tax, donations, etc.)",
+    availableToNonResidents: false,
+  },
+]
+
+const COMMON_DEADLINES: string[] = [
+  "Tax year: 1 January - 31 December",
+  "Filing deadline (self): 31 July of the following year",
+  "Filing deadline (with Steuerberater): end of February, two years later",
+  "Prepayment notices (Vorauszahlungsbescheid): quarterly on 10 Mar, 10 Jun, 10 Sep, 10 Dec",
+]
+
+const FLAT_RENTAL_RATE: ITaxRate = {
+  rate: 0.15825,
+  label: "15.825%",
+  note: "15% + 5.5% Soli surcharge — flat rate for non-residents",
+}
+
+const FLAT_CG_RATE: ITaxRate = {
+  rate: 0.15825,
+  label: "15.825%",
+  note: "Flat rate for non-residents",
+}
+
+const STANDARD_DIVIDENDS: ITaxRate = { rate: 0.26375, label: "26.375%" }
+
+const DBA_DIVIDENDS_15: ITaxRate = {
+  rate: 0.15,
+  label: "15%",
+  note: "DBA Article 10",
+}
+
+const DBA_DIVIDENDS_10: ITaxRate = {
+  rate: 0.1,
+  label: "10%",
+  note: "DBA Article 10",
+}
+
+/******************************************************************************
+                              Builder
+******************************************************************************/
+
+interface ICountryInput {
+  code: string
+  name: string
+  flag: string
+  dba: IDbaInfo
+  capitalGainsNote?: string
+  dbaReducedDividends: ITaxRate | null
+  notes: string[]
+}
+
+function buildCountry(input: ICountryInput): ICountryTaxData {
+  const withholding: IWithholdingRates = {
+    rentalIncome: FLAT_RENTAL_RATE,
+    capitalGains: input.capitalGainsNote
+      ? { rate: 0.15825, label: "15.825%", note: input.capitalGainsNote }
+      : FLAT_CG_RATE,
+    dividends: STANDARD_DIVIDENDS,
+    dbaReducedDividends: input.dbaReducedDividends,
+  }
+
+  return {
+    code: input.code,
+    name: input.name,
+    flag: input.flag,
+    dba: input.dba,
+    withholding,
+    filings: COMMON_FILINGS,
+    expenses: COMMON_EXPENSES,
+    deadlines: COMMON_DEADLINES,
+    notes: input.notes,
+  }
+}
+
+/******************************************************************************
+                              Country Data
+******************************************************************************/
+
+export const COUNTRY_TAX_DATA: ICountryTaxData[] = [
+  buildCountry({
+    code: "GB",
+    name: "United Kingdom",
+    flag: "\u{1F1EC}\u{1F1E7}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 2010,
+      reliefMethod: "credit",
+      rentalIncomeRule:
+        "Germany has primary taxing right. UK grants credit for German tax paid.",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. UK also taxes but grants credit.",
+      notes:
+        "Post-Brexit: DBA remains in force. UK residents file Self Assessment to claim foreign tax credit.",
+    },
+    capitalGainsNote: "Or progressive rate if higher — non-resident election",
+    dbaReducedDividends: DBA_DIVIDENDS_15,
+    notes: [
+      "UK HMRC allows you to claim Foreign Tax Credit Relief on your Self Assessment for German tax paid on rental income.",
+      "No UK capital gains tax exemption for overseas property — but German DBA credit applies.",
+      "Consider UK Non-Resident Landlord Scheme interactions if you also rent UK property.",
+    ],
+  }),
+  buildCountry({
+    code: "US",
+    name: "United States",
+    flag: "\u{1F1FA}\u{1F1F8}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 1989,
+      reliefMethod: "credit",
+      rentalIncomeRule:
+        "Germany taxes rental income at source. US grants Foreign Tax Credit (FTC) via Form 1116.",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. US also taxes worldwide but grants FTC.",
+      notes:
+        "US citizens/residents must report worldwide income. FATCA reporting may apply for German bank accounts.",
+    },
+    capitalGainsNote: "Or progressive rate — whichever is elected",
+    dbaReducedDividends: DBA_DIVIDENDS_15,
+    notes: [
+      "US citizens must file IRS Form 1116 (Foreign Tax Credit) to avoid double taxation on German rental income.",
+      "FBAR (FinCEN 114) filing required if German bank accounts exceed $10,000 aggregate.",
+      "FATCA Form 8938 may be required for specified foreign financial assets above thresholds.",
+    ],
+  }),
+  buildCountry({
+    code: "FR",
+    name: "France",
+    flag: "\u{1F1EB}\u{1F1F7}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 1959,
+      reliefMethod: "exemption",
+      rentalIncomeRule:
+        "Germany has exclusive taxing right. France exempts but uses progression (taux effectif).",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. France exempts with progression.",
+      notes:
+        "Revised protocol 2015. France uses the exemption-with-progression method — German income raises your French tax bracket.",
+    },
+    dbaReducedDividends: {
+      rate: 0.15,
+      label: "15%",
+      note: "DBA Article 9",
+    },
+    notes: [
+      "France uses exemption-with-progression: German rental income is exempt in France but raises your effective French tax rate.",
+      "You must still declare the German income on your French return (Form 2047) for progression calculation.",
+      "Social contributions (CSG/CRDS) do not apply to income from German property for EU/EEA residents.",
+    ],
+  }),
+  buildCountry({
+    code: "NL",
+    name: "Netherlands",
+    flag: "\u{1F1F3}\u{1F1F1}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 2012,
+      reliefMethod: "exemption",
+      rentalIncomeRule:
+        "Germany has primary taxing right. Netherlands exempts with progression.",
+      capitalGainsRule:
+        "Germany taxes gains. Netherlands exempts with progression.",
+      notes:
+        "Dutch Box 3 (wealth tax) may still apply to the net value of foreign property. Treaty updated 2012.",
+    },
+    dbaReducedDividends: DBA_DIVIDENDS_15,
+    notes: [
+      "Netherlands exempts German rental income but your German property value is included in Box 3 (wealth tax).",
+      "Dutch Box 3 tax is based on deemed return, not actual rental income — may result in additional Dutch tax.",
+      "Claim proportional exemption in Dutch return to avoid double counting.",
+    ],
+  }),
+  buildCountry({
+    code: "TR",
+    name: "Turkey",
+    flag: "\u{1F1F9}\u{1F1F7}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 2011,
+      reliefMethod: "credit",
+      rentalIncomeRule:
+        "Germany taxes rental income at source. Turkey grants credit for German tax paid.",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. Turkey grants credit.",
+      notes:
+        "Treaty entered into force 2012. Turkey applies credit method for all income types.",
+    },
+    dbaReducedDividends: DBA_DIVIDENDS_15,
+    notes: [
+      "Turkish residents must declare worldwide income including German rental income in their annual Turkish return.",
+      "German tax paid can be credited against Turkish tax — keep Steuerbescheid as proof.",
+      "Turkey has a rental income exemption threshold (~33,000 TRY) — German rental income may exceed this.",
+    ],
+  }),
+  buildCountry({
+    code: "PL",
+    name: "Poland",
+    flag: "\u{1F1F5}\u{1F1F1}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 2003,
+      reliefMethod: "exemption",
+      rentalIncomeRule:
+        "Germany taxes rental income. Poland exempts with progression.",
+      capitalGainsRule: "Germany taxes gains. Poland exempts with progression.",
+      notes:
+        "Revised 2003 treaty uses exemption-with-progression method. Poland switched from credit to exemption.",
+    },
+    dbaReducedDividends: {
+      rate: 0.05,
+      label: "5%",
+      note: "DBA Article 10 (company holding 25%+: 5%)",
+    },
+    notes: [
+      "Poland exempts German rental income but includes it for calculating your effective Polish tax rate.",
+      "Report German income on PIT-36 with attachment PIT/ZG for foreign income.",
+      "Many Polish investors in Germany — established advisory infrastructure in both countries.",
+    ],
+  }),
+  buildCountry({
+    code: "IT",
+    name: "Italy",
+    flag: "\u{1F1EE}\u{1F1F9}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 1989,
+      reliefMethod: "credit",
+      rentalIncomeRule:
+        "Germany taxes rental income at source. Italy grants credit for German tax paid.",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. Italy grants credit.",
+      notes:
+        "Treaty from 1989 with subsequent protocols. Italy uses credit method.",
+    },
+    dbaReducedDividends: DBA_DIVIDENDS_15,
+    notes: [
+      "Italian residents must declare German rental income on their Italian tax return (Redditi PF, Quadro CR).",
+      "Credito d'imposta: German tax paid is credited against Italian IRPEF on the same income.",
+      "Italian IVIE tax (0.76% of cadastral value) applies to foreign property — may add to total tax burden.",
+    ],
+  }),
+  buildCountry({
+    code: "CN",
+    name: "China",
+    flag: "\u{1F1E8}\u{1F1F3}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 2014,
+      reliefMethod: "credit",
+      rentalIncomeRule:
+        "Germany taxes rental income at source. China grants credit for German tax paid.",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. China grants credit.",
+      notes:
+        "Revised treaty 2014. China applies credit method. Foreign exchange controls may affect repatriation.",
+    },
+    dbaReducedDividends: DBA_DIVIDENDS_10,
+    notes: [
+      "Chinese forex controls (SAFE) limit outbound transfers — plan acquisition funding carefully.",
+      "Chinese residents must report worldwide income; credit for German tax paid via annual IIT filing.",
+      "Consider using a Hong Kong or Singapore entity for structuring — consult cross-border tax advisor.",
+    ],
+  }),
+  buildCountry({
+    code: "RU",
+    name: "Russia",
+    flag: "\u{1F1F7}\u{1F1FA}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 1996,
+      reliefMethod: "credit",
+      rentalIncomeRule:
+        "Germany taxes rental income at source. Russia grants credit for German tax paid.",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. Russia grants credit.",
+      notes:
+        "DBA from 1996 remains technically in force. Practical enforcement may be affected by sanctions — consult advisor.",
+    },
+    dbaReducedDividends: DBA_DIVIDENDS_15,
+    notes: [
+      "EU sanctions may restrict banking and payment flows — verify current sanctions list before transactions.",
+      "DBA treaty technically applies but practical credit claims may face administrative hurdles.",
+      "Russian residents taxed at 13% (15% above 5M RUB) on worldwide income — German credit may cover most or all.",
+    ],
+  }),
+  buildCountry({
+    code: "IN",
+    name: "India",
+    flag: "\u{1F1EE}\u{1F1F3}",
+    dba: {
+      hasTreaty: true,
+      treatyYear: 1995,
+      reliefMethod: "credit",
+      rentalIncomeRule:
+        "Germany taxes rental income at source. India grants credit for German tax paid under Section 91.",
+      capitalGainsRule:
+        "Germany taxes gains on immovable property. India grants credit.",
+      notes:
+        "Treaty from 1995. India uses credit method. LRS (Liberalised Remittance Scheme) limits outbound investment to $250,000/year.",
+    },
+    dbaReducedDividends: DBA_DIVIDENDS_10,
+    notes: [
+      "LRS limit of $250,000/year per person for outbound investment — plan property acquisition accordingly.",
+      "Indian residents must report foreign assets on Schedule FA of ITR; non-compliance attracts penalties.",
+      "Section 91 relief: credit for German tax paid on rental income, limited to Indian tax on the same income.",
+    ],
+  }),
+]
+
+/******************************************************************************
+                              Resident vs Non-Resident Comparison
+******************************************************************************/
+
+export const RESIDENT_VS_NON_RESIDENT: IResidentComparison[] = [
+  {
+    aspect: "Tax Filing Form",
+    residentTreatment: "ESt 1 A (full return with all income)",
+    nonResidentTreatment: "ESt 1 C (limited return, German-source income only)",
+    favored: "neutral",
+  },
+  {
+    aspect: "Tax Rate",
+    residentTreatment: "Progressive rate 14%-45% on worldwide income",
+    nonResidentTreatment:
+      "Flat 15.825% on rental income, or progressive rate election",
+    favored: "non-resident",
+  },
+  {
+    aspect: "Basic Allowance (Grundfreibetrag)",
+    residentTreatment: "~11,604 EUR tax-free",
+    nonResidentTreatment:
+      "Not available (unless 90% of income is from Germany)",
+    favored: "resident",
+  },
+  {
+    aspect: "Depreciation (AfA)",
+    residentTreatment: "2% linear on building value",
+    nonResidentTreatment: "2% linear on building value (same)",
+    favored: "neutral",
+  },
+  {
+    aspect: "Mortgage Interest Deduction",
+    residentTreatment: "Fully deductible against rental income",
+    nonResidentTreatment: "Fully deductible against rental income (same)",
+    favored: "neutral",
+  },
+  {
+    aspect: "Loss Offset",
+    residentTreatment: "Losses offset against other income types",
+    nonResidentTreatment:
+      "Losses only offset within German income; no cross-border offset",
+    favored: "resident",
+  },
+  {
+    aspect: "Capital Gains (< 10 years)",
+    residentTreatment: "Taxed at personal rate",
+    nonResidentTreatment: "Taxed at 15.825% flat or progressive election",
+    favored: "non-resident",
+  },
+  {
+    aspect: "Capital Gains (10+ years)",
+    residentTreatment: "Tax-free (Spekulationsfrist)",
+    nonResidentTreatment: "Tax-free (Spekulationsfrist applies equally)",
+    favored: "neutral",
+  },
+]

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/index.ts
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/index.ts
@@ -1,0 +1,1 @@
+export { CrossBorderTaxGuide } from "./CrossBorderTaxGuide"

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/DbaSection.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/DbaSection.tsx
@@ -1,0 +1,73 @@
+/**
+ * DBA Treaty Section
+ * Shows double taxation agreement status and details
+ */
+
+import { Shield } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import type { ICountryTaxData } from "../types"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  dba: ICountryTaxData["dba"]
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function DbaSection(props: Readonly<IProps>) {
+  const { dba } = props
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Shield className="h-4 w-4 text-muted-foreground" />
+        <h4 className="font-semibold text-sm">
+          Double Taxation Agreement (DBA)
+        </h4>
+        {dba.hasTreaty ? (
+          <Badge
+            variant="outline"
+            className="bg-green-50 text-green-700 border-green-200 dark:bg-green-950/20 dark:text-green-400 dark:border-green-800"
+          >
+            Active Treaty {dba.treatyYear && `(${dba.treatyYear})`}
+          </Badge>
+        ) : (
+          <Badge
+            variant="outline"
+            className="bg-red-50 text-red-700 border-red-200 dark:bg-red-950/20 dark:text-red-400 dark:border-red-800"
+          >
+            No Treaty
+          </Badge>
+        )}
+      </div>
+      <div className="rounded-lg bg-muted/50 p-4 space-y-2 text-sm">
+        {dba.reliefMethod && (
+          <p>
+            <strong>Relief method:</strong>{" "}
+            <span className="capitalize">{dba.reliefMethod}</span>
+          </p>
+        )}
+        <p>
+          <strong>Rental income:</strong> {dba.rentalIncomeRule}
+        </p>
+        <p>
+          <strong>Capital gains:</strong> {dba.capitalGainsRule}
+        </p>
+        {dba.notes && (
+          <p className="text-muted-foreground text-xs">{dba.notes}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { DbaSection }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/DeadlinesSection.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/DeadlinesSection.tsx
@@ -1,0 +1,42 @@
+/**
+ * Key Deadlines Section
+ * List of important tax filing deadlines
+ */
+
+import { Calendar } from "lucide-react"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  deadlines: string[]
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function DeadlinesSection(props: Readonly<IProps>) {
+  const { deadlines } = props
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Calendar className="h-4 w-4 text-muted-foreground" />
+        <h4 className="font-semibold text-sm">Key Deadlines</h4>
+      </div>
+      <ul className="list-disc pl-5 space-y-1 text-sm text-muted-foreground">
+        {deadlines.map((d) => (
+          <li key={d}>{d}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { DeadlinesSection }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/ExpensesSection.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/ExpensesSection.tsx
@@ -1,0 +1,59 @@
+/**
+ * Deductible Expenses Section
+ * Shows which expenses are deductible and non-resident availability
+ */
+
+import { CheckCircle2, Receipt, XCircle } from "lucide-react"
+import type { ICountryTaxData } from "../types"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  expenses: ICountryTaxData["expenses"]
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function ExpensesSection(props: Readonly<IProps>) {
+  const { expenses } = props
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Receipt className="h-4 w-4 text-muted-foreground" />
+        <h4 className="font-semibold text-sm">Deductible Expenses</h4>
+      </div>
+      <div className="space-y-1.5">
+        {expenses.map((e) => (
+          <div key={e.category} className="flex items-start gap-2 text-sm">
+            {e.availableToNonResidents ? (
+              <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0 mt-0.5" />
+            ) : (
+              <XCircle className="h-4 w-4 text-red-500 shrink-0 mt-0.5" />
+            )}
+            <div>
+              <span className="font-medium">{e.category}</span>
+              <span className="text-muted-foreground"> — {e.description}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        <CheckCircle2 className="inline h-3 w-3 text-green-600 mr-1" />
+        Available to non-residents
+        <XCircle className="inline h-3 w-3 text-red-500 ml-3 mr-1" />
+        Residents only
+      </p>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ExpensesSection }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/FilingSection.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/FilingSection.tsx
@@ -1,0 +1,49 @@
+/**
+ * Filing Requirements Section
+ * List of German tax forms required for non-residents
+ */
+
+import { FileText } from "lucide-react"
+import type { ICountryTaxData } from "../types"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  filings: ICountryTaxData["filings"]
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function FilingSection(props: Readonly<IProps>) {
+  const { filings } = props
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <FileText className="h-4 w-4 text-muted-foreground" />
+        <h4 className="font-semibold text-sm">Filing Requirements</h4>
+      </div>
+      <div className="space-y-2">
+        {filings.map((f) => (
+          <div key={f.formName} className="rounded-lg bg-muted/50 p-3 text-sm">
+            <p className="font-medium">{f.formName}</p>
+            <p className="text-muted-foreground text-xs">{f.description}</p>
+            <p className="text-xs mt-1">
+              <strong>Deadline:</strong> {f.deadline}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { FilingSection }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/NotesSection.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/NotesSection.tsx
@@ -1,0 +1,42 @@
+/**
+ * Country-Specific Notes Section
+ * Amber warning box with country-specific tax considerations
+ */
+
+import { AlertTriangle } from "lucide-react"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  notes: string[]
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function NotesSection(props: Readonly<IProps>) {
+  const { notes } = props
+
+  return (
+    <div className="rounded-lg bg-amber-50 dark:bg-amber-950/20 p-4 space-y-2">
+      <div className="flex items-center gap-2 text-amber-800 dark:text-amber-300">
+        <AlertTriangle className="h-4 w-4" />
+        <h4 className="font-semibold text-sm">Country-Specific Notes</h4>
+      </div>
+      <ul className="list-disc pl-5 space-y-1 text-sm text-amber-800 dark:text-amber-300">
+        {notes.map((n) => (
+          <li key={n}>{n}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { NotesSection }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/WithholdingSection.tsx
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/WithholdingSection.tsx
@@ -1,0 +1,66 @@
+/**
+ * Withholding Rates Section
+ * Grid of German withholding/tax rates for non-residents
+ */
+
+import { Receipt } from "lucide-react"
+import type { ICountryTaxData } from "../types"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  withholding: ICountryTaxData["withholding"]
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function WithholdingSection(props: Readonly<IProps>) {
+  const { withholding } = props
+  const rates = [
+    { key: "Rental Income", ...withholding.rentalIncome },
+    { key: "Capital Gains", ...withholding.capitalGains },
+    { key: "Dividends", ...withholding.dividends },
+  ]
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Receipt className="h-4 w-4 text-muted-foreground" />
+        <h4 className="font-semibold text-sm">
+          German Withholding / Tax Rates
+        </h4>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {rates.map((r) => (
+          <div
+            key={r.key}
+            className="rounded-lg border p-3 text-center space-y-1"
+          >
+            <p className="text-xs text-muted-foreground">{r.key}</p>
+            <p className="text-lg font-bold">{r.label}</p>
+            {r.note && (
+              <p className="text-xs text-muted-foreground">{r.note}</p>
+            )}
+          </div>
+        ))}
+      </div>
+      {withholding.dbaReducedDividends && (
+        <p className="text-xs text-muted-foreground">
+          DBA-reduced dividend rate: {withholding.dbaReducedDividends.label}
+          {withholding.dbaReducedDividends.note &&
+            ` (${withholding.dbaReducedDividends.note})`}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { WithholdingSection }

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/index.ts
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/sections/index.ts
@@ -1,0 +1,6 @@
+export { DbaSection } from "./DbaSection"
+export { DeadlinesSection } from "./DeadlinesSection"
+export { ExpensesSection } from "./ExpensesSection"
+export { FilingSection } from "./FilingSection"
+export { NotesSection } from "./NotesSection"
+export { WithholdingSection } from "./WithholdingSection"

--- a/frontend/src/components/Calculators/CrossBorderTaxGuide/types.ts
+++ b/frontend/src/components/Calculators/CrossBorderTaxGuide/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Cross-Border Tax Guide Types
+ * TypeScript interfaces for country-specific tax data
+ */
+
+export interface IDbaInfo {
+  hasTreaty: boolean
+  treatyYear: number | null
+  reliefMethod: "exemption" | "credit" | "mixed" | null
+  rentalIncomeRule: string
+  capitalGainsRule: string
+  notes: string
+}
+
+export interface ITaxRate {
+  rate: number
+  label: string
+  note?: string
+}
+
+export interface IWithholdingRates {
+  rentalIncome: ITaxRate
+  capitalGains: ITaxRate
+  dividends: ITaxRate
+  dbaReducedDividends: ITaxRate | null
+}
+
+export interface IFilingRequirement {
+  formName: string
+  description: string
+  deadline: string
+}
+
+export interface IDeductibleExpense {
+  category: string
+  description: string
+  availableToNonResidents: boolean
+}
+
+export interface ICountryTaxData {
+  code: string
+  name: string
+  flag: string
+  dba: IDbaInfo
+  withholding: IWithholdingRates
+  filings: IFilingRequirement[]
+  expenses: IDeductibleExpense[]
+  deadlines: string[]
+  notes: string[]
+}
+
+export interface IResidentComparison {
+  aspect: string
+  residentTreatment: string
+  nonResidentTreatment: string
+  favored: "resident" | "non-resident" | "neutral"
+}

--- a/frontend/src/components/Calculators/OwnershipComparison/EducationalSection.tsx
+++ b/frontend/src/components/Calculators/OwnershipComparison/EducationalSection.tsx
@@ -3,7 +3,8 @@
  * Collapsible card explaining private vs GmbH tax rules in Germany
  */
 
-import { BookOpen, ChevronDown } from "lucide-react"
+import { Link } from "@tanstack/react-router"
+import { ArrowRight, BookOpen, ChevronDown } from "lucide-react"
 import { useState } from "react"
 import { cn } from "@/common/utils"
 import {
@@ -120,6 +121,18 @@ function EducationalSection() {
               <li>
                 Consider consulting a Steuerberater (tax advisor) for your
                 specific situation
+              </li>
+              <li>
+                Non-resident investors: DBA treaties may affect how GmbH
+                distributions are taxed in your home country —{" "}
+                <Link
+                  to="/calculators"
+                  search={{ tab: "tax-guide" }}
+                  className="inline-flex items-center gap-1 font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  see the Cross-Border Tax Guide
+                  <ArrowRight className="h-3 w-3" />
+                </Link>
               </li>
             </ul>
           </div>

--- a/frontend/src/components/Calculators/ROICalculator.tsx
+++ b/frontend/src/components/Calculators/ROICalculator.tsx
@@ -3,11 +3,14 @@
  * Calculates rental investment returns, investment grade, and 10-year projections
  */
 
+import { Link } from "@tanstack/react-router"
 import {
+  ArrowRight,
   ChevronDown,
   Download,
   Euro,
   ExternalLink,
+  Globe,
   Info,
   Lightbulb,
   RefreshCw,
@@ -1261,6 +1264,26 @@ function ROICalculator(props: IProps) {
                       </span>
                     </div>
                   </div>
+                </div>
+
+                {/* Cross-Border Tax Guide Link */}
+                <div className="rounded-lg border border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20 p-4">
+                  <p className="text-sm font-medium text-green-800 dark:text-green-300 mb-1 flex items-center gap-2">
+                    <Globe className="h-4 w-4" />
+                    Investing from abroad?
+                  </p>
+                  <p className="text-xs text-green-700 dark:text-green-400 mb-2">
+                    See how your home country&apos;s tax treaty with Germany
+                    affects your returns.
+                  </p>
+                  <Link
+                    to="/calculators"
+                    search={{ tab: "tax-guide" }}
+                    className="inline-flex items-center gap-2 text-sm font-medium text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300"
+                  >
+                    View Cross-Border Tax Guide
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
                 </div>
 
                 <Button

--- a/frontend/src/components/Calculators/index.ts
+++ b/frontend/src/components/Calculators/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { CityComparison } from "./CityComparison"
+export { CrossBorderTaxGuide } from "./CrossBorderTaxGuide"
 export { FinancingWizard } from "./FinancingWizard"
 export { HiddenCostsCalculator } from "./HiddenCostsCalculator"
 export { MortgageAmortisation } from "./MortgageAmortisation"

--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -11,12 +11,14 @@ import {
   CalendarClock,
   ClipboardList,
   Euro,
+  Globe,
   Landmark,
   Scale,
   TrendingUp,
 } from "lucide-react"
 import {
   CityComparison,
+  CrossBorderTaxGuide,
   FinancingWizard,
   HiddenCostsCalculator,
   MortgageAmortisation,
@@ -123,6 +125,14 @@ function CalculatorsPage() {
             <Building2 className="h-4 w-4" />
             <span className="hidden sm:inline">City Compare</span>
           </TabsTrigger>
+          <TabsTrigger
+            value="tax-guide"
+            className="gap-2"
+            aria-label="Tax Guide"
+          >
+            <Globe className="h-4 w-4" />
+            <span className="hidden sm:inline">Tax Guide</span>
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="costs" className="mt-6">
@@ -155,6 +165,10 @@ function CalculatorsPage() {
 
         <TabsContent value="cities" className="mt-6">
           <CityComparison />
+        </TabsContent>
+
+        <TabsContent value="tax-guide" className="mt-6">
+          <CrossBorderTaxGuide />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
## Summary
- Add new **Tax Guide** tab (9th tab) to the calculators page with curated DBA treaty data for 10 countries (UK, US, France, Netherlands, Turkey, Poland, Italy, China, Russia, India)
- Each country profile shows: DBA treaty status/badge, withholding rates grid, filing requirements, deductible expenses with non-resident availability flags, key deadlines, and country-specific notes
- Always-visible resident vs. non-resident comparison table covering 8 tax aspects
- Collapsible educational section explaining Steuerpflicht, AfA, and Solidaritätszuschlag
- Cross-links from ROI Calculator ("Investing from abroad?") and GmbH comparison (Key Decision Factors bullet)

## Test plan
- [ ] Navigate to `/calculators?tab=tax-guide` — tab renders correctly
- [ ] Select each of 10 countries — content updates with correct DBA/treaty data
- [ ] Resident vs. non-resident comparison table always visible regardless of selection
- [ ] Educational section expands/collapses on click
- [ ] ROI Calculator → green "Investing from abroad?" box links to tax guide tab
- [ ] GmbH comparison → educational section bullet links to tax guide tab
- [ ] Mobile responsive — tab icon visible, content scrollable
- [ ] `bunx tsc --noEmit` passes with no errors
- [ ] `pre-commit run --all-files` passes clean