### PR TITLE
feat(legal): add terms, privacy, and imprint pages

### DIFF
--- a/frontend/src/components/Common/Footer.tsx
+++ b/frontend/src/components/Common/Footer.tsx
@@ -1,10 +1,16 @@
+import { Link } from "@tanstack/react-router"
+
 /******************************************************************************
                               Constants
 ******************************************************************************/
 
-const FOOTER_LINKS = [
-  { label: "Terms", href: "/terms" },
-  { label: "Privacy", href: "/privacy" },
+const INTERNAL_LINKS = [
+  { label: "Terms", to: "/terms" },
+  { label: "Privacy", to: "/privacy" },
+  { label: "Imprint", to: "/imprint" },
+] as const
+
+const EXTERNAL_LINKS = [
   { label: "Support", href: "mailto:support@heimpath.com" },
 ] as const
 
@@ -20,10 +26,19 @@ function Footer() {
     <footer className="border-t py-4 px-6">
       <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
         <p className="text-muted-foreground text-xs">
-          {currentYear} HeimPath. All rights reserved.
+          &copy; {currentYear} HeimPath. All rights reserved.
         </p>
         <nav className="flex items-center gap-4">
-          {FOOTER_LINKS.map(({ label, href }) => (
+          {INTERNAL_LINKS.map(({ label, to }) => (
+            <Link
+              key={label}
+              to={to}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {label}
+            </Link>
+          ))}
+          {EXTERNAL_LINKS.map(({ label, href }) => (
             <a
               key={label}
               href={href}

--- a/frontend/src/components/Common/LegalSection.tsx
+++ b/frontend/src/components/Common/LegalSection.tsx
@@ -1,0 +1,30 @@
+/**
+ * Legal Section Component
+ * Reusable section block for legal pages (Terms, Privacy, Imprint)
+ */
+
+interface IProps {
+  title: string
+  children: React.ReactNode
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Section with heading and content for legal pages. */
+function LegalSection(props: IProps) {
+  const { title, children } = props
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      <div className="space-y-2 text-muted-foreground">{children}</div>
+    </section>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { LegalSection }

--- a/frontend/src/components/Landing/LandingFooter.tsx
+++ b/frontend/src/components/Landing/LandingFooter.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@tanstack/react-router"
+
 import { Logo } from "@/components/Common/Logo"
 import { Separator } from "@/components/ui/separator"
 
@@ -36,14 +38,40 @@ const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
     [
       ["Terms of Service", "/terms"],
       ["Privacy Policy", "/privacy"],
-      ["Imprint", "#"],
+      ["Imprint", "/imprint"],
     ],
   ],
 ]
 
+/** Check if href is an internal route (starts with / but not # or mailto:). */
+function isInternalRoute(href: string): boolean {
+  return href.startsWith("/") && !href.startsWith("mailto:")
+}
+
 /******************************************************************************
                               Components
 ******************************************************************************/
+
+/** Footer link — uses TanStack Link for internal routes, plain <a> otherwise. */
+function FooterLink(props: { href: string; children: React.ReactNode }) {
+  const { href, children } = props
+  const className =
+    "text-sm text-muted-foreground transition-colors hover:text-foreground"
+
+  if (isInternalRoute(href)) {
+    return (
+      <Link to={href} className={className}>
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  )
+}
 
 /** Default component. Landing page footer with navigation columns. */
 function LandingFooter() {
@@ -69,12 +97,7 @@ function LandingFooter() {
               <ul className="space-y-2">
                 {links.map(([label, href]) => (
                   <li key={label}>
-                    <a
-                      href={href}
-                      className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      {label}
-                    </a>
+                    <FooterLink href={href}>{label}</FooterLink>
                   </li>
                 ))}
               </ul>
@@ -85,7 +108,7 @@ function LandingFooter() {
         <Separator className="my-8" />
 
         <p className="text-center text-xs text-muted-foreground">
-          {currentYear} HeimPath. All rights reserved.
+          &copy; {currentYear} HeimPath. All rights reserved.
         </p>
       </div>
     </footer>

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -12,10 +12,13 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as VerifyEmailRouteImport } from './routes/verify-email'
 import { Route as UnsubscribeRouteImport } from './routes/unsubscribe'
 import { Route as ToolsRouteImport } from './routes/tools'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as RecoverPasswordRouteImport } from './routes/recover-password'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as ImprintRouteImport } from './routes/imprint'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ToolsIndexRouteImport } from './routes/tools/index'
@@ -62,6 +65,11 @@ const ToolsRoute = ToolsRouteImport.update({
   path: '/tools',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
@@ -77,9 +85,19 @@ const RecoverPasswordRoute = RecoverPasswordRouteImport.update({
   path: '/recover-password',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ImprintRoute = ImprintRouteImport.update({
+  id: '/imprint',
+  path: '/imprint',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LayoutRoute = LayoutRouteImport.update({
@@ -241,10 +259,13 @@ const LayoutJourneysJourneyIdPropertyEvaluationRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/imprint': typeof ImprintRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/tools': typeof ToolsRouteWithChildren
   '/unsubscribe': typeof UnsubscribeRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -279,10 +300,13 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/imprint': typeof ImprintRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/unsubscribe': typeof UnsubscribeRoute
   '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
@@ -317,10 +341,13 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_layout': typeof LayoutRouteWithChildren
+  '/imprint': typeof ImprintRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/tools': typeof ToolsRouteWithChildren
   '/unsubscribe': typeof UnsubscribeRoute
   '/verify-email': typeof VerifyEmailRoute
@@ -357,10 +384,13 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/imprint'
     | '/login'
+    | '/privacy'
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/terms'
     | '/tools'
     | '/unsubscribe'
     | '/verify-email'
@@ -395,10 +425,13 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/imprint'
     | '/login'
+    | '/privacy'
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/terms'
     | '/unsubscribe'
     | '/verify-email'
     | '/admin'
@@ -432,10 +465,13 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_layout'
+    | '/imprint'
     | '/login'
+    | '/privacy'
     | '/recover-password'
     | '/reset-password'
     | '/signup'
+    | '/terms'
     | '/tools'
     | '/unsubscribe'
     | '/verify-email'
@@ -472,10 +508,13 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LayoutRoute: typeof LayoutRouteWithChildren
+  ImprintRoute: typeof ImprintRoute
   LoginRoute: typeof LoginRoute
+  PrivacyRoute: typeof PrivacyRoute
   RecoverPasswordRoute: typeof RecoverPasswordRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
+  TermsRoute: typeof TermsRoute
   ToolsRoute: typeof ToolsRouteWithChildren
   UnsubscribeRoute: typeof UnsubscribeRoute
   VerifyEmailRoute: typeof VerifyEmailRoute
@@ -505,6 +544,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ToolsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/signup': {
       id: '/signup'
       path: '/signup'
@@ -526,11 +572,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RecoverPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/imprint': {
+      id: '/imprint'
+      path: '/imprint'
+      fullPath: '/imprint'
+      preLoaderRoute: typeof ImprintRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_layout': {
@@ -834,10 +894,13 @@ const ToolsRouteWithChildren = ToolsRoute._addFileChildren(ToolsRouteChildren)
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LayoutRoute: LayoutRouteWithChildren,
+  ImprintRoute: ImprintRoute,
   LoginRoute: LoginRoute,
+  PrivacyRoute: PrivacyRoute,
   RecoverPasswordRoute: RecoverPasswordRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,
+  TermsRoute: TermsRoute,
   ToolsRoute: ToolsRouteWithChildren,
   UnsubscribeRoute: UnsubscribeRoute,
   VerifyEmailRoute: VerifyEmailRoute,

--- a/frontend/src/routes/imprint.tsx
+++ b/frontend/src/routes/imprint.tsx
@@ -1,0 +1,186 @@
+/**
+ * Imprint (Impressum) Page
+ * Legally required in Germany under TMG §5
+ * Public legal page — accessible without authentication
+ *
+ * TODO: Replace all bracketed placeholder fields (e.g., [Company legal name])
+ * with real company information before production launch. TMG §5 requires
+ * complete company details for any commercial German website.
+ */
+
+import { createFileRoute } from "@tanstack/react-router"
+
+import { LegalSection } from "@/components/Common/LegalSection"
+import { LandingFooter } from "@/components/Landing/LandingFooter"
+import { LandingHeader } from "@/components/Landing/LandingHeader"
+
+export const Route = createFileRoute("/imprint")({
+  component: ImprintPage,
+  head: () => ({
+    meta: [
+      { title: "Imprint - HeimPath" },
+      {
+        name: "description",
+        content:
+          "Impressum (Imprint) for HeimPath pursuant to §5 TMG. Company information, contact details, and legal notices.",
+      },
+    ],
+  }),
+})
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const LAST_UPDATED = "April 20, 2026"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Imprint (Impressum) page. */
+function ImprintPage() {
+  return (
+    <div className="flex min-h-svh flex-col">
+      <LandingHeader />
+      <main className="flex-1">
+        <div className="mx-auto max-w-3xl px-4 py-12 md:px-6">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Imprint (Impressum)
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Information pursuant to &sect;5 TMG (Telemediengesetz)
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Last updated: {LAST_UPDATED}
+          </p>
+
+          <div className="mt-8 space-y-8">
+            <LegalSection title="Company Information">
+              <p>
+                HeimPath
+                <br />
+                [Company legal name to be added]
+                <br />
+                [Street address]
+                <br />
+                [Postal code, City], Germany
+              </p>
+            </LegalSection>
+
+            <LegalSection title="Contact">
+              <p>
+                Email:{" "}
+                <a
+                  href="mailto:contact@heimpath.com"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  contact@heimpath.com
+                </a>
+                <br />
+                Phone: [Phone number to be added]
+              </p>
+            </LegalSection>
+
+            <LegalSection title="Represented by">
+              <p>[Managing director / founder name to be added]</p>
+            </LegalSection>
+
+            <LegalSection title="Register Entry">
+              <p>
+                [Trade register entry to be added upon registration]
+                <br />
+                Registration court: [Amtsgericht]
+                <br />
+                Registration number: [HRB number]
+              </p>
+            </LegalSection>
+
+            <LegalSection title="VAT Identification Number">
+              <p>
+                VAT ID pursuant to &sect;27a Umsatzsteuergesetz:
+                <br />
+                [VAT ID to be added, e.g., DE XXXXXXXXX]
+              </p>
+            </LegalSection>
+
+            <LegalSection title="Responsible for Content">
+              <p>
+                Responsible for content pursuant to &sect;18 Abs. 2 MStV:
+                <br />
+                [Name]
+                <br />
+                [Address]
+              </p>
+            </LegalSection>
+
+            <LegalSection title="Dispute Resolution">
+              <p>
+                The European Commission provides a platform for online dispute
+                resolution (ODR):{" "}
+                <a
+                  href="https://ec.europa.eu/consumers/odr/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  https://ec.europa.eu/consumers/odr/
+                </a>
+              </p>
+              <p>
+                We are neither obligated nor willing to participate in dispute
+                resolution proceedings before a consumer arbitration board.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="Liability for Content">
+              <p>
+                As a service provider, we are responsible for our own content on
+                these pages under general law pursuant to &sect;7(1) TMG.
+                However, under &sect;&sect;8 to 10 TMG, we are not obligated to
+                monitor transmitted or stored third-party information or to
+                investigate circumstances that indicate illegal activity.
+              </p>
+              <p>
+                Obligations to remove or block the use of information under
+                general law remain unaffected. However, liability in this regard
+                is only possible from the point in time at which we become aware
+                of a specific infringement. Upon becoming aware of such
+                violations, we will remove the content immediately.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="Liability for Links">
+              <p>
+                Our website contains links to external third-party websites over
+                whose content we have no influence. We therefore cannot accept
+                any liability for this third-party content. The respective
+                provider or operator of the linked pages is always responsible
+                for the content of the linked pages.
+              </p>
+              <p>
+                The linked pages were checked for possible legal violations at
+                the time of linking. Illegal content was not recognizable at the
+                time of linking. Permanent monitoring of the content of the
+                linked pages is not reasonable without concrete evidence of an
+                infringement. Upon becoming aware of legal violations, we will
+                remove such links immediately.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="Copyright">
+              <p>
+                The content and works on these pages created by the site
+                operator are subject to German copyright law. Duplication,
+                processing, distribution, and any form of commercialization of
+                such material beyond the scope of copyright law require the
+                prior written consent of the respective author or creator.
+              </p>
+            </LegalSection>
+          </div>
+        </div>
+      </main>
+      <LandingFooter />
+    </div>
+  )
+}

--- a/frontend/src/routes/privacy.tsx
+++ b/frontend/src/routes/privacy.tsx
@@ -1,0 +1,389 @@
+/**
+ * Privacy Policy Page
+ * Public legal page — accessible without authentication
+ * GDPR-compliant privacy policy for EU users
+ */
+
+import { createFileRoute } from "@tanstack/react-router"
+
+import { LegalSection } from "@/components/Common/LegalSection"
+import { LandingFooter } from "@/components/Landing/LandingFooter"
+import { LandingHeader } from "@/components/Landing/LandingHeader"
+
+export const Route = createFileRoute("/privacy")({
+  component: PrivacyPage,
+  head: () => ({
+    meta: [
+      { title: "Privacy Policy - HeimPath" },
+      {
+        name: "description",
+        content:
+          "HeimPath privacy policy. Learn how we collect, use, and protect your personal data in compliance with GDPR.",
+      },
+    ],
+  }),
+})
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const LAST_UPDATED = "April 20, 2026"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Privacy Policy page. */
+function PrivacyPage() {
+  return (
+    <div className="flex min-h-svh flex-col">
+      <LandingHeader />
+      <main className="flex-1">
+        <div className="mx-auto max-w-3xl px-4 py-12 md:px-6">
+          <h1 className="text-3xl font-bold tracking-tight">Privacy Policy</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Last updated: {LAST_UPDATED}
+          </p>
+
+          <div className="mt-8 space-y-8">
+            <LegalSection title="1. Data Controller">
+              <p>
+                The data controller responsible for processing your personal
+                data is:
+              </p>
+              <p>
+                HeimPath
+                <br />
+                Email:{" "}
+                <a
+                  href="mailto:privacy@heimpath.com"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  privacy@heimpath.com
+                </a>
+              </p>
+              <p>
+                For details about our company, please see our{" "}
+                <a
+                  href="/imprint"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  Imprint
+                </a>
+                .
+              </p>
+            </LegalSection>
+
+            <LegalSection title="2. What Data We Collect">
+              <p>We collect and process the following categories of data:</p>
+              <p className="font-medium text-foreground">Account data</p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  Email address, name, and password (hashed) when you create an
+                  account
+                </li>
+                <li>
+                  Profile information you provide (e.g., citizenship, property
+                  preferences)
+                </li>
+              </ul>
+              <p className="font-medium text-foreground">Usage data</p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  Pages visited, features used, journey progress, and calculator
+                  inputs
+                </li>
+                <li>
+                  Device information (browser type, operating system, screen
+                  resolution)
+                </li>
+                <li>IP address and approximate location (country/region)</li>
+              </ul>
+              <p className="font-medium text-foreground">Uploaded documents</p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  Documents you upload for translation (e.g., purchase
+                  agreements, rental contracts)
+                </li>
+                <li>
+                  These may contain personal data — please redact sensitive
+                  information before uploading if you wish
+                </li>
+              </ul>
+              <p className="font-medium text-foreground">Payment data</p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  Payment processing is handled by Stripe. We do not store your
+                  credit card numbers
+                </li>
+                <li>
+                  We receive transaction confirmations, subscription status, and
+                  billing email from Stripe
+                </li>
+              </ul>
+            </LegalSection>
+
+            <LegalSection title="3. Legal Basis for Processing">
+              <p>
+                We process your data under the following legal bases (GDPR Art.
+                6):
+              </p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  <span className="font-medium text-foreground">
+                    Contract performance (Art. 6(1)(b)):
+                  </span>{" "}
+                  Processing necessary to provide our services (account
+                  management, journey tracking, calculations, document
+                  translation)
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Legitimate interest (Art. 6(1)(f)):
+                  </span>{" "}
+                  Analytics and error monitoring to improve our services, fraud
+                  prevention, and security
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Consent (Art. 6(1)(a)):
+                  </span>{" "}
+                  Marketing communications (you can withdraw consent at any
+                  time)
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Legal obligation (Art. 6(1)(c)):
+                  </span>{" "}
+                  Retention of billing records as required by German tax law
+                </li>
+              </ul>
+            </LegalSection>
+
+            <LegalSection title="4. Third-Party Services">
+              <p>
+                We share data with the following third-party processors, each
+                bound by data processing agreements
+                (Auftragsverarbeitungsvertrag / AVV):
+              </p>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left">
+                      <th
+                        scope="col"
+                        className="pb-2 pr-4 font-semibold text-foreground"
+                      >
+                        Service
+                      </th>
+                      <th
+                        scope="col"
+                        className="pb-2 pr-4 font-semibold text-foreground"
+                      >
+                        Purpose
+                      </th>
+                      <th
+                        scope="col"
+                        className="pb-2 font-semibold text-foreground"
+                      >
+                        Data shared
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    <tr>
+                      <td className="py-2 pr-4">Microsoft Azure</td>
+                      <td className="py-2 pr-4">
+                        Hosting, document translation (Azure Translator)
+                      </td>
+                      <td className="py-2">
+                        All platform data, uploaded documents
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4">Stripe</td>
+                      <td className="py-2 pr-4">Payment processing</td>
+                      <td className="py-2">
+                        Email, subscription plan, payment details
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4">SendGrid</td>
+                      <td className="py-2 pr-4">Transactional emails</td>
+                      <td className="py-2">Email address, name</td>
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4">Sentry</td>
+                      <td className="py-2 pr-4">Error monitoring</td>
+                      <td className="py-2">
+                        Error logs, device info, IP address
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <p>
+                All processors are located within the EU/EEA or operate under
+                Standard Contractual Clauses (SCCs) approved by the European
+                Commission for data transfers outside the EU.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="5. Cookies and Tracking">
+              <p>
+                We use essential cookies required for the platform to function
+                (e.g., authentication tokens, session management). These do not
+                require consent under the ePrivacy Directive.
+              </p>
+              <p>
+                We do not currently use third-party analytics cookies or
+                advertising trackers. If this changes, we will implement a
+                cookie consent mechanism and update this policy.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="6. Data Retention">
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  <span className="font-medium text-foreground">
+                    Account data:
+                  </span>{" "}
+                  Retained while your account is active. Deleted within 30 days
+                  of account deletion.
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Uploaded documents:
+                  </span>{" "}
+                  Retained while your account is active. Deleted within 30 days
+                  of account deletion or upon your request.
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Billing records:
+                  </span>{" "}
+                  Retained for 10 years as required by German tax law (AO
+                  &sect;147).
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Error logs:
+                  </span>{" "}
+                  Retained for 90 days, then automatically purged.
+                </li>
+              </ul>
+            </LegalSection>
+
+            <LegalSection title="7. Your Rights (GDPR)">
+              <p>
+                Under the General Data Protection Regulation, you have the
+                following rights:
+              </p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  <span className="font-medium text-foreground">
+                    Right of access (Art. 15):
+                  </span>{" "}
+                  Request a copy of all personal data we hold about you
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Right to rectification (Art. 16):
+                  </span>{" "}
+                  Correct inaccurate personal data
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Right to erasure (Art. 17):
+                  </span>{" "}
+                  Request deletion of your personal data (&quot;right to be
+                  forgotten&quot;)
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Right to restrict processing (Art. 18):
+                  </span>{" "}
+                  Limit how we use your data
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Right to data portability (Art. 20):
+                  </span>{" "}
+                  Receive your data in a machine-readable format
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Right to object (Art. 21):
+                  </span>{" "}
+                  Object to processing based on legitimate interest
+                </li>
+                <li>
+                  <span className="font-medium text-foreground">
+                    Right to withdraw consent (Art. 7(3)):
+                  </span>{" "}
+                  Withdraw consent for marketing communications at any time
+                </li>
+              </ul>
+              <p>
+                To exercise any of these rights, contact us at{" "}
+                <a
+                  href="mailto:privacy@heimpath.com"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  privacy@heimpath.com
+                </a>
+                . We will respond within 30 days.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="8. Right to Lodge a Complaint">
+              <p>
+                You have the right to lodge a complaint with a data protection
+                supervisory authority. In Germany, you can contact:
+              </p>
+              <p>
+                Berliner Beauftragte für Datenschutz und Informationsfreiheit
+                <br />
+                Friedrichstr. 219, 10969 Berlin
+                <br />
+                <a
+                  href="https://www.datenschutz-berlin.de"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  www.datenschutz-berlin.de
+                </a>
+              </p>
+            </LegalSection>
+
+            <LegalSection title="9. Changes to This Policy">
+              <p>
+                We may update this Privacy Policy from time to time. We will
+                notify registered users of material changes via email at least
+                14 days before the changes take effect. The &quot;Last
+                updated&quot; date at the top of this page indicates the most
+                recent revision.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="10. Contact">
+              <p>
+                For privacy-related inquiries, please contact us at{" "}
+                <a
+                  href="mailto:privacy@heimpath.com"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  privacy@heimpath.com
+                </a>
+                .
+              </p>
+            </LegalSection>
+          </div>
+        </div>
+      </main>
+      <LandingFooter />
+    </div>
+  )
+}

--- a/frontend/src/routes/terms.tsx
+++ b/frontend/src/routes/terms.tsx
@@ -1,0 +1,255 @@
+/**
+ * Terms of Service Page
+ * Public legal page — accessible without authentication
+ */
+
+import { createFileRoute } from "@tanstack/react-router"
+
+import { LegalSection } from "@/components/Common/LegalSection"
+import { LandingFooter } from "@/components/Landing/LandingFooter"
+import { LandingHeader } from "@/components/Landing/LandingHeader"
+
+export const Route = createFileRoute("/terms")({
+  component: TermsPage,
+  head: () => ({
+    meta: [
+      { title: "Terms of Service - HeimPath" },
+      {
+        name: "description",
+        content:
+          "Terms of Service for HeimPath, the German real estate navigator for foreign investors and immigrants.",
+      },
+    ],
+  }),
+})
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const LAST_UPDATED = "April 20, 2026"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Terms of Service page. */
+function TermsPage() {
+  return (
+    <div className="flex min-h-svh flex-col">
+      <LandingHeader />
+      <main className="flex-1">
+        <div className="mx-auto max-w-3xl px-4 py-12 md:px-6">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Terms of Service
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Last updated: {LAST_UPDATED}
+          </p>
+
+          <div className="mt-8 space-y-8">
+            <LegalSection title="1. Scope of Services">
+              <p>
+                HeimPath (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;)
+                provides an online platform that helps foreign investors and
+                immigrants navigate the German real estate market. Our services
+                include guided property journeys, financial calculators, a legal
+                knowledge base, document translation tools, and a glossary of
+                German real estate terminology.
+              </p>
+              <p>
+                By creating an account or using our services, you agree to these
+                Terms of Service. If you do not agree, please do not use
+                HeimPath.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="2. Important Disclaimers">
+              <p className="font-medium text-foreground">
+                HeimPath is an informational and educational platform. We are
+                not a law firm, tax advisory service, financial advisor, or
+                licensed real estate broker.
+              </p>
+              <p>
+                The content provided through our platform — including legal
+                summaries, financial calculations, cost estimates, and document
+                translations — is for general informational purposes only and
+                does not constitute legal, tax, financial, or professional
+                advice.
+              </p>
+              <p>
+                Our calculators provide estimates based on publicly available
+                rates and user-provided inputs. Actual costs may vary. Always
+                consult a qualified notary (Notar), tax advisor (Steuerberater),
+                or legal professional before making property purchase decisions.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="3. User Accounts">
+              <p>
+                You must provide accurate and complete information when creating
+                an account. You are responsible for maintaining the
+                confidentiality of your login credentials and for all activities
+                under your account.
+              </p>
+              <p>
+                You must be at least 18 years old to create an account. We
+                reserve the right to suspend or terminate accounts that violate
+                these terms.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="4. Acceptable Use">
+              <p>You agree not to:</p>
+              <ul className="list-disc space-y-1 pl-6">
+                <li>
+                  Use the platform for any unlawful purpose or in violation of
+                  applicable laws
+                </li>
+                <li>
+                  Upload documents you do not have the legal right to share
+                </li>
+                <li>
+                  Attempt to gain unauthorized access to other users&apos;
+                  accounts or data
+                </li>
+                <li>
+                  Reverse-engineer, decompile, or attempt to extract source code
+                  from our platform
+                </li>
+                <li>
+                  Use automated tools to scrape or collect data from the
+                  platform
+                </li>
+              </ul>
+            </LegalSection>
+
+            <LegalSection title="5. Subscriptions and Payments">
+              <p>
+                HeimPath offers free and paid subscription tiers. Paid
+                subscriptions are billed through our payment processor (Stripe).
+                By subscribing to a paid plan, you authorize us to charge the
+                payment method on file.
+              </p>
+              <p>
+                Subscription fees are billed in advance on a monthly or annual
+                basis. You may cancel your subscription at any time through your
+                account settings. Cancellation takes effect at the end of the
+                current billing period.
+              </p>
+              <p>
+                We reserve the right to change subscription pricing with 30 days
+                advance notice. Existing subscribers will be notified before any
+                price change takes effect.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="6. Document Translation">
+              <p>
+                Our document translation feature uses automated translation
+                technology. Translations are provided as-is and may contain
+                inaccuracies, particularly for legal and financial terminology.
+              </p>
+              <p>
+                Translated documents should be reviewed by a qualified
+                professional before being relied upon for legal or financial
+                decisions. We flag terms that may require expert review, but
+                this flagging is not exhaustive.
+              </p>
+              <p>
+                Documents you upload are processed in accordance with our
+                Privacy Policy. We do not claim ownership of your uploaded
+                documents.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="7. Intellectual Property">
+              <p>
+                All content on HeimPath — including text, graphics, logos, and
+                software — is owned by HeimPath or its licensors and protected
+                by applicable intellectual property laws.
+              </p>
+              <p>
+                You retain ownership of any documents you upload. By using our
+                translation and analysis features, you grant us a limited
+                license to process your documents solely for the purpose of
+                providing the requested services.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="8. Limitation of Liability">
+              <p>
+                To the maximum extent permitted by applicable law, HeimPath
+                shall not be liable for any indirect, incidental, special,
+                consequential, or punitive damages arising from your use of or
+                inability to use the platform.
+              </p>
+              <p>
+                Our total liability for any claim arising from these terms or
+                your use of the platform shall not exceed the amount you paid to
+                us in the 12 months preceding the claim.
+              </p>
+              <p>
+                We do not guarantee the accuracy, completeness, or timeliness of
+                any information provided through the platform, including but not
+                limited to tax rates, legal summaries, cost calculations, and
+                market data.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="9. Termination">
+              <p>
+                You may delete your account at any time through your account
+                settings. We may suspend or terminate your account if you
+                violate these terms.
+              </p>
+              <p>
+                Upon termination, your right to use the platform ceases
+                immediately. We may retain certain data as required by law or
+                for legitimate business purposes, as described in our Privacy
+                Policy.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="10. Changes to These Terms">
+              <p>
+                We may update these Terms of Service from time to time. We will
+                notify registered users of material changes via email or an
+                in-app notification at least 14 days before the changes take
+                effect.
+              </p>
+              <p>
+                Continued use of the platform after changes take effect
+                constitutes acceptance of the updated terms.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="11. Governing Law and Jurisdiction">
+              <p>
+                These terms are governed by the laws of the Federal Republic of
+                Germany. Any disputes arising from these terms or your use of
+                the platform shall be subject to the exclusive jurisdiction of
+                the courts of Berlin, Germany.
+              </p>
+            </LegalSection>
+
+            <LegalSection title="12. Contact">
+              <p>
+                If you have questions about these Terms of Service, please
+                contact us at{" "}
+                <a
+                  href="mailto:legal@heimpath.com"
+                  className="text-foreground underline underline-offset-4"
+                >
+                  legal@heimpath.com
+                </a>
+                .
+              </p>
+            </LegalSection>
+          </div>
+        </div>
+      </main>
+      <LandingFooter />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Create `/terms` (Terms of Service), `/privacy` (Privacy Policy), and `/imprint` (Impressum) route pages
- GDPR-compliant privacy policy covering data controller, third-party services (Azure, Stripe, SendGrid, Sentry), user rights, cookie policy, and data retention
- Terms of Service covering service scope, disclaimers (not legal/tax/financial advice), subscriptions, document translation, liability limitations, German governing law
- Impressum with TMG §5 template (placeholders for company details to be filled in)
- Wire Imprint footer link from `#` to `/imprint` in LandingFooter
- Add Imprint link to Common/Footer (authenticated layout)

## Context
These pages are legally required for any commercial website targeting German users:
- **Impressum**: TMG §5 (Telemediengesetz) — mandatory for all German commercial websites
- **Privacy Policy**: GDPR Art. 13 & 14 — mandatory when collecting personal data from EU users
- **Terms of Service**: Strongly recommended, especially with the signup form consent text linking to `/terms`

The signup form already links to `/terms` and `/privacy` — both returned 404 until now. This was the #1 launch blocker.

## Test plan
- [ ] Navigate to `/terms` — page renders with full Terms of Service content
- [ ] Navigate to `/privacy` — page renders with GDPR-compliant Privacy Policy
- [ ] Navigate to `/imprint` — page renders with Impressum template
- [ ] All three pages show LandingHeader + LandingFooter (public layout)
- [ ] Footer "Imprint" link navigates to `/imprint` (not `#`)
- [ ] Authenticated footer shows Terms, Privacy, Imprint, Support links
- [ ] Signup consent text links to working `/terms` and `/privacy` pages
- [ ] Pages are accessible without authentication
- [ ] Responsive layout works on mobile and desktop