### PR TITLE
feat(dashboard): add budget gauge and days-to-target countdown

### DIFF
--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -36,6 +36,10 @@ class JourneyOverview(BaseModel):
     next_step_title: str | None = None
     next_step_id: uuid.UUID | None = None
     phases: dict[str, dict[str, int]]
+    budget_euros: int | None = None
+    target_purchase_date: datetime | None = None
+    days_to_target: int | None = None
+    estimated_total_cost: float | None = None
 
 
 class SavedDocumentSummary(BaseModel):

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -74,6 +74,9 @@ def get_journey_overview(
     progress = journey_service.get_progress(session, journey)
     next_step = journey_service.get_next_step(session, journey)
 
+    days_to_target = _compute_days_to_target(journey.target_purchase_date)
+    estimated_total_cost = _get_estimated_total_cost(session, user_id)
+
     return JourneyOverview(
         id=journey.id,
         title=journey.title,
@@ -87,7 +90,42 @@ def get_journey_overview(
         next_step_title=next_step.title if next_step else None,
         next_step_id=next_step.id if next_step else None,
         phases=progress["phases"],
+        budget_euros=journey.budget_euros,
+        target_purchase_date=journey.target_purchase_date,
+        days_to_target=days_to_target,
+        estimated_total_cost=estimated_total_cost,
     )
+
+
+def _compute_days_to_target(
+    target_purchase_date: datetime | None,
+) -> int | None:
+    """Compute days remaining until the target purchase date."""
+    if target_purchase_date is None:
+        return None
+    now = datetime.now(timezone.utc)
+    target = (
+        target_purchase_date.replace(tzinfo=timezone.utc)
+        if target_purchase_date.tzinfo is None
+        else target_purchase_date
+    )
+    delta = (target - now).days
+    return max(delta, 0)
+
+
+def _get_estimated_total_cost(
+    session: Session,
+    user_id: uuid.UUID,
+) -> float | None:
+    """Get the total cost of ownership from the user's most recent hidden cost calculation."""
+    statement = (
+        select(HiddenCostCalculation.total_cost_of_ownership)
+        .where(HiddenCostCalculation.user_id == user_id)
+        .order_by(HiddenCostCalculation.created_at.desc())
+        .limit(1)
+    )
+    result = session.exec(statement).first()
+    return result
 
 
 def _get_recent_documents(

--- a/backend/tests/services/test_dashboard_service.py
+++ b/backend/tests/services/test_dashboard_service.py
@@ -18,9 +18,11 @@ from app.schemas.dashboard import (
     JourneyOverview,
 )
 from app.services.dashboard_service import (
+    _compute_days_to_target,
     _count_documents_this_month,
     _count_total_bookmarks,
     _count_total_calculations,
+    _get_estimated_total_cost,
     _get_recent_bookmarks,
     _get_recent_calculations,
     _get_recent_documents,
@@ -143,14 +145,19 @@ class TestGetJourneyOverview:
         assert result is None
 
     @patch("app.services.dashboard_service.journey_service")
+    @patch("app.services.dashboard_service._get_estimated_total_cost")
     def test_returns_overview_for_active_journey(
-        self, mock_js, user_id: uuid.UUID
+        self, mock_cost, mock_js, user_id: uuid.UUID
     ) -> None:
         """Test that overview is built from the most recent active journey."""
+        mock_cost.return_value = 250_000.0
+
         mock_journey = MagicMock(spec=Journey)
         mock_journey.id = uuid.uuid4()
         mock_journey.title = "Berlin Apartment"
         mock_journey.started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        mock_journey.budget_euros = 200_000
+        mock_journey.target_purchase_date = datetime(2026, 12, 1, tzinfo=timezone.utc)
 
         mock_next_step = MagicMock(spec=JourneyStep)
         mock_next_step.title = "Define Your Property Goals"
@@ -180,16 +187,25 @@ class TestGetJourneyOverview:
         assert result.total_steps == 15
         assert result.next_step_title == "Define Your Property Goals"
         assert result.next_step_id == mock_next_step.id
+        assert result.budget_euros == 200_000
+        assert result.estimated_total_cost == 250_000.0
+        assert result.days_to_target is not None
+        assert result.days_to_target >= 0
 
+    @patch("app.services.dashboard_service._get_estimated_total_cost")
     @patch("app.services.dashboard_service.journey_service")
     def test_handles_completed_journey_no_next_step(
-        self, mock_js, user_id: uuid.UUID
+        self, mock_js, mock_cost, user_id: uuid.UUID
     ) -> None:
         """Test overview when journey is complete (no next step)."""
+        mock_cost.return_value = None
+
         mock_journey = MagicMock(spec=Journey)
         mock_journey.id = uuid.uuid4()
         mock_journey.title = "Completed Journey"
         mock_journey.started_at = datetime(2025, 6, 1, tzinfo=timezone.utc)
+        mock_journey.budget_euros = None
+        mock_journey.target_purchase_date = None
 
         mock_js.get_user_journeys.return_value = [mock_journey]
         mock_js.get_progress.return_value = {
@@ -460,6 +476,65 @@ class TestCountTotalCalculations:
 
         result = _count_total_calculations(mock_session, user_id)
         assert result == 0
+
+
+class TestComputeDaysToTarget:
+    """Tests for days-to-target computation."""
+
+    def test_returns_none_when_no_target_date(self) -> None:
+        """Test None result when target date is not set."""
+        assert _compute_days_to_target(None) is None
+
+    def test_returns_positive_days_for_future_date(self) -> None:
+        """Test positive day count for a future target date."""
+        from datetime import timedelta
+
+        future = datetime.now(timezone.utc) + timedelta(days=100)
+        result = _compute_days_to_target(future)
+        assert result is not None
+        # Allow 1-day rounding tolerance
+        assert 99 <= result <= 100
+
+    def test_returns_zero_for_past_date(self) -> None:
+        """Test that past dates return 0 (not negative)."""
+        from datetime import timedelta
+
+        past = datetime.now(timezone.utc) - timedelta(days=30)
+        result = _compute_days_to_target(past)
+        assert result == 0
+
+    def test_handles_naive_datetime(self) -> None:
+        """Test that naive datetime is treated as UTC."""
+        from datetime import timedelta
+
+        naive_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+            days=50
+        )
+        result = _compute_days_to_target(naive_future)
+        assert result is not None
+        assert 49 <= result <= 50
+
+
+class TestGetEstimatedTotalCost:
+    """Tests for estimated total cost lookup."""
+
+    def test_returns_cost_from_most_recent_calculation(
+        self, user_id: uuid.UUID
+    ) -> None:
+        """Test that the most recent calculation's total_cost_of_ownership is returned."""
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = 350_000.0
+
+        result = _get_estimated_total_cost(mock_session, user_id)
+        assert result == 350_000.0
+
+    def test_returns_none_when_no_calculations(self, user_id: uuid.UUID) -> None:
+        """Test None when user has no hidden cost calculations."""
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = None
+
+        result = _get_estimated_total_cost(mock_session, user_id)
+        assert result is None
 
 
 class TestCountTotalBookmarks:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3061,6 +3061,51 @@ export const JourneyOverviewSchema = {
             },
             type: 'object',
             title: 'Phases'
+        },
+        budget_euros: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Budget Euros'
+        },
+        target_purchase_date: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Target Purchase Date'
+        },
+        days_to_target: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Days To Target'
+        },
+        estimated_total_cost: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Estimated Total Cost'
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -919,6 +919,10 @@ export type JourneyOverview = {
             [key: string]: (number);
         };
     };
