### PR TITLE
fix(auth): wire password reset to new auth endpoints

### DIFF
--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -9,7 +9,7 @@ import { Mail } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
-import { LoginService } from "@/client"
+import { AuthService } from "@/client"
 import { AuthLayout } from "@/components/Common/AuthLayout"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {
@@ -83,7 +83,7 @@ function RecoverPassword() {
   const { showSuccessToast, showErrorToast } = useCustomToast()
 
   const recoverPassword = async (data: FormData) => {
-    await LoginService.recoverPassword({ requestBody: { email: data.email } })
+    await AuthService.forgotPassword({ requestBody: { email: data.email } })
   }
 
   const mutation = useMutation({

--- a/frontend/src/routes/reset-password.tsx
+++ b/frontend/src/routes/reset-password.tsx
@@ -9,7 +9,7 @@ import { CheckCircle } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
-import { LoginService } from "@/client"
+import { AuthService } from "@/client"
 import { AuthLayout } from "@/components/Common/AuthLayout"
 import {
   Form,
@@ -118,7 +118,7 @@ function ResetPassword() {
 
   const mutation = useMutation({
     mutationFn: (data: { new_password: string; token: string }) =>
-      LoginService.resetPassword({ requestBody: data }),
+      AuthService.resetPassword({ requestBody: data }),
     onSuccess: () => {
       showSuccessToast("Password updated successfully")
     },

--- a/frontend/tests/reset-password.spec.ts
+++ b/frontend/tests/reset-password.spec.ts
@@ -87,7 +87,9 @@ test("Expired or invalid reset link", async ({ page }) => {
   await page.getByTestId("confirm-password-input").fill(password)
   await page.getByRole("button", { name: "Reset Password" }).click()
 
-  await expect(page.getByText("Invalid token")).toBeVisible()
+  await expect(
+    page.getByText("Invalid or expired password reset token"),
+  ).toBeVisible()
 })
 
 test("Weak new password validation", async ({ page, request }) => {


### PR DESCRIPTION
## Summary
- Switch password reset flow from deprecated `LoginService` endpoints to new `AuthService` endpoints
- `recover-password.tsx`: `LoginService.recoverPassword()` -> `AuthService.forgotPassword()` (uses `/api/v1/auth/forgot-password` with Redis-backed tokens, rate limiting, 1-hour TTL)
- `reset-password.tsx`: `LoginService.resetPassword()` -> `AuthService.resetPassword()` (uses `/api/v1/auth/reset-password` with one-time token consumption)

## Test plan
- [ ] Navigate to `/recover-password` from login "Forgot password?" link
- [ ] Submit email — shows "Check your email" success state
- [ ] Click reset link from email — navigates to `/reset-password?token=...`
- [ ] Enter new password + confirmation — shows success with "Sign in" link
- [ ] Rate limiting: 4th attempt within 1 hour returns 429