### PR TITLE
feat(ui): color-code portfolio stat cards and sidebar active state

### DIFF
--- a/frontend/src/components/Portfolio/KpiSummaryBar.tsx
+++ b/frontend/src/components/Portfolio/KpiSummaryBar.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Building2, DollarSign, Home, TrendingUp } from "lucide-react"
-import { formatEur } from "@/common/utils"
+import { cn, formatEur } from "@/common/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { PortfolioSummary } from "@/models/portfolio"
 
@@ -31,11 +31,19 @@ function KpiSummaryBar(props: Readonly<IProps>) {
       title: "Properties",
       value: String(summary.totalProperties),
       icon: Building2,
+      iconColor: "text-blue-600 dark:text-blue-400",
+      accent: "border-l-blue-500",
     },
     {
       title: "Net Cash Flow",
       value: formatEur(summary.netCashFlow),
       icon: DollarSign,
+      iconColor:
+        summary.netCashFlow >= 0
+          ? "text-emerald-600 dark:text-emerald-400"
+          : "text-red-600 dark:text-red-400",
+      accent:
+        summary.netCashFlow >= 0 ? "border-l-emerald-500" : "border-l-red-500",
       valueClassName:
         summary.netCashFlow >= 0
           ? "text-emerald-600 dark:text-emerald-400"
@@ -45,26 +53,30 @@ function KpiSummaryBar(props: Readonly<IProps>) {
       title: "Vacancy Rate",
       value: formatPercent(summary.vacancyRate),
       icon: Home,
+      iconColor: "text-amber-600 dark:text-amber-400",
+      accent: "border-l-amber-500",
     },
     {
       title: "Avg. Gross Yield",
       value: formatPercent(summary.averageGrossYield),
       icon: TrendingUp,
+      iconColor: "text-teal-600 dark:text-teal-400",
+      accent: "border-l-teal-500",
     },
   ]
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {cards.map((card) => (
-        <Card key={card.title}>
+        <Card key={card.title} className={cn("border-l-4", card.accent)}>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground">
               {card.title}
             </CardTitle>
-            <card.icon className="h-4 w-4 text-muted-foreground" />
+            <card.icon className={cn("h-4 w-4", card.iconColor)} />
           </CardHeader>
           <CardContent>
-            <div className={`text-2xl font-bold ${card.valueClassName ?? ""}`}>
+            <div className={cn("text-2xl font-bold", card.valueClassName)}>
               {card.value}
             </div>
           </CardContent>

--- a/frontend/src/components/Sidebar/Main.tsx
+++ b/frontend/src/components/Sidebar/Main.tsx
@@ -1,6 +1,7 @@
 import { Link as RouterLink, useRouterState } from "@tanstack/react-router"
 import type { LucideIcon } from "lucide-react"
 
+import { cn } from "@/common/utils"
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -49,9 +50,12 @@ export function Main({ items }: MainProps) {
                   tooltip={item.title}
                   isActive={isActive}
                   asChild
+                  className={cn(
+                    isActive && "border-l-[3px] border-l-primary pl-[5px]",
+                  )}
                 >
                   <RouterLink to={item.path} onClick={handleMenuClick}>
-                    <item.icon />
+                    <item.icon className={cn(isActive && "text-primary")} />
                     <span>{item.title}</span>
                   </RouterLink>
                 </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- Color-code portfolio KPI stat cards with distinct accent colors per metric type
  - Properties: blue icon + left border
  - Net Cash Flow: green/red (dynamic based on positive/negative value)
  - Vacancy Rate: amber icon + left border
  - Avg. Gross Yield: teal icon + left border
- Improve sidebar navigation active state with a primary-colored left border and icon highlight

## Test plan
- [ ] Portfolio page: verify each stat card has a distinct colored left border and icon
- [ ] Portfolio page: add property with negative cash flow — verify card turns red
- [ ] Portfolio page: positive cash flow — verify card shows green
- [ ] Sidebar: verify active page has a visible left border accent and colored icon
- [ ] Sidebar: navigate between pages — verify active state follows
- [ ] Sidebar collapsed: verify active state is still visible (left border)
- [ ] Dark mode: verify colors have sufficient contrast
- [ ] Mobile: verify sidebar active state works in mobile drawer