+    budget_euros?: (number | null);
+    target_purchase_date?: (string | null);
+    days_to_target?: (number | null);
+    estimated_total_cost?: (number | null);
 };
 
 /**

--- a/frontend/src/components/Dashboard/BudgetGaugeCard.tsx
+++ b/frontend/src/components/Dashboard/BudgetGaugeCard.tsx
@@ -1,0 +1,157 @@
+/**
+ * Budget vs Estimated Cost Gauge Card
+ * Shows a gauge comparing the user's budget against estimated total property cost
+ */
+
+import { Link } from "@tanstack/react-router"
+import { ArrowRight } from "lucide-react"
+
+import { cn } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+interface IProps {
+  budgetEuros: number | null
+  estimatedTotalCost: number | null
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const EUR = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 0,
+})
+
+const AMBER_THRESHOLD = 0.9
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** CTA when no evaluation exists yet. */
+function EvaluationCta() {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Budget Check</CardTitle>
+        <CardDescription>
+          Run a cost calculation to see how your budget compares
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button variant="outline" size="sm" className="w-full" asChild>
+          <Link to="/calculators">
+            Calculate Costs
+            <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Main gauge display. */
+function GaugeBar(props: Readonly<{ budget: number; estimated: number }>) {
+  const { budget, estimated } = props
+  const ratio = estimated / budget
+  const fillPercent = Math.min(ratio * 100, 100)
+  const overflowPercent = ratio > 1 ? Math.min((ratio - 1) * 100, 100) : 0
+
+  const status =
+    ratio <= AMBER_THRESHOLD ? "under" : ratio <= 1 ? "close" : "over"
+
+  const barColor =
+    status === "under"
+      ? "bg-green-500"
+      : status === "close"
+        ? "bg-amber-500"
+        : "bg-red-500"
+
+  const statusLabel =
+    status === "under"
+      ? "Under budget"
+      : status === "close"
+        ? "Close to budget"
+        : "Over budget"
+
+  const statusColor =
+    status === "under"
+      ? "text-green-600 dark:text-green-400"
+      : status === "close"
+        ? "text-amber-600 dark:text-amber-400"
+        : "text-red-600 dark:text-red-400"
+
+  return (
+    <div className="space-y-3">
+      {/* Gauge bar */}
+      <div className="relative h-3 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn("h-full rounded-full transition-all", barColor)}
+          style={{ width: `${fillPercent}%` }}
+        />
+        {overflowPercent > 0 && (
+          <div
+            className="absolute right-0 top-0 h-full animate-pulse bg-red-500/30"
+            style={{ width: `${overflowPercent}%` }}
+          />
+        )}
+        {/* Budget marker line */}
+        <div className="absolute right-0 top-0 h-full w-0.5 bg-foreground/40" />
+      </div>
+
+      {/* Labels */}
+      <div className="flex items-center justify-between text-sm">
+        <div>
+          <span className="text-muted-foreground">Estimated </span>
+          <span className="font-semibold">{EUR.format(estimated)}</span>
+        </div>
+        <div className="text-right">
+          <span className="text-muted-foreground">Budget </span>
+          <span className="font-semibold">{EUR.format(budget)}</span>
+        </div>
+      </div>
+
+      {/* Status badge */}
+      <p className={cn("text-center text-xs font-medium", statusColor)}>
+        {statusLabel}
+        {status === "over" && ` by ${EUR.format(estimated - budget)}`}
+      </p>
+    </div>
+  )
+}
+
+/** Default component. Budget gauge card for the dashboard. */
+function BudgetGaugeCard(props: Readonly<IProps>) {
+  const { budgetEuros, estimatedTotalCost } = props
+
+  if (budgetEuros == null || budgetEuros <= 0 || estimatedTotalCost == null) {
+    return <EvaluationCta />
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Budget Check</CardTitle>
+        <CardDescription>Budget vs estimated total cost</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <GaugeBar budget={budgetEuros} estimated={estimatedTotalCost} />
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default BudgetGaugeCard

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -18,6 +18,8 @@ import {
 
 import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
 import { cn } from "@/common/utils"
+import BudgetGaugeCard from "@/components/Dashboard/BudgetGaugeCard"
+import DaysToTargetCard from "@/components/Dashboard/DaysToTargetCard"
 import JourneyRingChart from "@/components/Dashboard/JourneyRingChart"
 import { GettingStartedChecklist } from "@/components/Onboarding"
 import { Badge } from "@/components/ui/badge"
@@ -497,7 +499,20 @@ function DashboardPage(props: Readonly<IProps>) {
         {/* Left column: 2/3 width */}
         <div className="space-y-6 lg:col-span-2">
           {data.hasJourney && data.journey ? (
-            <JourneyOverviewCard journey={data.journey} />
+            <>
+              <JourneyOverviewCard journey={data.journey} />
+              <div className="grid gap-4 sm:grid-cols-2">
+                <BudgetGaugeCard
+                  budgetEuros={data.journey.budgetEuros}
+                  estimatedTotalCost={data.journey.estimatedTotalCost}
+                />
+                <DaysToTargetCard
+                  daysToTarget={data.journey.daysToTarget}
+                  targetPurchaseDate={data.journey.targetPurchaseDate}
+                  journeyId={data.journey.id}
+                />
+              </div>
+            </>
           ) : (
             <EmptyJourneyCard />
           )}

--- a/frontend/src/components/Dashboard/DaysToTargetCard.tsx
+++ b/frontend/src/components/Dashboard/DaysToTargetCard.tsx
@@ -1,0 +1,118 @@
+/**
+ * Days-to-Target Countdown Card
+ * Shows days remaining until the user's target purchase date
+ */
+
+import { Link } from "@tanstack/react-router"
+import { ArrowRight, CalendarClock } from "lucide-react"
+
+import { cn } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+interface IProps {
+  daysToTarget: number | null
+  targetPurchaseDate: string | null
+  journeyId: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const DATE_FMT = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+})
+
+const MILESTONES: { maxDays: number; message: string }[] = [
+  { maxDays: 0, message: "Today is the day — good luck!" },
+  { maxDays: 14, message: "Final stretch — check all documents are ready" },
+  { maxDays: 30, message: "Time to confirm notary appointment" },
+  { maxDays: 60, message: "Schedule your notary appointment soon" },
+  { maxDays: 90, message: "Start finalising your mortgage offer" },
+  { maxDays: 180, message: "Good pace — keep progressing on your steps" },
+]
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** CTA when no target date is set. */
+function SetDateCta(props: Readonly<{ journeyId: string }>) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Target Date</CardTitle>
+        <CardDescription>
+          Set a target closing date to track your timeline
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button variant="outline" size="sm" className="w-full" asChild>
+          <Link
+            to="/journeys/$journeyId"
+            params={{ journeyId: props.journeyId }}
+          >
+            Set Target Date
+            <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Default component. Countdown card for the dashboard. */
+function DaysToTargetCard(props: Readonly<IProps>) {
+  const { daysToTarget, targetPurchaseDate, journeyId } = props
+
+  if (daysToTarget == null || targetPurchaseDate == null) {
+    return <SetDateCta journeyId={journeyId} />
+  }
+
+  const milestone = MILESTONES.find((m) => daysToTarget <= m.maxDays)
+  const dateLabel = DATE_FMT.format(new Date(targetPurchaseDate))
+
+  const urgencyColor =
+    daysToTarget <= 30
+      ? "text-red-600 dark:text-red-400"
+      : daysToTarget <= 90
+        ? "text-amber-600 dark:text-amber-400"
+        : "text-blue-600 dark:text-blue-400"
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-4 w-4 text-muted-foreground" />
+          <CardTitle className="text-base">Target Date</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2 text-center">
+        <p className={cn("text-4xl font-bold tabular-nums", urgencyColor)}>
+          {daysToTarget}
+        </p>
+        <p className="text-sm text-muted-foreground">days until {dateLabel}</p>
+        {milestone && (
+          <p className="text-xs text-muted-foreground italic">
+            {milestone.message}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default DaysToTargetCard

--- a/frontend/src/models/dashboard.ts
+++ b/frontend/src/models/dashboard.ts
@@ -25,6 +25,10 @@ export interface JourneyOverview {
   nextStepTitle: string | null
   nextStepId: string | null
   phases: Record<string, { total: number; completed: number }>
+  budgetEuros: number | null
+  targetPurchaseDate: string | null
+  daysToTarget: number | null
+  estimatedTotalCost: number | null
 }
 
 export interface SavedDocumentSummary {


### PR DESCRIPTION
## Summary
- Adds **Budget Gauge** widget comparing user's budget vs estimated total cost (from most recent hidden cost calculation) with green/amber/red color coding
- Adds **Days-to-Target Countdown** widget showing days until target purchase date with milestone-based guidance messages
- Both widgets show contextual CTAs when data is missing (no calculation or no target date set)
- Extends `JourneyOverview` schema with `budget_euros`, `target_purchase_date`, `days_to_target`, and `estimated_total_cost` fields

## Test plan
- [ ] Create journey with budget and target date, run a hidden cost calculation — verify gauge shows budget vs estimated cost with correct color
- [ ] Change budget to exceed estimate — verify gauge turns green
- [ ] Remove calculation — verify CTA "Calculate Costs" appears
- [ ] Remove target date — verify countdown shows "Set Target Date" CTA
- [ ] Verify countdown shows correct days and milestone message
- [ ] Test at 375px mobile viewport — widgets stack vertically
- [ ] Run `bunx tsc --noEmit` — no errors
- [ ] Run `pre-commit run --all-files` — clean
- [ ] Run `pytest tests/services/test_dashboard_service.py` — 25 tests pass