### PR TITLE
fix(glossary): add seed_glossary to init_db so glossary terms are populated

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -4,6 +4,7 @@ from app import crud
 from app.core.config import settings
 from app.core.seed_professionals import seed_professionals
 from app.models import User, UserCreate
+from app.seed_glossary import seed_glossary
 from app.seed_laws import seed_laws
 
 engine = create_engine(str(settings.SQLALCHEMY_DATABASE_URI))
@@ -39,3 +40,4 @@ def init_db(session: Session) -> None:
 
     seed_laws(session)
     seed_professionals(session)
+    seed_glossary(session)


### PR DESCRIPTION
## Summary
- **Glossary page "no items found"**: `seed_glossary()` was never called in `init_db()`. The function existed in `seed_glossary.py` with 52 German real estate terms but was not wired into the initialization pipeline alongside `seed_laws()` and `seed_professionals()`.
- **Documents page "failed to load"**: The Docker image was stale — `prestart` container couldn't find migration `b4x5y6z7a8c9` because the image hadn't been rebuilt. A `docker compose build --no-cache` resolved this. Additionally, the `glossary_term` table referenced by the migration chain was missing from the database despite alembic marking it as applied, causing a 500 on the glossary endpoint.

## Changes
- Added `seed_glossary(session)` call to `backend/app/core/db.py` `init_db()` function
- Added corresponding import for `seed_glossary`

## Test plan
- [x] `docker compose up -d` — prestart completes successfully, logs show "Glossary seed complete: 52 created"
- [x] `GET /api/v1/glossary/` — returns 52 terms with categories
- [x] `GET /api/v1/glossary/categories` — returns 6 categories with correct counts
- [x] `GET /api/v1/documents/` — returns 200 with empty list (no auth error)
- [x] `pre-commit run` — all checks pass