### PR TITLE
fix(calculators): replace json export with branded pdf in hidden costs calculator

### DIFF
--- a/frontend/src/components/Calculators/HiddenCosts/GenerateHiddenCostsPdf.ts
+++ b/frontend/src/components/Calculators/HiddenCosts/GenerateHiddenCostsPdf.ts
@@ -1,0 +1,198 @@
+/**
+ * PDF generation utility for Hidden Costs Calculator reports
+ * Uses jsPDF + jspdf-autotable for branded report output
+ */
+
+import jsPDF from "jspdf"
+
+import {
+  addFooter,
+  addHeader,
+  addSectionTitle,
+  addTable,
+  BRAND_BLUE,
+  CONTENT_WIDTH,
+  PAGE_MARGIN,
+  TEXT_MUTED,
+} from "../common/PdfHelpers"
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface CostBreakdown {
+  propertyPrice: number
+  transferTax: number
+  notaryFee: number
+  landRegistryFee: number
+  agentCommission: number
+  renovationEstimate: number
+  movingCosts: number
+  totalAdditionalCosts: number
+  totalCostOfOwnership: number
+  additionalCostPercentage: number
+}
+
+interface HiddenCostsInputs {
+  state: string
+  stateName: string
+  propertyType: string
+  propertyTypeLabel: string
+  renovationLevel: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const EUR = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+})
+
+const RENOVATION_LABELS: Record<string, string> = {
+  none: "None",
+  light: "Light (3%)",
+  medium: "Medium (8%)",
+  full: "Full (15%)",
+}
+
+/******************************************************************************
+                              Functions
+******************************************************************************/
+
+/** Add the total cost highlight box. */
+function addTotalCostHighlight(
+  doc: jsPDF,
+  costs: CostBreakdown,
+  y: number,
+): number {
+  const boxHeight = 18
+
+  // Blue border box
+  doc.setDrawColor(...BRAND_BLUE)
+  doc.setLineWidth(0.6)
+  doc.setFillColor(255, 255, 255)
+  doc.rect(PAGE_MARGIN, y, CONTENT_WIDTH, boxHeight, "S")
+
+  // Label
+  doc.setFontSize(9)
+  doc.setTextColor(...TEXT_MUTED)
+  doc.setFont("helvetica", "normal")
+  doc.text("Total Cost of Ownership", PAGE_MARGIN + 4, y + 7)
+
+  // Value
+  doc.setFontSize(16)
+  doc.setTextColor(...BRAND_BLUE)
+  doc.setFont("helvetica", "bold")
+  doc.text(EUR.format(costs.totalCostOfOwnership), PAGE_MARGIN + 4, y + 14.5)
+
+  // Additional costs percentage on the right
+  doc.setFontSize(9)
+  doc.setTextColor(...TEXT_MUTED)
+  doc.setFont("helvetica", "normal")
+  doc.text(
+    `Additional Costs: ${costs.additionalCostPercentage.toFixed(1)}%`,
+    PAGE_MARGIN + CONTENT_WIDTH - 4,
+    y + 7,
+    { align: "right" },
+  )
+  doc.text(
+    EUR.format(costs.totalAdditionalCosts),
+    PAGE_MARGIN + CONTENT_WIDTH - 4,
+    y + 14.5,
+    { align: "right" },
+  )
+
+  return y + boxHeight + 8
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+/** Generate and download a branded PDF hidden costs report. */
+export function generateHiddenCostsPdf(
+  costs: CostBreakdown,
+  inputs: Readonly<HiddenCostsInputs>,
+): void {
+  const doc = new jsPDF({ unit: "mm", format: "a4" })
+  const date = new Date().toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  })
+
+  // Header
+  let y = addHeader(doc, "Hidden Costs Calculator Report", date)
+
+  // Highlight box
+  y = addTotalCostHighlight(doc, costs, y)
+
+  // 1. Property Details
+  y = addSectionTitle(doc, "1. Property Details", y)
+  y = addTable(
+    doc,
+    [
+      ["Purchase Price", EUR.format(costs.propertyPrice)],
+      ["State (Bundesland)", inputs.stateName],
+      ["Property Type", inputs.propertyTypeLabel],
+      ["Renovation Level", RENOVATION_LABELS[inputs.renovationLevel] ?? "None"],
+    ],
+    y,
+  )
+  y += 6
+
+  // 2. Cost Breakdown
+  y = addSectionTitle(doc, "2. Cost Breakdown", y)
+
+  const rows: [string, string][] = [
+    [
+      "Property Transfer Tax (Grunderwerbsteuer)",
+      EUR.format(costs.transferTax),
+    ],
+    ["Notary Fees (Notarkosten)", EUR.format(costs.notaryFee)],
+    [
+      "Land Registry Fee (Grundbuchgebühren)",
+      EUR.format(costs.landRegistryFee),
+    ],
+  ]
+  if (costs.agentCommission > 0) {
+    rows.push([
+      "Agent Commission (Maklerprovision)",
+      EUR.format(costs.agentCommission),
+    ])
+  }
+  if (costs.renovationEstimate > 0) {
+    rows.push(["Renovation Estimate", EUR.format(costs.renovationEstimate)])
+  }
+  if (costs.movingCosts > 0) {
+    rows.push(["Moving Costs", EUR.format(costs.movingCosts)])
+  }
+
+  y = addTable(doc, rows, y)
+  y += 6
+
+  // 3. Summary
+  y = addSectionTitle(doc, "3. Summary", y)
+  y = addTable(
+    doc,
+    [
+      ["Purchase Price", EUR.format(costs.propertyPrice)],
+      ["Total Additional Costs", EUR.format(costs.totalAdditionalCosts)],
+      [
+        "Additional Cost Percentage",
+        `${costs.additionalCostPercentage.toFixed(1)}%`,
+      ],
+      ["Total Cost of Ownership", EUR.format(costs.totalCostOfOwnership)],
+    ],
+    y,
+  )
+
+  // Footer
+  addFooter(doc)
+
+  // Download
+  doc.save(`hidden-costs-report-${Date.now()}.pdf`)
+}

