### PR TITLE
fix(auth): add rate limiting to resend-verification

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -313,8 +313,21 @@ async def resend_verification(
     Generates a new verification token and sends it to the user's email.
     Any previous token for the user is invalidated.
 
+    Rate limiting: 3 attempts per hour.
+
     Note: Always returns success to prevent email enumeration attacks.
     """
+    # Check rate limit before processing
+    if rate_limit_service.is_resend_verification_locked(request.email):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many verification email requests. Please try again later.",
+            headers={"Retry-After": "3600"},
+        )
+
+    # Record attempt regardless of outcome (prevents email enumeration via timing)
+    rate_limit_service.record_resend_verification_attempt(request.email)
+
     # Find user by email
     statement = select(User).where(User.email == request.email)
     user = session.exec(statement).first()

--- a/backend/app/services/rate_limit_service.py
+++ b/backend/app/services/rate_limit_service.py
@@ -29,6 +29,11 @@ PASSWORD_RESET_MAX_ATTEMPTS: int = 3
 PASSWORD_RESET_WINDOW_SECONDS: int = 3600  # 1 hour
 PASSWORD_RESET_LOCKOUT_SECONDS: int = 3600  # 1 hour
 
+# Resend verification rate limit constants
+RESEND_VERIFICATION_MAX_ATTEMPTS: int = 3
+RESEND_VERIFICATION_WINDOW_SECONDS: int = 3600  # 1 hour
+RESEND_VERIFICATION_LOCKOUT_SECONDS: int = 3600  # 1 hour
+
 _ATTEMPTS_PREFIX = "auth:ratelimit:attempts:"
 _LOCKOUT_PREFIX = "auth:ratelimit:lockout:"
 
@@ -37,6 +42,9 @@ _REGISTER_LOCKOUT_PREFIX = "auth:ratelimit:register:lockout:"
 
 _PASSWORD_RESET_ATTEMPTS_PREFIX = "auth:ratelimit:password_reset:attempts:"
 _PASSWORD_RESET_LOCKOUT_PREFIX = "auth:ratelimit:password_reset:lockout:"
+
+_RESEND_VERIFICATION_ATTEMPTS_PREFIX = "auth:ratelimit:resend_verification:attempts:"
+_RESEND_VERIFICATION_LOCKOUT_PREFIX = "auth:ratelimit:resend_verification:lockout:"
 
 # Module-level Redis client (connection pool, lazily initialised)
 _redis_client: redis_lib.Redis | None = None
@@ -214,4 +222,24 @@ def record_password_reset_attempt(identifier: str) -> RateLimitInfo:
         PASSWORD_RESET_MAX_ATTEMPTS,
         PASSWORD_RESET_WINDOW_SECONDS,
         PASSWORD_RESET_LOCKOUT_SECONDS,
+    )
+
+
+# ── Resend verification rate limiting ────────────────────────────────────────
+
+
+def is_resend_verification_locked(identifier: str) -> bool:
+    """Return *True* if the identifier is locked for resend verification."""
+    return _redis().ttl(f"{_RESEND_VERIFICATION_LOCKOUT_PREFIX}{identifier}") > 0
+
+
+def record_resend_verification_attempt(identifier: str) -> RateLimitInfo:
+    """Record a resend-verification attempt and return the updated status."""
+    return _record_attempt(
+        identifier,
+        _RESEND_VERIFICATION_ATTEMPTS_PREFIX,
+        _RESEND_VERIFICATION_LOCKOUT_PREFIX,
+        RESEND_VERIFICATION_MAX_ATTEMPTS,
+        RESEND_VERIFICATION_WINDOW_SECONDS,
+        RESEND_VERIFICATION_LOCKOUT_SECONDS,
     )

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -309,6 +309,8 @@ export class AuthService {
      * Generates a new verification token and sends it to the user's email.
      * Any previous token for the user is invalidated.
      *
+     * Rate limiting: 3 attempts per hour.
+     *
      * Note: Always returns success to prevent email enumeration attacks.
      * @param data The data for the request.
      * @param data.requestBody


### PR DESCRIPTION
## Summary
- Add rate limiting (3 attempts/hour) to the resend-verification endpoint
- Follows same pattern as forgot-password and register endpoints
- Prevents abuse via repeated verification email requests
- Records attempt before processing to prevent timing-based enumeration

## Test plan
- [ ] Resend verification works normally for first 3 attempts
- [ ] 4th attempt within 1 hour returns 429 Too Many Requests
- [ ] Rate limit resets after the lockout period
- [ ] Error message is user-friendly: "Too many verification email requests"