### PR TITLE
fix(calculators): improve ROI calculator empty state hint

### DIFF
--- a/frontend/src/components/Calculators/ROICalculator.tsx
+++ b/frontend/src/components/Calculators/ROICalculator.tsx
@@ -1309,7 +1309,18 @@ function ROICalculator(props: IProps) {
               <div className="flex flex-col items-center justify-center py-12 text-center">
                 <TrendingUp className="h-12 w-12 text-muted-foreground mb-4" />
                 <p className="text-muted-foreground">
-                  Enter property details to see ROI analysis
+                  Enter a{" "}
+                  <span className="font-medium text-foreground">
+                    Purchase Price
+                  </span>{" "}
+                  and{" "}
+                  <span className="font-medium text-foreground">
+                    Monthly Rent
+                  </span>{" "}
+                  to see your investment analysis
+                </p>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Results update automatically as you type
                 </p>
               </div>
             )}


### PR DESCRIPTION
## Summary
- Improve the ROI Calculator empty state to clearly communicate the reactive calculation pattern
- Highlight the two required fields (Purchase Price, Monthly Rent) with bold text
- Add subtitle: "Results update automatically as you type"

## Test plan
- [ ] Open `/tools/roi-calculator` — empty state shows improved hint with highlighted field names
- [ ] Enter Purchase Price + Monthly Rent — results panel populates automatically
- [ ] Clear both fields — empty state reappears with hint