### PR TITLE
fix(laws): include property_type in search results to prevent crash

### DIFF
--- a/backend/app/api/routes/laws.py
+++ b/backend/app/api/routes/laws.py
@@ -123,6 +123,7 @@ async def search_laws(
             citation=law.citation,
             title_en=law.title_en,
             category=LawCategory(law.category),
+            property_type=PropertyTypeApplicability(law.property_type),
             one_line_summary=law.one_line_summary,
             relevance_score=min(score, 1.0),  # Normalize to 0-1
             matched_fields=[],  # TODO: Add matched field tracking

--- a/backend/app/schemas/legal.py
+++ b/backend/app/schemas/legal.py
@@ -125,6 +125,7 @@ class LawSearchResult(BaseModel):
     citation: str
     title_en: str
     category: LawCategory
+    property_type: PropertyTypeApplicability
     one_line_summary: str
     relevance_score: float = Field(..., ge=0, le=1)
     matched_fields: list[str] = []

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4027,6 +4027,9 @@ export const LawSearchResultSchema = {
         category: {
             '$ref': '#/components/schemas/LawCategory'
         },
+        property_type: {
+            '$ref': '#/components/schemas/PropertyTypeApplicability'
+        },
         one_line_summary: {
             type: 'string',
             title: 'One Line Summary'
@@ -4047,7 +4050,7 @@ export const LawSearchResultSchema = {
         }
     },
     type: 'object',
-    required: ['id', 'citation', 'title_en', 'category', 'one_line_summary', 'relevance_score'],
+    required: ['id', 'citation', 'title_en', 'category', 'property_type', 'one_line_summary', 'relevance_score'],
     title: 'LawSearchResult',
     description: 'Search result with relevance score.'
 } as const;

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1173,6 +1173,7 @@ export type LawSearchResult = {
     citation: string;
     title_en: string;
     category: LawCategory;
+    property_type: PropertyTypeApplicability;
     one_line_summary: string;
     relevance_score: number;
     matched_fields?: Array<(string)>;

--- a/frontend/src/components/Legal/LawCard.tsx
+++ b/frontend/src/components/Legal/LawCard.tsx
@@ -61,7 +61,8 @@ function LawCard(props: IProps) {
 
   const categoryLabel =
     LAW_CATEGORIES.find((c) => c.key === law.category)?.label || law.category
-  const PropertyIcon = PROPERTY_TYPE_ICONS[law.propertyType]
+  const propertyType = law.propertyType ?? "all"
+  const PropertyIcon = PROPERTY_TYPE_ICONS[propertyType]
 
   return (
     <Card className={cn("transition-shadow hover:shadow-md group", className)}>
@@ -79,7 +80,7 @@ function LawCard(props: IProps) {
               )}
               <Badge variant="outline" className="text-xs gap-1">
                 <PropertyIcon className="h-3 w-3" />
-                {PROPERTY_TYPE_LABELS[law.propertyType]}
+                {PROPERTY_TYPE_LABELS[propertyType]}
               </Badge>
             </div>
             <Link


### PR DESCRIPTION
## Summary
- Add `property_type` field to `LawSearchResult` backend schema and populate it in the search endpoint response
- Add defensive fallback in `LawCard` component (`propertyType ?? "all"`) so missing data doesn't crash the page
- Root cause: search endpoint returned results without `property_type`, but `LawCard` unconditionally accessed `law.propertyType` to look up icons and labels, causing an unhandled undefined error

## Test plan
- [ ] Navigate to `/laws` and switch to the Search tab
- [ ] Type a search query (e.g., "notar") — results should render without crashing
- [ ] Verify search result cards show correct property type badge (icon + label)
- [ ] Verify the browse tab still works correctly
- [ ] Backend tests pass (`test-backend` CI)