### PR TITLE
fix(articles): hide view count when below threshold

### DIFF
--- a/frontend/src/components/Articles/ArticleCard.tsx
+++ b/frontend/src/components/Articles/ArticleCard.tsx
@@ -101,10 +101,12 @@ function ArticleCard(props: IProps) {
               <Clock className="h-3 w-3" />
               {article.readingTimeMinutes} min read
             </span>
-            <span className="flex items-center gap-1">
-              <Eye className="h-3 w-3" />
-              {article.viewCount.toLocaleString()} views
-            </span>
+            {article.viewCount > 10 && (
+              <span className="flex items-center gap-1">
+                <Eye className="h-3 w-3" />
+                {article.viewCount.toLocaleString()} views
+              </span>
+            )}
           </div>
         </div>
       </CardHeader>

--- a/frontend/src/components/Articles/ArticleDetail.tsx
+++ b/frontend/src/components/Articles/ArticleDetail.tsx
@@ -300,10 +300,12 @@ function ArticleDetail(props: IProps) {
             <Clock className="h-3.5 w-3.5" />
             {article.readingTimeMinutes} min read
           </span>
-          <span className="flex items-center gap-1">
-            <Eye className="h-3.5 w-3.5" />
-            {article.viewCount.toLocaleString()} views
-          </span>
+          {article.viewCount > 10 && (
+            <span className="flex items-center gap-1">
+              <Eye className="h-3.5 w-3.5" />
+              {article.viewCount.toLocaleString()} views
+            </span>
+          )}
         </div>
 
         <ShareButtons title={article.title} slug={article.slug} />


### PR DESCRIPTION
## Summary
- Hide article view count on card and detail pages when views are 10 or fewer
- Prevents "0 views" from showing during beta launch, which signals an unused product
- View count automatically appears once articles get real traffic (>10 views)

## Test plan
- [ ] Articles with 0 views show no view count
- [ ] Articles with >10 views show the count normally
- [ ] Reading time still displays on all articles
- [ ] Consistent behavior on both listing cards and detail page