### PR TITLE
fix(professionals): make entire card clickable

### DIFF
--- a/frontend/src/components/Professionals/ProfessionalCard.tsx
+++ b/frontend/src/components/Professionals/ProfessionalCard.tsx
@@ -42,93 +42,94 @@ function ProfessionalCard(props: Readonly<IProps>) {
   const { professional, className } = props
 
   return (
-    <Card className={cn("transition-shadow hover:shadow-md group", className)}>
-      <CardHeader className="pb-2">
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 flex-wrap">
-            <Badge
-              variant="outline"
-              className={cn("text-xs", TYPE_COLORS[professional.type])}
-            >
-              {PROFESSIONAL_TYPE_LABELS[professional.type]}
-            </Badge>
-            {professional.isVerified && (
+    <Link
+      to="/professionals/$professionalId"
+      params={{ professionalId: professional.id }}
+      className="block"
+    >
+      <Card
+        className={cn(
+          "cursor-pointer transition-all hover:shadow-md hover:-translate-y-0.5 group h-full",
+          className,
+        )}
+      >
+        <CardHeader className="pb-2">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <Badge
                 variant="outline"
-                className="text-xs bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400"
+                className={cn("text-xs", TYPE_COLORS[professional.type])}
               >
-                <BadgeCheck className="h-3 w-3 mr-1" />
-                Verified
+                {PROFESSIONAL_TYPE_LABELS[professional.type]}
               </Badge>
-            )}
-          </div>
-          <Link
-            to="/professionals/$professionalId"
-            params={{ professionalId: professional.id }}
-            className="block"
-          >
+              {professional.isVerified && (
+                <Badge
+                  variant="outline"
+                  className="text-xs bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400"
+                >
+                  <BadgeCheck className="h-3 w-3 mr-1" />
+                  Verified
+                </Badge>
+              )}
+            </div>
             <CardTitle className="text-base font-semibold group-hover:text-blue-600 transition-colors">
               {professional.name}
             </CardTitle>
-          </Link>
-          <div className="flex items-center gap-2">
-            <StarRating rating={Math.round(professional.averageRating)} />
-            <span className="text-xs text-muted-foreground">
-              {professional.averageRating.toFixed(1)} (
-              {professional.reviewCount}{" "}
-              {professional.reviewCount === 1 ? "review" : "reviews"})
-            </span>
+            <div className="flex items-center gap-2">
+              <StarRating rating={Math.round(professional.averageRating)} />
+              <span className="text-xs text-muted-foreground">
+                {professional.averageRating.toFixed(1)} (
+                {professional.reviewCount}{" "}
+                {professional.reviewCount === 1 ? "review" : "reviews"})
+              </span>
+            </div>
+            {professional.recommendationRate != null &&
+              professional.recommendationRate > 80 &&
+              professional.reviewCount >= 3 && (
+                <Badge
+                  variant="outline"
+                  className="text-xs bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                >
+                  <ThumbsUp className="h-3 w-3 mr-1" />
+                  Recommended by {Math.round(professional.recommendationRate)}%
+                </Badge>
+              )}
           </div>
-          {professional.recommendationRate != null &&
-            professional.recommendationRate > 80 &&
-            professional.reviewCount >= 3 && (
-              <Badge
-                variant="outline"
-                className="text-xs bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-              >
-                <ThumbsUp className="h-3 w-3 mr-1" />
-                Recommended by {Math.round(professional.recommendationRate)}%
-              </Badge>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-col gap-1.5 text-sm text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <MapPin className="h-3.5 w-3.5 shrink-0" />
+              {professional.city}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Globe className="h-3.5 w-3.5 shrink-0" />
+              {professional.languages}
+            </span>
+            {professional.email && (
+              <span className="flex items-center gap-1.5">
+                <Mail className="h-3.5 w-3.5 shrink-0" />
+                {professional.email}
+              </span>
             )}
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div className="flex flex-col gap-1.5 text-sm text-muted-foreground">
-          <span className="flex items-center gap-1.5">
-            <MapPin className="h-3.5 w-3.5 shrink-0" />
-            {professional.city}
-          </span>
-          <span className="flex items-center gap-1.5">
-            <Globe className="h-3.5 w-3.5 shrink-0" />
-            {professional.languages}
-          </span>
-          {professional.email && (
-            <span className="flex items-center gap-1.5">
-              <Mail className="h-3.5 w-3.5 shrink-0" />
-              {professional.email}
-            </span>
+            {professional.phone && (
+              <span className="flex items-center gap-1.5">
+                <Phone className="h-3.5 w-3.5 shrink-0" />
+                {professional.phone}
+              </span>
+            )}
+          </div>
+          {professional.description && (
+            <p className="text-sm text-muted-foreground line-clamp-2">
+              {professional.description}
+            </p>
           )}
-          {professional.phone && (
-            <span className="flex items-center gap-1.5">
-              <Phone className="h-3.5 w-3.5 shrink-0" />
-              {professional.phone}
-            </span>
-          )}
-        </div>
-        {professional.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2">
-            {professional.description}
-          </p>
-        )}
-        <Link
-          to="/professionals/$professionalId"
-          params={{ professionalId: professional.id }}
-          className="inline-block text-sm font-medium text-blue-600 hover:text-blue-700"
-        >
-          View profile →
-        </Link>
-      </CardContent>
-    </Card>
+          <span className="inline-block text-sm font-medium text-blue-600 group-hover:text-blue-700">
+            View profile →
+          </span>
+        </CardContent>
+      </Card>
+    </Link>
   )
 }
 


### PR DESCRIPTION
## Summary
- Wrap ProfessionalCard in a `Link` so the entire card navigates to the profile
- Add hover lift effect (`hover:-translate-y-0.5`) and `cursor-pointer`
- Remove redundant inner `Link` elements (name link, "View profile" link) to avoid nested `<a>` tags
- Keep "View profile →" as a visual indicator using `<span>` with group-hover color

## Test plan
- [ ] Clicking anywhere on a professional card navigates to the profile
- [ ] Card shows pointer cursor and lift effect on hover
- [ ] Card is keyboard-accessible (Tab + Enter navigates)
- [ ] No nested `<a>` tag warnings in browser console