### PR TITLE
fix(ui): wire footer links and fix journey phase labels

### DIFF
--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -16,6 +16,7 @@ import {
   Upload,
 } from "lucide-react"
 
+import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
 import { cn } from "@/common/utils"
 import { ProgressBar } from "@/components/Journey/ProgressBar"
 import { GettingStartedChecklist } from "@/components/Onboarding"
@@ -49,19 +50,9 @@ interface IProps {
                               Constants
 ******************************************************************************/
 
-const PHASE_LABELS: Record<string, string> = {
-  research: "Research",
-  preparation: "Preparation",
-  buying: "Buying",
-  closing: "Closing",
-}
-
-const PHASE_COLORS: Record<string, string> = {
-  research: "bg-blue-100 text-blue-800",
-  preparation: "bg-purple-100 text-purple-800",
-  buying: "bg-orange-100 text-orange-800",
-  closing: "bg-green-100 text-green-800",
-}
+const PHASE_LABELS: Record<string, string> = Object.fromEntries(
+  JOURNEY_PHASES.map((p) => [p.key, p.label]),
+)
 
 const ACTIVITY_ICONS: Record<ActivityType, typeof FileText> = {
   journey_started: MapIcon,

--- a/frontend/src/components/Journey/JourneyCard.tsx
+++ b/frontend/src/components/Journey/JourneyCard.tsx
@@ -5,7 +5,12 @@
 
 import { Link } from "@tanstack/react-router"
 import { ArrowRight, Calendar, Home, MapPin, Trash2 } from "lucide-react"
-import { GERMAN_STATES, PHASE_COLORS, PROPERTY_TYPES } from "@/common/constants"
+import {
+  GERMAN_STATES,
+  JOURNEY_PHASES,
+  PHASE_COLORS,
+  PROPERTY_TYPES,
+} from "@/common/constants"
 import { cn, formatDate, formatEur } from "@/common/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -91,8 +96,8 @@ function JourneyCard(props: IProps) {
               variant="secondary"
               className={cn("shrink-0", PHASE_COLORS[journey.current_phase])}
             >
-              {journey.current_phase.charAt(0).toUpperCase() +
-                journey.current_phase.slice(1)}{" "}
+              {JOURNEY_PHASES.find((p) => p.key === journey.current_phase)
+                ?.label ?? journey.current_phase}{" "}
               Phase
             </Badge>
           </div>

--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -9,6 +9,7 @@ import { useState } from "react"
 import {
   FINANCING_TYPES,
   GERMAN_STATES,
+  JOURNEY_PHASES,
   PHASE_COLORS,
   PROPERTY_TYPES,
 } from "@/common/constants"
@@ -234,8 +235,8 @@ function JourneyDetail(props: IProps) {
                   PHASE_COLORS[journey.current_phase],
                 )}
               >
-                {journey.current_phase.charAt(0).toUpperCase() +
-                  journey.current_phase.slice(1)}{" "}
+                {JOURNEY_PHASES.find((p) => p.key === journey.current_phase)
+                  ?.label ?? journey.current_phase}{" "}
                 Phase
               </Badge>
             </div>

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -6,7 +6,7 @@
 import { Check, ChevronDown, ChevronRight, Circle, Clock } from "lucide-react"
 import { useState } from "react"
 
-import { PHASE_COLORS } from "@/common/constants"
+import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
 import { cn } from "@/common/utils"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -132,7 +132,8 @@ function StepCard(props: IProps) {
                 variant="outline"
                 className={cn("text-xs", PHASE_COLORS[step.phase])}
               >
-                {step.phase.charAt(0).toUpperCase() + step.phase.slice(1)}
+                {JOURNEY_PHASES.find((p) => p.key === step.phase)?.label ??
+                  step.phase}
               </Badge>
               <span className="text-xs text-muted-foreground">
                 Step {step.step_number}

--- a/frontend/src/components/Landing/LandingFooter.tsx
+++ b/frontend/src/components/Landing/LandingFooter.tsx
@@ -14,7 +14,6 @@ const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
     [
       ["Features", "#features"],
       ["How It Works", "#how-it-works"],
-      ["Pricing", "#"],
     ],
   ],
   [
@@ -25,14 +24,7 @@ const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
       ["ROI Calculator", "/tools/roi-calculator"],
     ],
   ],
-  [
-    "Company",
-    [
-      ["About", "#"],
-      ["Blog", "#"],
-      ["Contact", "mailto:support@heimpath.com"],
-    ],
-  ],
+  ["Company", [["Contact", "mailto:support@heimpath.com"]]],
   [
     "Legal",
     [


### PR DESCRIPTION
## Summary
- Remove dead `href="#"` footer links (Pricing, About, Blog) that did nothing when clicked and eroded user trust
- Fix journey phase labels: use centralized `JOURNEY_PHASES` constant in DashboardPage and JourneyDetail so "ownership" and "rental_setup" render as "Ownership" and "Rental Setup" instead of raw database values
- Replace DashboardPage's incomplete local `PHASE_LABELS` and `PHASE_COLORS` with imports from shared constants (includes dark mode support)

## Test plan
- [ ] Verify landing page footer shows no dead links — Pricing, About, Blog removed
- [ ] Verify remaining footer links work: Features, How It Works (anchor), Free Tools (routes), Contact (mailto), Legal pages (routes)
- [ ] Create a journey and verify dashboard badge shows "Ownership" and "Rental Setup" correctly
- [ ] Open journey detail and verify phase badge shows proper label (not "Rental_setup Phase")