### PR TITLE
feat(dashboard): replace journey progress bar with ring chart

### DIFF
--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -18,7 +18,7 @@ import {
 
 import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
 import { cn } from "@/common/utils"
-import { ProgressBar } from "@/components/Journey/ProgressBar"
+import JourneyRingChart from "@/components/Dashboard/JourneyRingChart"
 import { GettingStartedChecklist } from "@/components/Onboarding"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -126,29 +126,10 @@ function JourneyOverviewCard(props: { journey: JourneyOverview }) {
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-2">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">Overall Progress</span>
-            <span className="font-medium">
-              {journey.completedSteps} / {journey.totalSteps} steps
-            </span>
-          </div>
-          <ProgressBar value={journey.progressPercentage} showLabel size="md" />
-        </div>
-
-        {/* Phase progress indicators */}
-        <div className="grid grid-cols-4 gap-2">
-          {Object.entries(journey.phases).map(([phase, counts]) => (
-            <div key={phase} className="text-center">
-              <div className="text-xs text-muted-foreground mb-1">
-                {PHASE_LABELS[phase] ?? phase}
-              </div>
-              <div className="text-sm font-medium">
-                {counts.completed}/{counts.total}
-              </div>
-            </div>
-          ))}
-        </div>
+        <JourneyRingChart
+          phases={journey.phases}
+          overallPercentage={journey.progressPercentage}
+        />
 
         {journey.nextStepTitle && (
           <div className="flex items-center justify-between rounded-lg border p-3">

--- a/frontend/src/components/Dashboard/JourneyRingChart.tsx
+++ b/frontend/src/components/Dashboard/JourneyRingChart.tsx
@@ -1,0 +1,196 @@
+/**
+ * Journey Progress Ring Chart
+ * Donut chart showing per-phase completion with overall percentage in center.
+ */
+
+import { JOURNEY_PHASES } from "@/common/constants"
+import Colors from "@/common/styles/Colors"
+
+interface PhaseData {
+  total: number
+  completed: number
+}
+
+interface IProps {
+  phases: Record<string, PhaseData>
+  overallPercentage: number
+  size?: number
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const STROKE_WIDTH = 10
+const ARC_GAP = 4
+
+const PHASE_CHART_COLORS: Record<string, { stroke: string; bg: string }> = {
+  research: { stroke: Colors.Journey.Research, bg: "#dbeafe" },
+  preparation: { stroke: Colors.Journey.Preparation, bg: "#f3e8ff" },
+  buying: { stroke: Colors.Journey.Buying, bg: "#ffedd5" },
+  closing: { stroke: Colors.Journey.Closing, bg: "#dcfce7" },
+  // ownership and rental_setup are not in Colors.Journey — defined locally
+  ownership: { stroke: "#f59e0b", bg: "#fef3c7" },
+  rental_setup: { stroke: "#14b8a6", bg: "#ccfbf1" },
+}
+
+const DEFAULT_COLOR = { stroke: "#6b7280", bg: "#f3f4f6" }
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Single ring arc for a phase. */
+function PhaseArc(props: {
+  cx: number
+  cy: number
+  radius: number
+  strokeWidth: number
+  percentage: number
+  offset: number
+  circumference: number
+  color: string
+  bgColor: string
+}) {
+  const { cx, cy, radius, strokeWidth, percentage, offset, circumference } =
+    props
+  const dashLength = (percentage / 100) * circumference
+  const gapLength = circumference - dashLength
+
+  return (
+    <g>
+      {/* Background track */}
+      <circle
+        cx={cx}
+        cy={cy}
+        r={radius}
+        fill="none"
+        stroke={props.bgColor}
+        strokeWidth={strokeWidth}
+        strokeDasharray={`${circumference}`}
+        strokeDashoffset={-offset}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${cx} ${cy})`}
+        className="opacity-40 dark:opacity-20"
+      />
+      {/* Filled arc */}
+      {dashLength > 0 && (
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke={props.color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={`${dashLength} ${gapLength}`}
+          strokeDashoffset={-offset}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${cx} ${cy})`}
+          className="transition-all duration-700 ease-out motion-reduce:transition-none"
+        />
+      )}
+    </g>
+  )
+}
+
+/** Default component. Donut chart with per-phase arcs. */
+function JourneyRingChart(props: Readonly<IProps>) {
+  const { phases, overallPercentage, size = 160 } = props
+
+  const cx = size / 2
+  const cy = size / 2
+  const outerRadius = size / 2 - STROKE_WIDTH / 2 - 2
+
+  // Build ordered phase entries that exist in the data
+  const phaseEntries = JOURNEY_PHASES.filter((p) => phases[p.key] != null).map(
+    (p) => ({
+      key: p.key,
+      label: p.label,
+      ...phases[p.key],
+    }),
+  )
+
+  const phaseCount = phaseEntries.length
+  if (phaseCount === 0) return null
+
+  // Each phase gets an equal arc segment of the circle
+  const totalCircumference = 2 * Math.PI * outerRadius
+  const gapTotal = phaseCount * ARC_GAP
+  const availableArc = totalCircumference - gapTotal
+  const arcPerPhase = availableArc / phaseCount
+
+  // Pre-compute offsets to avoid mutable state in render
+  const offsets = phaseEntries.map((_, i) => i * (arcPerPhase + ARC_GAP))
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="relative" style={{ width: size, height: size }}>
+        <svg
+          width={size}
+          height={size}
+          viewBox={`0 0 ${size} ${size}`}
+          aria-hidden="true"
+        >
+          {phaseEntries.map((phase, idx) => {
+            const colors = PHASE_CHART_COLORS[phase.key] ?? DEFAULT_COLOR
+            const phasePercentage =
+              phase.total > 0 ? (phase.completed / phase.total) * 100 : 0
+            const filledLength = (phasePercentage / 100) * arcPerPhase
+            const fillPct =
+              totalCircumference > 0
+                ? (filledLength / totalCircumference) * 100
+                : 0
+
+            return (
+              <PhaseArc
+                key={phase.key}
+                cx={cx}
+                cy={cy}
+                radius={outerRadius}
+                strokeWidth={STROKE_WIDTH}
+                percentage={fillPct}
+                offset={offsets[idx]}
+                circumference={totalCircumference}
+                color={colors.stroke}
+                bgColor={colors.bg}
+              />
+            )
+          })}
+        </svg>
+
+        {/* Center label */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-2xl font-bold">{overallPercentage}%</span>
+          <span className="text-xs text-muted-foreground">Complete</span>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+        {phaseEntries.map((phase) => {
+          const colors = PHASE_CHART_COLORS[phase.key] ?? DEFAULT_COLOR
+          return (
+            <div key={phase.key} className="flex items-center gap-1.5 text-xs">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: colors.stroke }}
+              />
+              <span className="text-muted-foreground">
+                {phase.label}{" "}
+                <span className="font-medium text-foreground">
+                  {phase.completed}/{phase.total}
+                </span>
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default JourneyRingChart


### PR DESCRIPTION
## Summary
- Replace the plain progress bar and numeric phase grid on the dashboard journey card with a donut/ring chart
- Each journey phase (Research, Preparation, Buying, Closing, etc.) gets a color-coded arc segment showing fill level
- Overall completion percentage displayed in the center of the ring
- Color-coded legend below the chart shows phase name and completed/total counts
- Smooth transition animation on the filled arcs, respects `prefers-reduced-motion`
- Works in both light and dark mode

## Test plan
- [ ] Dashboard shows ring chart when user has an active journey
- [ ] Each phase arc fills proportionally to completed/total steps
- [ ] Center shows correct overall percentage
- [ ] Legend shows all active phases with correct counts
- [ ] Colors match existing phase color scheme (blue=Research, purple=Preparation, orange=Buying, green=Closing)
- [ ] Dark mode: chart is readable with appropriate opacity
- [ ] Mobile: chart scales down and remains legible
- [ ] `prefers-reduced-motion`: transitions are disabled