### PR TITLE
fix(documents): improve error state UX in document list

### DIFF
--- a/frontend/src/components/Documents/DocumentList.tsx
+++ b/frontend/src/components/Documents/DocumentList.tsx
@@ -3,7 +3,7 @@
  * Grid of DocumentCards with filtering and pagination
  */
 
-import { FileText, Search } from "lucide-react"
+import { FileText, RefreshCw, Search } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -140,10 +140,15 @@ function DocumentList(props: IProps) {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center space-y-2">
-        <p className="text-sm text-destructive">Failed to load documents</p>
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <FileText className="h-12 w-12 text-muted-foreground/50 mb-4" />
+        <h3 className="text-lg font-medium">Unable to load documents</h3>
+        <p className="text-sm text-muted-foreground mt-1 mb-4">
+          Something went wrong. Please try again.
+        </p>
         <Button variant="outline" size="sm" onClick={() => refetch()}>
-          Try again
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Retry
         </Button>
       </div>
     )


### PR DESCRIPTION
## Summary
- Replace the harsh red error box ("Failed to load documents") with a softer, consistent empty-state style
- Uses the same FileText icon and layout as the empty state for visual consistency
- Adds a RefreshCw icon to the retry button for clarity
- Message changed to "Unable to load documents / Something went wrong. Please try again."

## Context
The documents page showed a jarring red error box when the API call failed (e.g., expired token, backend unavailable). The global query error handler already redirects to login on 401/403, so this error state only appears for network/server errors. The new design matches the existing empty state pattern.

## Test plan
- [ ] Disconnect backend → verify error state shows friendly message with retry button
- [ ] Click retry → verify it attempts to reload
- [ ] With backend running and no documents → verify empty state shows "No documents yet"
- [ ] `bunx tsc --noEmit` passes
- [ ] `pre-commit` passes