--- a/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
+++ b/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
@@ -45,6 +45,7 @@ import { isLoggedIn } from "@/hooks/useAuth"
 import type { HiddenCostCalculationInput } from "@/models/calculator"
 import { FormRow } from "./common/FormRow"
 import { SaveShareSection } from "./common/SaveShareSection"
+import { generateHiddenCostsPdf } from "./HiddenCosts/GenerateHiddenCostsPdf"
 
 interface IProps {
   className?: string
@@ -232,27 +233,19 @@ function HiddenCostsCalculator(props: IProps) {
   const handleExport = () => {
     if (!costs) return
 
-    const data = {
-      inputs: {
-        propertyPrice: costs.propertyPrice,
-        state: inputs.state,
-        propertyType: inputs.propertyType,
-      },
-      breakdown: costs,
-      generatedAt: new Date().toISOString(),
-    }
+    const stateName =
+      GERMAN_STATES.find((s) => s.code === inputs.state)?.name ?? inputs.state
+    const propertyTypeLabel =
+      PROPERTY_TYPES.find((t) => t.value === inputs.propertyType)?.label ??
+      inputs.propertyType
 
-    const blob = new Blob([JSON.stringify(data, null, 2)], {
-      type: "application/json",
+    generateHiddenCostsPdf(costs, {
+      state: inputs.state,
+      stateName,
+      propertyType: inputs.propertyType,
+      propertyTypeLabel,
+      renovationLevel: inputs.renovationLevel,
     })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = `cost-calculation-${Date.now()}.json`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
   }
 
   const handleSave = () => {

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/GenerateEvaluationPdf.ts
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/GenerateEvaluationPdf.ts
@@ -17,66 +17,29 @@ import type {
   PropertyEvaluationState,
 } from "@/models/propertyEvaluation"
 
+import {
+  addFooter,
+  addHeader,
+  addSectionTitle,
+  addTable,
+  BRAND_BLUE,
+  CONTENT_WIDTH,
+  ensureSpace,
+  PAGE_MARGIN,
+  TEXT_DARK,
+  TEXT_MUTED,
+} from "../common/PdfHelpers"
+
 /******************************************************************************
                               Constants
 ******************************************************************************/
 
-const BRAND_BLUE = [30, 64, 175] as const // #1e40af
-const TEXT_DARK = [17, 24, 39] as const // #111827
-const TEXT_MUTED = [107, 114, 128] as const // #6b7280
 const GREEN = [22, 163, 74] as const // #16a34a
 const RED = [220, 38, 38] as const // #dc2626
-const PAGE_MARGIN = 20
-const CONTENT_WIDTH = 170 // A4 width (210) minus 2 * margin
 
 /******************************************************************************
                               Functions
 ******************************************************************************/
-
-/** Add branded header to the PDF. */
-function addHeader(doc: jsPDF, address: string, date: string): number {
-  let y = PAGE_MARGIN
-
-  // Blue square logo with "H"
-  doc.setFillColor(...BRAND_BLUE)
-  doc.rect(PAGE_MARGIN, y, 12, 12, "F")
-  doc.setTextColor(255, 255, 255)
-  doc.setFontSize(10)
-  doc.setFont("helvetica", "bold")
-  doc.text("H", PAGE_MARGIN + 4.2, y + 8.5)
-
-  // Title
-  doc.setTextColor(...TEXT_DARK)
-  doc.setFontSize(18)
-  doc.setFont("helvetica", "bold")
-  doc.text("HeimPath", PAGE_MARGIN + 16, y + 5)
-
-  // Subtitle
-  doc.setFontSize(11)
-  doc.setFont("helvetica", "normal")
-  doc.setTextColor(...TEXT_MUTED)
-  doc.text("Property Evaluation Report", PAGE_MARGIN + 16, y + 11)
-
-  y += 18
-
-  // Address and date
-  doc.setFontSize(9)
-  doc.setTextColor(...TEXT_MUTED)
-  if (address) {
-    doc.text(address, PAGE_MARGIN, y)
-    y += 5
-  }
-  doc.text(`Generated: ${date}`, PAGE_MARGIN, y)
-  y += 4
-
-  // Blue divider
-  doc.setDrawColor(...BRAND_BLUE)
-  doc.setLineWidth(0.8)
-  doc.line(PAGE_MARGIN, y, PAGE_MARGIN + CONTENT_WIDTH, y)
-  y += 6
-
-  return y
-}
 
 /** Add the cashflow highlight box. */
 function addCashflowHighlight(
@@ -128,92 +91,6 @@ function addCashflowHighlight(
   )
 
   return y + boxHeight + 8
-}
-
-/** Add a section title. */
-function addSectionTitle(doc: jsPDF, title: string, y: number): number {
-  doc.setFontSize(11)
-  doc.setFont("helvetica", "bold")
-  doc.setTextColor(...BRAND_BLUE)
-  doc.text(title, PAGE_MARGIN, y)
-  return y + 2
-}
-
-/** Add a two-column table using autoTable. */
-function addTable(
-  doc: jsPDF,
-  rows: [string, string][],
-  startY: number,
-): number {
-  autoTable(doc, {
-    startY,
-    margin: { left: PAGE_MARGIN, right: PAGE_MARGIN },
-    tableWidth: CONTENT_WIDTH,
-    head: [],
-    body: rows,
-    theme: "plain",
-    styles: {
-      fontSize: 9,
-      cellPadding: { top: 2.5, bottom: 2.5, left: 3, right: 3 },
-      textColor: [...TEXT_DARK] as [number, number, number],
-    },
-    columnStyles: {
-      0: { cellWidth: CONTENT_WIDTH * 0.55, fontStyle: "normal" },
-      1: {
-        cellWidth: CONTENT_WIDTH * 0.45,
-        halign: "right",
-        fontStyle: "bold",
-      },
-    },
-    alternateRowStyles: {
-      fillColor: [248, 250, 252], // slate-50
-    },
-  })
-
-  return (doc as jsPDF & { lastAutoTable: { finalY: number } }).lastAutoTable
-    .finalY
-}
-
-/** Add footer to every page. */
-function addFooter(doc: jsPDF): void {
-  const pageCount = doc.getNumberOfPages()
-  for (let i = 1; i <= pageCount; i++) {
-    doc.setPage(i)
-    const pageHeight = doc.internal.pageSize.getHeight()
-
-    // Disclaimer
-    doc.setFontSize(7)
-    doc.setTextColor(...TEXT_MUTED)
-    doc.text(
-      "This report is for informational purposes only and does not constitute financial or legal advice.",
-      PAGE_MARGIN,
-      pageHeight - 14,
-    )
-
-    // Branding + page number
-    doc.setFontSize(8)
-    doc.setFont("helvetica", "bold")
-    doc.setTextColor(...BRAND_BLUE)
-    doc.text("HeimPath", PAGE_MARGIN, pageHeight - 8)
-    doc.setFont("helvetica", "normal")
-    doc.setTextColor(...TEXT_MUTED)
-    doc.text(
-      `Page ${i} of ${pageCount}`,
-      PAGE_MARGIN + CONTENT_WIDTH,
-      pageHeight - 8,
-      { align: "right" },
-    )
-  }
-}
-
-/** Check if we need a new page and add one if so. */
-function ensureSpace(doc: jsPDF, y: number, needed: number): number {
-  const pageHeight = doc.internal.pageSize.getHeight()
-  if (y + needed > pageHeight - 25) {
-    doc.addPage()
-    return PAGE_MARGIN
-  }
-  return y
 }
 
 /** Add the Property Overview section (shared by both variants). */
@@ -322,7 +199,12 @@ export function generateEvaluationPdf(
   })
 
   // Header
-  let y = addHeader(doc, state.propertyInfo.address, date)
+  let y = addHeader(
+    doc,
+    "Property Evaluation Report",
+    date,
+    state.propertyInfo.address,
+  )
 
   if (isOwnerOccupier) {
     // Owner-occupier variant: cost of ownership focus

--- a/frontend/src/components/Calculators/common/PdfHelpers.ts
+++ b/frontend/src/components/Calculators/common/PdfHelpers.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared PDF generation helpers for calculator reports.
+ * Used by GenerateEvaluationPdf and GenerateHiddenCostsPdf.
+ */
+
+import type jsPDF from "jspdf"
+import autoTable from "jspdf-autotable"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+export const BRAND_BLUE = [30, 64, 175] as const // #1e40af
+export const TEXT_DARK = [17, 24, 39] as const // #111827
+export const TEXT_MUTED = [107, 114, 128] as const // #6b7280
+export const PAGE_MARGIN = 20
+export const CONTENT_WIDTH = 170 // A4 width (210) minus 2 * margin
+
+/******************************************************************************
+                              Functions
+******************************************************************************/
+
+/** Add branded header to the PDF. */
+export function addHeader(
+  doc: jsPDF,
+  subtitle: string,
+  date: string,
+  address?: string,
+): number {
+  let y = PAGE_MARGIN
+
+  // Blue square logo with "H"
+  doc.setFillColor(...BRAND_BLUE)
+  doc.rect(PAGE_MARGIN, y, 12, 12, "F")
+  doc.setTextColor(255, 255, 255)
+  doc.setFontSize(10)
+  doc.setFont("helvetica", "bold")
+  doc.text("H", PAGE_MARGIN + 4.2, y + 8.5)
+
+  // Title
+  doc.setTextColor(...TEXT_DARK)
+  doc.setFontSize(18)
+  doc.setFont("helvetica", "bold")
+  doc.text("HeimPath", PAGE_MARGIN + 16, y + 5)
+
+  // Subtitle
+  doc.setFontSize(11)
+  doc.setFont("helvetica", "normal")
+  doc.setTextColor(...TEXT_MUTED)
+  doc.text(subtitle, PAGE_MARGIN + 16, y + 11)
+
+  y += 18
+
+  // Address and date
+  doc.setFontSize(9)
+  doc.setTextColor(...TEXT_MUTED)
+  if (address) {
+    doc.text(address, PAGE_MARGIN, y)
+    y += 5
+  }
+  doc.text(`Generated: ${date}`, PAGE_MARGIN, y)
+  y += 4
+
+  // Blue divider
+  doc.setDrawColor(...BRAND_BLUE)
+  doc.setLineWidth(0.8)
+  doc.line(PAGE_MARGIN, y, PAGE_MARGIN + CONTENT_WIDTH, y)
+  y += 6
+
+  return y
+}
+
+/** Add a section title. */
+export function addSectionTitle(doc: jsPDF, title: string, y: number): number {
+  doc.setFontSize(11)
+  doc.setFont("helvetica", "bold")
+  doc.setTextColor(...BRAND_BLUE)
+  doc.text(title, PAGE_MARGIN, y)
+  return y + 2
+}
+
+/** Add a two-column table using autoTable. */
+export function addTable(
+  doc: jsPDF,
+  rows: [string, string][],
+  startY: number,
+): number {
+  autoTable(doc, {
+    startY,
+    margin: { left: PAGE_MARGIN, right: PAGE_MARGIN },
+    tableWidth: CONTENT_WIDTH,
+    head: [],
+    body: rows,
+    theme: "plain",
+    styles: {
+      fontSize: 9,
+      cellPadding: { top: 2.5, bottom: 2.5, left: 3, right: 3 },
+      textColor: [...TEXT_DARK] as [number, number, number],
+    },
+    columnStyles: {
+      0: { cellWidth: CONTENT_WIDTH * 0.55, fontStyle: "normal" },
+      1: {
+        cellWidth: CONTENT_WIDTH * 0.45,
+        halign: "right",
+        fontStyle: "bold",
+      },
+    },
+    alternateRowStyles: {
+      fillColor: [248, 250, 252], // slate-50
+    },
+  })
+
+  return (doc as jsPDF & { lastAutoTable: { finalY: number } }).lastAutoTable
+    .finalY
+}
+
+/** Add footer to every page. */
+export function addFooter(doc: jsPDF): void {
+  const pageCount = doc.getNumberOfPages()
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i)
+    const pageHeight = doc.internal.pageSize.getHeight()
+
+    // Disclaimer
+    doc.setFontSize(7)
+    doc.setTextColor(...TEXT_MUTED)
+    doc.text(
+      "This report is for informational purposes only and does not constitute financial or legal advice.",
+      PAGE_MARGIN,
+      pageHeight - 14,
+    )
+
+    // Branding + page number
+    doc.setFontSize(8)
+    doc.setFont("helvetica", "bold")
+    doc.setTextColor(...BRAND_BLUE)
+    doc.text("HeimPath", PAGE_MARGIN, pageHeight - 8)
+    doc.setFont("helvetica", "normal")
+    doc.setTextColor(...TEXT_MUTED)
+    doc.text(
+      `Page ${i} of ${pageCount}`,
+      PAGE_MARGIN + CONTENT_WIDTH,
+      pageHeight - 8,
+      { align: "right" },
+    )
+  }
+}
+
+/** Check if we need a new page and add one if so. */
+export function ensureSpace(doc: jsPDF, y: number, needed: number): number {
+  const pageHeight = doc.internal.pageSize.getHeight()
+  if (y + needed > pageHeight - 25) {
+    doc.addPage()
+    return PAGE_MARGIN
+  }
+  return y
+}


### PR DESCRIPTION
## Summary
- Replace the JSON file export in the Hidden Costs Calculator with a branded PDF report using jsPDF + jspdf-autotable
- PDF includes HeimPath branded header, total cost highlight box, property details, itemized cost breakdown, and summary table
- Follows the same pattern as the existing Property Evaluation Calculator PDF export (`GenerateEvaluationPdf.ts`)

## Test plan
- [ ] Open Hidden Costs Calculator, enter a property price and state
- [ ] Click "Export Results" — a PDF file should download
- [ ] Verify PDF contains branded header, cost breakdown table, and footer disclaimer
- [ ] Verify all cost line items match what's shown on screen