### PR TITLE
feat(journey): improve mobile touch targets and responsive layouts

### DIFF
--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -328,7 +328,7 @@ function JourneyWizard(props: IProps) {
         <CardContent className="pt-6">{renderStep()}</CardContent>
       </Card>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-4">
         <Button
           variant="outline"
           onClick={handleBack}

--- a/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
+++ b/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
@@ -121,7 +121,7 @@ function FeatureCheckbox(props: {
     <label
       htmlFor={checkboxId}
       className={cn(
-        "flex cursor-pointer items-center gap-2 rounded-md border px-2 py-1.5 transition-all",
+        "flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2.5 transition-all",
         checked
           ? "border-blue-600 bg-blue-50 dark:bg-blue-950/30"
           : "border-muted-foreground/20 hover:border-muted-foreground/40",
@@ -307,7 +307,7 @@ function PropertyGoalsForm(props: IProps) {
       </div>
 
       {/* Property Type — inline select */}
-      <div className="flex items-center gap-3">
+      <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:items-center sm:gap-3">
         <Label className="shrink-0 text-sm font-medium">Property Type</Label>
         <Select
           value={goals.preferred_property_type}
@@ -339,7 +339,7 @@ function PropertyGoalsForm(props: IProps) {
       />
 
       {/* Min. Rooms — inline */}
-      <div className="flex items-center gap-3">
+      <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:items-center sm:gap-3">
         <Label className="shrink-0 text-sm font-medium">Min. Rooms</Label>
         <Select
           value={goals.min_rooms?.toString() ?? ""}
@@ -361,7 +361,7 @@ function PropertyGoalsForm(props: IProps) {
       </div>
 
       {/* Min. Bathrooms — inline */}
-      <div className="flex items-center gap-3">
+      <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:items-center sm:gap-3">
         <Label className="shrink-0 text-sm font-medium">Min. Bathrooms</Label>
         <Select
           value={goals.min_bathrooms?.toString() ?? ""}
@@ -384,7 +384,7 @@ function PropertyGoalsForm(props: IProps) {
 
       {/* Preferred Floor & Elevator — inline */}
       {isFloorRelevant && (
-        <div className="flex items-center gap-3">
+        <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:items-center sm:gap-3">
           <Label className="shrink-0 text-sm font-medium">Floor</Label>
           <Select
             value={goals.preferred_floor}

--- a/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
+++ b/frontend/src/components/Journey/StepContent/PropertyGoalsForm.tsx
@@ -313,7 +313,7 @@ function PropertyGoalsForm(props: IProps) {
           value={goals.preferred_property_type}
           onValueChange={handlePropertyTypeChange}
         >
-          <SelectTrigger className="w-auto min-w-0 flex-1">
+          <SelectTrigger className="w-full min-w-0 sm:w-auto sm:flex-1">
             <SelectValue placeholder="Select type" />
           </SelectTrigger>
           <SelectContent>
@@ -347,7 +347,7 @@ function PropertyGoalsForm(props: IProps) {
             setGoals((prev) => ({ ...prev, min_rooms: Number(v) }))
           }
         >
-          <SelectTrigger className="w-auto min-w-0 flex-1">
+          <SelectTrigger className="w-full min-w-0 sm:w-auto sm:flex-1">
             <SelectValue placeholder="Any" />
           </SelectTrigger>
           <SelectContent>
@@ -369,7 +369,7 @@ function PropertyGoalsForm(props: IProps) {
             setGoals((prev) => ({ ...prev, min_bathrooms: Number(v) }))
           }
         >
-          <SelectTrigger className="w-auto min-w-0 flex-1">
+          <SelectTrigger className="w-full min-w-0 sm:w-auto sm:flex-1">
             <SelectValue placeholder="Any" />
           </SelectTrigger>
           <SelectContent>
@@ -392,7 +392,7 @@ function PropertyGoalsForm(props: IProps) {
               setGoals((prev) => ({ ...prev, preferred_floor: v }))
             }
           >
-            <SelectTrigger className="w-auto min-w-0 flex-1">
+            <SelectTrigger className="w-full min-w-0 sm:w-auto sm:flex-1">
               <SelectValue placeholder="Any floor" />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/components/Journey/TaskCheckbox.tsx
+++ b/frontend/src/components/Journey/TaskCheckbox.tsx
@@ -29,7 +29,7 @@ function TaskCheckbox(props: IProps) {
   return (
     <div
       className={cn(
-        "flex items-start gap-3 rounded-lg border p-3 transition-colors",
+        "flex min-h-[44px] items-start gap-3 rounded-lg border p-3 transition-colors",
         task.is_completed && "bg-muted/50",
         !disabled && "hover:bg-muted/30",
         className,
@@ -40,7 +40,7 @@ function TaskCheckbox(props: IProps) {
         checked={task.is_completed}
         onCheckedChange={handleChange}
         disabled={disabled}
-        className="mt-0.5"
+        className="mt-0.5 size-5 sm:size-4"
       />
       <label
         htmlFor={`task-${task.id}`}


### PR DESCRIPTION
## Summary
- Add `min-h-[44px]` and responsive checkbox sizing (`size-5 sm:size-4`) to `TaskCheckbox` for WCAG 2.1 touch target compliance
- Stack inline select rows (Property Type, Rooms, Bathrooms, Floor) vertically on mobile, inline on `sm:` breakpoint in `PropertyGoalsForm`
- Enlarge `FeatureCheckbox` padding (`px-3 py-2.5`) to meet 44px minimum touch target
- Add `gap-4` to `JourneyWizard` footer buttons to prevent visual overlap on narrow screens

## Test plan
- [ ] Verify TaskCheckbox touch target is at least 44px tall on mobile viewports
- [ ] Verify FeatureCheckbox items meet 44px touch target height
- [ ] Verify PropertyGoalsForm select rows stack vertically on screens < 640px
- [ ] Verify PropertyGoalsForm select rows display inline on screens >= 640px
- [ ] Verify JourneyWizard footer buttons have visible gap on narrow screens
- [ ] Run `bunx tsc --noEmit` — no type errors
- [ ] Run `pre-commit run --all-files` — all checks pass