### PR TITLE
fix(glossary): improve empty state message

### DIFF
--- a/frontend/src/components/Glossary/GlossaryList.tsx
+++ b/frontend/src/components/Glossary/GlossaryList.tsx
@@ -56,7 +56,7 @@ function EmptyState(props: Readonly<{ category?: GlossaryCategory }>) {
       <p className="mt-2 text-sm text-muted-foreground max-w-sm">
         {category
           ? "No terms found in this category. Try selecting a different category."
-          : "No glossary terms available. Check back later for updates."}
+          : "We're building a comprehensive glossary of 120+ German real estate terms. This feature is coming soon."}
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
- Replace generic "Check back later for updates" empty state with a friendlier teaser message
- Sets expectations about the upcoming 120+ term glossary instead of implying the feature is broken
- Category-filtered empty state remains unchanged ("No terms found in this category")

## Test plan
- [ ] Verify glossary page shows improved message when no terms are loaded
- [ ] Verify category filter empty state still shows category-specific message