### PR TITLE
feat(landing): replace hero icon cards with SVG illustration

### DIFF
--- a/frontend/src/components/Landing/HeroIllustration.tsx
+++ b/frontend/src/components/Landing/HeroIllustration.tsx
@@ -1,0 +1,412 @@
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Decorative SVG illustration of a stylized German property scene. */
+function HeroIllustration() {
+  return (
+    <svg
+      viewBox="0 0 400 360"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className="h-full w-full"
+    >
+      {/* Ground line */}
+      <rect
+        x="0"
+        y="300"
+        width="400"
+        height="60"
+        rx="8"
+        className="fill-blue-100/60 dark:fill-blue-900/30"
+      />
+
+      {/* Background building — left Altbau */}
+      <rect
+        x="30"
+        y="150"
+        width="70"
+        height="150"
+        rx="2"
+        className="fill-blue-200/40 dark:fill-blue-800/40"
+      />
+      <rect
+        x="30"
+        y="140"
+        width="70"
+        height="14"
+        rx="2"
+        className="fill-blue-300/40 dark:fill-blue-700/40"
+      />
+      {/* Altbau windows */}
+      <rect
+        x="42"
+        y="170"
+        width="14"
+        height="18"
+        rx="7"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="72"
+        y="170"
+        width="14"
+        height="18"
+        rx="7"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="42"
+        y="210"
+        width="14"
+        height="18"
+        rx="7"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="72"
+        y="210"
+        width="14"
+        height="18"
+        rx="7"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="42"
+        y="250"
+        width="14"
+        height="18"
+        rx="7"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="72"
+        y="250"
+        width="14"
+        height="18"
+        rx="7"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+
+      {/* Background building — right apartment */}
+      <rect
+        x="310"
+        y="120"
+        width="65"
+        height="180"
+        rx="2"
+        className="fill-blue-200/40 dark:fill-blue-800/40"
+      />
+      <rect
+        x="310"
+        y="112"
+        width="65"
+        height="12"
+        rx="2"
+        className="fill-blue-300/40 dark:fill-blue-700/40"
+      />
+      {/* Apartment windows */}
+      <rect
+        x="320"
+        y="138"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="350"
+        y="138"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="320"
+        y="170"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="350"
+        y="170"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="320"
+        y="202"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="350"
+        y="202"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="320"
+        y="234"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="350"
+        y="234"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="320"
+        y="266"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+      <rect
+        x="350"
+        y="266"
+        width="12"
+        height="16"
+        rx="2"
+        className="fill-blue-100/60 dark:fill-blue-900/40"
+      />
+
+      {/* Dashed path — "HeimPath" metaphor */}
+      <path
+        d="M 60 340 C 120 320, 140 280, 200 270"
+        fill="none"
+        strokeWidth="2.5"
+        strokeDasharray="8 6"
+        strokeLinecap="round"
+        className="stroke-blue-400 dark:stroke-blue-500"
+      />
+
+      {/* Stepping stones along the path */}
+      <circle
+        cx="80"
+        cy="332"
+        r="4"
+        className="fill-blue-300/60 dark:fill-blue-600/60"
+      />
+      <circle
+        cx="120"
+        cy="312"
+        r="4"
+        className="fill-blue-300/60 dark:fill-blue-600/60"
+      />
+      <circle
+        cx="158"
+        cy="286"
+        r="4"
+        className="fill-blue-300/60 dark:fill-blue-600/60"
+      />
+
+      {/* Central house — walls */}
+      <rect
+        x="150"
+        y="200"
+        width="100"
+        height="100"
+        rx="2"
+        className="fill-blue-100 dark:fill-blue-900/60"
+      />
+
+      {/* Central house — roof */}
+      <polygon points="140,200 200,145 260,200" className="fill-blue-600" />
+
+      {/* Chimney */}
+      <rect
+        x="225"
+        y="155"
+        width="14"
+        height="30"
+        rx="2"
+        className="fill-blue-500"
+      />
+
+      {/* Central house — door */}
+      <rect
+        x="186"
+        y="256"
+        width="28"
+        height="44"
+        rx="3"
+        className="fill-purple-500"
+      />
+      <circle cx="208" cy="280" r="2.5" className="fill-purple-300" />
+
+      {/* Central house — windows */}
+      <rect
+        x="160"
+        y="216"
+        width="22"
+        height="22"
+        rx="2"
+        className="fill-white/80 dark:fill-blue-800/60"
+      />
+      <rect
+        x="218"
+        y="216"
+        width="22"
+        height="22"
+        rx="2"
+        className="fill-white/80 dark:fill-blue-800/60"
+      />
+      <line
+        x1="171"
+        y1="216"
+        x2="171"
+        y2="238"
+        strokeWidth="1.5"
+        className="stroke-blue-300/60 dark:stroke-blue-600/60"
+      />
+      <line
+        x1="160"
+        y1="227"
+        x2="182"
+        y2="227"
+        strokeWidth="1.5"
+        className="stroke-blue-300/60 dark:stroke-blue-600/60"
+      />
+      <line
+        x1="229"
+        y1="216"
+        x2="229"
+        y2="238"
+        strokeWidth="1.5"
+        className="stroke-blue-300/60 dark:stroke-blue-600/60"
+      />
+      <line
+        x1="218"
+        y1="227"
+        x2="240"
+        y2="227"
+        strokeWidth="1.5"
+        className="stroke-blue-300/60 dark:stroke-blue-600/60"
+      />
+
+      {/* Key motif — lower right */}
+      <g transform="translate(290, 260) rotate(-30)">
+        {/* Key head — ring */}
+        <circle
+          cx="0"
+          cy="0"
+          r="12"
+          fill="none"
+          strokeWidth="3.5"
+          className="stroke-blue-600 dark:stroke-blue-400"
+        />
+        {/* Key shaft */}
+        <line
+          x1="12"
+          y1="0"
+          x2="42"
+          y2="0"
+          strokeWidth="3.5"
+          strokeLinecap="round"
+          className="stroke-blue-600 dark:stroke-blue-400"
+        />
+        {/* Key teeth */}
+        <line
+          x1="34"
+          y1="0"
+          x2="34"
+          y2="8"
+          strokeWidth="3"
+          strokeLinecap="round"
+          className="stroke-blue-600 dark:stroke-blue-400"
+        />
+        <line
+          x1="42"
+          y1="0"
+          x2="42"
+          y2="10"
+          strokeWidth="3"
+          strokeLinecap="round"
+          className="stroke-blue-600 dark:stroke-blue-400"
+        />
+      </g>
+
+      {/* Euro sign accent */}
+      <g transform="translate(120, 130)">
+        <circle
+          cx="0"
+          cy="0"
+          r="16"
+          className="fill-purple-100/60 dark:fill-purple-900/40"
+        />
+        <text
+          x="0"
+          y="6"
+          textAnchor="middle"
+          fontSize="18"
+          fontWeight="bold"
+          className="fill-purple-400"
+        >
+          €
+        </text>
+      </g>
+
+      {/* Document icon accent */}
+      <g transform="translate(320, 80)">
+        <rect
+          x="-10"
+          y="-14"
+          width="20"
+          height="28"
+          rx="3"
+          className="fill-blue-100/60 dark:fill-blue-900/40"
+        />
+        <line
+          x1="-5"
+          y1="-5"
+          x2="5"
+          y2="-5"
+          strokeWidth="2"
+          strokeLinecap="round"
+          className="stroke-blue-400"
+        />
+        <line
+          x1="-5"
+          y1="1"
+          x2="5"
+          y2="1"
+          strokeWidth="2"
+          strokeLinecap="round"
+          className="stroke-blue-400"
+        />
+        <line
+          x1="-5"
+          y1="7"
+          x2="2"
+          y2="7"
+          strokeWidth="2"
+          strokeLinecap="round"
+          className="stroke-blue-400"
+        />
+      </g>
+    </svg>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { HeroIllustration }

--- a/frontend/src/components/Landing/HeroSection.tsx
+++ b/frontend/src/components/Landing/HeroSection.tsx
@@ -1,52 +1,15 @@
 import { Link } from "@tanstack/react-router"
-import { Calculator, FileText, Home, Scale } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 
-/******************************************************************************
-                              Constants
-******************************************************************************/
-
-const HERO_ICONS = [
-  {
-    icon: Home,
-    color: "bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-400",
-    size: "h-16 w-16",
-    iconSize: "h-8 w-8",
-    position: "top-0 right-0",
-  },
-  {
-    icon: Scale,
-    color:
-      "bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400",
-    size: "h-14 w-14",
-    iconSize: "h-7 w-7",
-    position: "top-20 right-24",
-  },
-  {
-    icon: Calculator,
-    color:
-      "bg-orange-100 text-orange-600 dark:bg-orange-900/40 dark:text-orange-400",
-    size: "h-12 w-12",
-    iconSize: "h-6 w-6",
-    position: "bottom-8 right-4",
-  },
-  {
-    icon: FileText,
-    color:
-      "bg-green-100 text-green-600 dark:bg-green-900/40 dark:text-green-400",
-    size: "h-14 w-14",
-    iconSize: "h-7 w-7",
-    position: "bottom-0 right-20",
-  },
-] as const
+import { HeroIllustration } from "./HeroIllustration"
 
 /******************************************************************************
                               Components
 ******************************************************************************/
 
-/** Default component. Hero section with headline, CTAs, and decorative icons. */
+/** Default component. Hero section with headline, CTAs, and property illustration. */
 function HeroSection() {
   return (
     <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20">
@@ -57,22 +20,25 @@ function HeroSection() {
       <div className="mx-auto flex max-w-7xl flex-col items-center gap-12 px-4 py-20 md:flex-row md:px-6 md:py-28 lg:py-32">
         {/* Text content */}
         <div className="flex flex-1 flex-col items-center text-center md:items-start md:text-left">
-          <Badge variant="secondary" className="mb-6">
+          <Badge
+            variant="secondary"
+            className="mb-6 animate-in fade-in slide-in-from-bottom-3 duration-500 fill-mode-backwards motion-reduce:animate-none"
+          >
             Your German Property Journey Starts Here
           </Badge>
 
-          <h1 className="text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
+          <h1 className="animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards text-4xl font-bold tracking-tight delay-100 duration-500 motion-reduce:animate-none md:text-5xl lg:text-6xl">
             Navigate German Real Estate{" "}
             <span className="text-blue-600">with Confidence</span>
           </h1>
 
-          <p className="mt-6 max-w-xl text-lg text-muted-foreground">
+          <p className="mt-6 max-w-xl animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards text-lg text-muted-foreground delay-200 duration-500 motion-reduce:animate-none">
             HeimPath guides foreign investors and immigrants through every step
             of buying property in Germany — from research to closing, in a
             language you understand.
           </p>
 
-          <div className="mt-8 flex flex-wrap gap-4">
+          <div className="mt-8 flex animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards flex-wrap gap-4 delay-300 duration-500 motion-reduce:animate-none">
             <Button size="lg" asChild>
               <Link to="/signup">Start Your Journey</Link>
             </Button>
@@ -82,16 +48,9 @@ function HeroSection() {
           </div>
         </div>
 
-        {/* Decorative icon composition */}
-        <div className="relative hidden h-64 w-64 md:block lg:h-80 lg:w-80">
-          {HERO_ICONS.map(({ icon: Icon, color, size, iconSize, position }) => (
-            <div
-              key={position}
-              className={`absolute ${position} flex ${size} items-center justify-center rounded-2xl ${color} shadow-sm`}
-            >
-              <Icon className={iconSize} />
-            </div>
-          ))}
+        {/* Property illustration */}
+        <div className="hidden flex-1 animate-in fade-in zoom-in-95 fill-mode-backwards delay-300 duration-700 motion-reduce:animate-none md:block md:max-w-xs lg:max-w-sm">
+          <HeroIllustration />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Replace abstract floating icon cards in the hero section with a custom inline SVG illustration depicting a stylized German property scene (buildings, central house, key motif, dashed path, euro and document accents)
- Add staggered fade-up animations to hero text elements using tw-animate-css utilities
- SVG supports dark mode via Tailwind classes and is hidden on mobile, visible on md+

## Test plan
- [ ] Verify illustration renders correctly in light mode
- [ ] Verify illustration renders correctly in dark mode
- [ ] Verify illustration is hidden on mobile, visible on md+ breakpoints
- [ ] Verify text animations play in staggered sequence on page load
- [ ] Verify no TypeScript errors (`bunx tsc --noEmit`)
- [ ] Verify pre-commit hooks pass