### PR TITLE
fix(journey): prevent wizard overflow at mid-width viewports

### DIFF
--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -317,7 +317,7 @@ function JourneyWizard(props: IProps) {
   const isSubmitStep = showSummary
 
   return (
-    <div className={cn("space-y-8", className)}>
+    <div className={cn("space-y-8 overflow-hidden", className)}>
       <WizardStepIndicator
         steps={WIZARD_STEPS.map((s) => ({ id: s.id, title: s.title }))}
         currentStep={showSummary ? WIZARD_STEPS.length + 1 : currentStep}

--- a/frontend/src/components/Journey/WizardStepIndicator.tsx
+++ b/frontend/src/components/Journey/WizardStepIndicator.tsx
@@ -65,7 +65,7 @@ function StepDot(props: {
       {!isLast && (
         <div
           className={cn(
-            "mx-1 sm:mx-2 h-0.5 w-4 sm:w-12 md:w-16",
+            "mx-1 sm:mx-2 h-0.5 w-4 shrink sm:min-w-4 sm:flex-1 sm:max-w-16",
             isCompleted ? "bg-green-600" : "bg-muted-foreground/30",
           )}
         />


### PR DESCRIPTION
## Summary
- Make step indicator connectors flexible (`flex-1` with `max-w-16`) instead of fixed widths (`sm:w-12 md:w-16`), so they shrink when the sidebar reduces available content width at ~901px
- Add `overflow-hidden` to the wizard container to prevent any horizontal scrollbar

## Test plan
- [ ] Test at 768px, 901px, 1024px viewport widths with sidebar open
- [ ] Step indicator connectors shrink proportionally at narrow widths
- [ ] No horizontal scrollbar or content clipping at any breakpoint
- [ ] Back/Next buttons are fully visible at all widths