### PR TITLE
feat(ui): add warm amber accent for trust indicators

### DIFF
--- a/frontend/src/common/styles/Colors.ts
+++ b/frontend/src/common/styles/Colors.ts
@@ -32,6 +32,11 @@ const Base = {
     Default: "#eab308",
     Dark: "#a16207",
   },
+  Amber: {
+    Light: "#fbbf24",
+    Default: "#f59e0b",
+    Dark: "#d97706",
+  },
   Orange: {
     Light: "#fdba74",
     Default: "#f97316",
@@ -95,7 +100,7 @@ const Colors = {
   Status: {
     NotStarted: Base.Grey.Default,
     InProgress: Base.Blue.Default,
-    Completed: Base.Green.Default,
+    Completed: Base.Amber.Default,
     Skipped: Base.Grey.Light,
   },
 
@@ -103,7 +108,7 @@ const Colors = {
   Chart: {
     Blue: Base.Blue.Default,
     Green: Base.Green.Default,
-    Amber: "#f59e0b",
+    Amber: Base.Amber.Default,
     Purple: Base.Purple.Default,
   },
 } as const

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -71,7 +71,7 @@ const ACTIVITY_ICONS: Record<ActivityType, typeof FileText> = {
 
 const ACTIVITY_COLORS: Record<ActivityType, string> = {
   journey_started: "text-blue-600 bg-blue-50",
-  step_completed: "text-green-600 bg-green-50",
+  step_completed: "text-amber-600 bg-amber-50",
   document_uploaded: "text-purple-600 bg-purple-50",
   calculation_saved: "text-orange-600 bg-orange-50",
   roi_calculated: "text-orange-600 bg-orange-50",

--- a/frontend/src/components/Journey/JourneyGenerating.tsx
+++ b/frontend/src/components/Journey/JourneyGenerating.tsx
@@ -103,7 +103,7 @@ function JourneyGenerating(props: IProps) {
 
   return (
     <div className="flex flex-col items-center justify-center space-y-6 py-16">
-      <CheckCircle2 className="h-12 w-12 text-green-500" />
+      <CheckCircle2 className="h-12 w-12 text-amber-500" />
       <div className="space-y-2 text-center">
         <h2 className="text-2xl font-bold">Your journey is ready!</h2>
         <p className="text-muted-foreground">

--- a/frontend/src/components/Journey/PhaseIndicator.tsx
+++ b/frontend/src/components/Journey/PhaseIndicator.tsx
@@ -43,7 +43,7 @@ function PhaseStep(props: {
           <div
             className={cn(
               "flex h-6 w-6 items-center justify-center rounded-full border-2 text-xs font-medium transition-colors sm:h-8 sm:w-8 sm:text-sm",
-              isCompleted && "border-green-600 bg-green-600 text-white",
+              isCompleted && "border-amber-600 bg-amber-600 text-white",
               isCurrent &&
                 !isCompleted &&
                 "border-blue-600 bg-blue-600 text-white",
@@ -62,7 +62,7 @@ function PhaseStep(props: {
             className={cn(
               "text-sm font-medium",
               isCurrent && "text-foreground",
-              isCompleted && "text-green-600",
+              isCompleted && "text-amber-600",
               !isCurrent && !isCompleted && "text-muted-foreground",
               variant === "horizontal" && "hidden sm:inline",
             )}
@@ -79,7 +79,7 @@ function PhaseStep(props: {
         <div
           className={cn(
             "mx-1 h-0.5 w-4 sm:mx-2 sm:w-auto sm:flex-1",
-            isCompleted ? "bg-green-600" : "bg-muted-foreground/30",
+            isCompleted ? "bg-amber-600" : "bg-muted-foreground/30",
           )}
         />
       )}
@@ -88,7 +88,7 @@ function PhaseStep(props: {
         <div
           className={cn(
             "ml-4 mt-2 mb-2 w-0.5 h-8",
-            isCompleted ? "bg-green-600" : "bg-muted-foreground/30",
+            isCompleted ? "bg-amber-600" : "bg-muted-foreground/30",
           )}
         />
       )}

--- a/frontend/src/components/Journey/ProgressBar.tsx
+++ b/frontend/src/components/Journey/ProgressBar.tsx
@@ -55,7 +55,7 @@ function ProgressBar(props: IProps) {
         <div
           className={cn(
             "h-full rounded-full bg-blue-600 transition-all duration-300 motion-reduce:transition-none",
-            percentage === 100 && "bg-green-600",
+            percentage === 100 && "bg-amber-600",
           )}
           style={{ width: `${animatedPercentage}%` }}
         />

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -77,7 +77,7 @@ function StatusBadge(props: { status: StepStatus }) {
       className={cn(
         "gap-1",
         status === "completed" &&
-          "border border-green-200 bg-green-100 text-green-800 dark:border-green-700 dark:bg-green-900/30 dark:text-green-400",
+          "border border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
       )}
     >
       <Icon className="h-3 w-3" />
@@ -111,7 +111,7 @@ function StepCard(props: IProps) {
         "overflow-hidden transition-all",
         isActive && "ring-2 ring-blue-600 ring-offset-2",
         step.status === "completed" &&
-          "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20",
+          "border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20",
         className,
       )}
     >

--- a/frontend/src/components/Journey/WizardStepIndicator.tsx
+++ b/frontend/src/components/Journey/WizardStepIndicator.tsx
@@ -15,7 +15,7 @@ interface WizardStep {
 interface IProps {
   steps: WizardStep[]
   currentStep: number
-  /** Step IDs that have a confirmed selection — shown with green checkmark. */
+  /** Step IDs that have a confirmed selection — shown with amber checkmark. */
   completedSteps?: Set<number>
   className?: string
 }
@@ -40,7 +40,7 @@ function StepDot(props: {
           className={cn(
             "flex h-8 w-8 sm:h-10 sm:w-10 items-center justify-center rounded-full border-2 text-xs sm:text-sm font-medium transition-all",
             isCompleted
-              ? "border-green-600 bg-green-600 text-white"
+              ? "border-amber-600 bg-amber-600 text-white"
               : isCurrent
                 ? "border-blue-600 bg-blue-600 text-white"
                 : "border-muted-foreground/30 bg-background text-muted-foreground",
@@ -52,7 +52,7 @@ function StepDot(props: {
           className={cn(
             "mt-2 text-xs font-medium text-center max-w-[80px] hidden sm:block",
             isCompleted
-              ? "text-green-600"
+              ? "text-amber-600"
               : isCurrent
                 ? "text-foreground"
                 : "text-muted-foreground",
@@ -66,7 +66,7 @@ function StepDot(props: {
         <div
           className={cn(
             "mx-1 sm:mx-2 h-0.5 w-4 shrink sm:min-w-4 sm:flex-1 sm:max-w-16",
-            isCompleted ? "bg-green-600" : "bg-muted-foreground/30",
+            isCompleted ? "bg-amber-600" : "bg-muted-foreground/30",
           )}
         />
       )}

--- a/frontend/src/components/Professionals/ProfessionalCard.tsx
+++ b/frontend/src/components/Professionals/ProfessionalCard.tsx
@@ -65,7 +65,7 @@ function ProfessionalCard(props: Readonly<IProps>) {
               {professional.isVerified && (
                 <Badge
                   variant="outline"
-                  className="text-xs bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400"
+                  className="text-xs bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
                 >
                   <BadgeCheck className="h-3 w-3 mr-1" />
                   Verified
@@ -88,7 +88,7 @@ function ProfessionalCard(props: Readonly<IProps>) {
               professional.reviewCount >= 3 && (
                 <Badge
                   variant="outline"
-                  className="text-xs bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                  className="text-xs bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
                 >
                   <ThumbsUp className="h-3 w-3 mr-1" />
                   Recommended by {Math.round(professional.recommendationRate)}%

--- a/frontend/src/components/Professionals/ProfessionalDetail.tsx
+++ b/frontend/src/components/Professionals/ProfessionalDetail.tsx
@@ -63,7 +63,7 @@ function ReviewItem(props: Readonly<{ review: ProfessionalReviewType }>) {
         )}
         {review.wouldRecommend != null && (
           <span
-            className={`flex items-center gap-1 text-xs ${review.wouldRecommend ? "text-green-600" : "text-red-500"}`}
+            className={`flex items-center gap-1 text-xs ${review.wouldRecommend ? "text-amber-600" : "text-red-500"}`}
           >
             <ThumbsUp
               className={`h-3 w-3 ${review.wouldRecommend ? "" : "rotate-180"}`}
@@ -114,7 +114,7 @@ function ProfessionalDetail(props: Readonly<IProps>) {
         <div className="flex items-center gap-3 flex-wrap">
           <h1 className="text-2xl font-bold">{professional.name}</h1>
           {professional.isVerified && (
-            <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+            <Badge className="bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
               <BadgeCheck className="h-3.5 w-3.5 mr-1" />
               Verified
             </Badge>
@@ -163,7 +163,7 @@ function ProfessionalDetail(props: Readonly<IProps>) {
                 <div className="flex flex-wrap gap-6">
                   {professional.recommendationRate != null && (
                     <div className="flex items-center gap-2">
-                      <ThumbsUp className="h-5 w-5 text-green-600" />
+                      <ThumbsUp className="h-5 w-5 text-amber-600" />
                       <div>
                         <p className="text-sm font-medium">
                           {Math.round(professional.recommendationRate)}%

--- a/frontend/src/components/Professionals/StarRating.tsx
+++ b/frontend/src/components/Professionals/StarRating.tsx
@@ -58,7 +58,7 @@ function StarRating(props: Readonly<IProps>) {
             className={cn(
               SIZE_CLASSES[size],
               isFilled
-                ? "fill-yellow-400 text-yellow-400"
+                ? "fill-amber-400 text-amber-400"
                 : "fill-none text-gray-300 dark:text-gray-600",
             )}
           />

--- a/frontend/src/components/Profile/SubscriptionCard.tsx
+++ b/frontend/src/components/Profile/SubscriptionCard.tsx
@@ -117,7 +117,7 @@ function SubscriptionCard(props: IProps) {
           <ul className="space-y-2">
             {config.features.map((feature, index) => (
               <li key={index} className="flex items-center gap-2 text-sm">
-                <Check className="h-4 w-4 text-green-600 shrink-0" />
+                <Check className="h-4 w-4 text-amber-600 shrink-0" />
                 <span className="text-muted-foreground">{feature}</span>
               </li>
             ))}

--- a/frontend/src/components/Profile/SubscriptionUpgrade.tsx
+++ b/frontend/src/components/Profile/SubscriptionUpgrade.tsx
@@ -144,7 +144,7 @@ function PlanCard(props: {
         <ul className="space-y-2">
           {plan.features.map((feature, index) => (
             <li key={index} className="flex items-start gap-2 text-sm">
-              <Check className="h-4 w-4 text-green-600 shrink-0 mt-0.5" />
+              <Check className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
               <span className="text-muted-foreground">{feature}</span>
             </li>
           ))}


### PR DESCRIPTION
## Summary
- Replace green with warm amber on trust-related UI: verified badges, recommended-by-expats badges, journey completion checkmarks/phase indicators, star ratings, subscription feature checks, step-completed activity icons
- Add Amber base color token (`Light`/`Default`/`Dark`) to Colors.ts and update `Status.Completed` to use it
- Retain green for standard success feedback (toasts, form validation, budget gauge, positive financial values)

## Test plan
- [ ] Professional directory: verified badges display in amber
- [ ] Professional directory: "Recommended by X%" badges display in amber
- [ ] Professional detail: recommendation % icon and "Recommends" text in amber
- [ ] Star ratings: filled stars show amber-400 instead of yellow-400
- [ ] Journey steps: completed step badges and card backgrounds use amber
- [ ] Wizard step indicator: completed circles, labels, and connector lines use amber
- [ ] Phase indicator: completed phase circles, labels, and lines use amber
- [ ] Progress bar: 100% fill uses amber instead of green
- [ ] Journey generating: "Your journey is ready!" checkmark icon uses amber
- [ ] Dashboard: step_completed activity icon uses amber
- [ ] Subscription card/upgrade: feature checkmarks use amber
- [ ] Standard success toasts still use green
- [ ] Budget gauge "Under budget" still uses green
- [ ] Dark mode: all amber shades render with sufficient contrast