### PR TITLE
fix(auth): distinguish empty vs invalid email validation

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -23,7 +23,10 @@ import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
 
 const formSchema = z.object({
-  username: z.string().email({ message: "Please enter a valid email address" }),
+  username: z
+    .string()
+    .min(1, { message: "Email is required" })
+    .email({ message: "Please enter a valid email address" }),
   password: z
     .string()
     .min(1, { message: "Password is required" })

--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -27,7 +27,10 @@ import useCustomToast from "@/hooks/useCustomToast"
 import { handleError } from "@/utils"
 
 const formSchema = z.object({
-  email: z.string().email({ message: "Please enter a valid email address" }),
+  email: z
+    .string()
+    .min(1, { message: "Email is required" })
+    .email({ message: "Please enter a valid email address" }),
 })
 
 type FormData = z.infer<typeof formSchema>

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -36,7 +36,10 @@ import useAuth, { isLoggedIn } from "@/hooks/useAuth"
 
 const formSchema = z
   .object({
-    email: z.string().email({ message: "Please enter a valid email address" }),
+    email: z
+      .string()
+      .min(1, { message: "Email is required" })
+      .email({ message: "Please enter a valid email address" }),
     full_name: z.string().min(1, { message: "Full name is required" }),
     citizenship: z.string().optional(),
     password: z

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -148,9 +148,7 @@ test("Sign up with missing email", async ({ page }) => {
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Create Account" }).click()
 
-  await expect(
-    page.getByText("Please enter a valid email address"),
-  ).toBeVisible()
+  await expect(page.getByText("Email is required")).toBeVisible()
 })
 
 test("Sign up with missing password", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add `.min(1, { message: "Email is required" })` before `.email()` validation on signup, login, and recover-password forms
- Empty field now shows "Email is required" instead of "Please enter a valid email address"
- Invalid format still shows "Please enter a valid email address"

## Test plan
- [ ] On signup form, submit with empty email — should show "Email is required"
- [ ] On signup form, enter "abc" then blur — should show "Please enter a valid email address"
- [ ] Same behavior verified on login and recover-password forms