### PR TITLE
feat(ui): add portfolio management to landing page and dashboard

### DIFF
--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -7,9 +7,11 @@ import { Link } from "@tanstack/react-router"
 import {
   ArrowRight,
   BookOpen,
+  Building2,
   Calculator,
   Clock,
   FileText,
+  LayoutDashboard,
   MapIcon,
   Plus,
   TrendingUp,
@@ -218,6 +220,31 @@ function PropertyEvaluationChip() {
   )
 }
 
+/** Portfolio CTA card for users who have started a journey. */
+function PortfolioCta() {
+  return (
+    <Card className="border-teal-200 bg-teal-50/50 dark:border-teal-900 dark:bg-teal-950/20">
+      <CardContent className="flex items-center gap-4 p-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900/50">
+          <LayoutDashboard className="h-5 w-5 text-teal-600 dark:text-teal-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold">Portfolio</h3>
+          <p className="text-xs text-muted-foreground">
+            Track properties, income, and performance
+          </p>
+        </div>
+        <Button size="sm" variant="outline" asChild>
+          <Link to="/portfolio">
+            View
+            <ArrowRight className="ml-1 h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
 /** Quick action buttons grid. */
 function QuickActions(props: { journeyId?: string }) {
   const actions = [
@@ -245,6 +272,12 @@ function QuickActions(props: { journeyId?: string }) {
       icon: BookOpen,
       to: "/laws" as const,
       color: "text-indigo-600",
+    },
+    {
+      label: "View Portfolio",
+      icon: Building2,
+      to: "/portfolio" as const,
+      color: "text-teal-600",
     },
   ]
 
@@ -569,6 +602,8 @@ function DashboardPage(props: Readonly<IProps>) {
           ) : (
             <PropertyEvaluationCta />
           )}
+
+          {data.hasJourney && <PortfolioCta />}
 
           <SavedItemsSection
             documents={data.recentDocuments}

--- a/frontend/src/components/Landing/AdvantagesSection.tsx
+++ b/frontend/src/components/Landing/AdvantagesSection.tsx
@@ -1,4 +1,4 @@
-import { Globe, ShieldCheck, TrendingUp } from "lucide-react"
+import { Globe, LayoutDashboard, ShieldCheck, TrendingUp } from "lucide-react"
 
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -12,18 +12,30 @@ const ADVANTAGES = [
     title: "Built for International Buyers",
     description:
       "Designed specifically for non-German speakers. Every legal term, process step, and document is presented in clear English with cultural context.",
+    color: "bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-400",
   },
   {
     icon: ShieldCheck,
     title: "Risk-Aware Guidance",
     description:
       "Legal terms are automatically flagged with risk warnings. Document translations include confidence scores so you know what needs professional review.",
+    color:
+      "bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400",
   },
   {
     icon: TrendingUp,
     title: "Complete Cost Transparency",
     description:
       "No hidden fees or surprise costs. Our calculators break down every expense — from property transfer tax to notary fees — so you know exactly what you'll pay.",
+    color:
+      "bg-orange-100 text-orange-600 dark:bg-orange-900/40 dark:text-orange-400",
+  },
+  {
+    icon: LayoutDashboard,
+    title: "Post-Purchase Support",
+    description:
+      "Your journey doesn't end at closing. Track property performance, manage rental income, monitor running costs, and grow your portfolio with ongoing tools.",
+    color: "bg-teal-100 text-teal-600 dark:bg-teal-900/40 dark:text-teal-400",
   },
 ] as const
 
@@ -46,14 +58,16 @@ function AdvantagesSection() {
           </p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
           {ADVANTAGES.map((advantage) => (
             <Card
               key={advantage.title}
               className="transition-shadow hover:shadow-md"
             >
               <CardContent className="p-6">
-                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-400">
+                <div
+                  className={`mb-4 flex h-12 w-12 items-center justify-center rounded-full ${advantage.color}`}
+                >
                   <advantage.icon className="h-6 w-6" />
                 </div>
                 <h3 className="font-semibold">{advantage.title}</h3>

--- a/frontend/src/components/Landing/FeaturesSection.tsx
+++ b/frontend/src/components/Landing/FeaturesSection.tsx
@@ -1,4 +1,10 @@
-import { Calculator, FileText, Home, Scale } from "lucide-react"
+import {
+  Calculator,
+  FileText,
+  Home,
+  LayoutDashboard,
+  Scale,
+} from "lucide-react"
 
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -38,6 +44,13 @@ const FEATURES = [
     color:
       "bg-green-100 text-green-600 dark:bg-green-900/40 dark:text-green-400",
   },
+  {
+    icon: LayoutDashboard,
+    title: "Portfolio Management",
+    description:
+      "Track your properties, monitor rental yields, manage running costs, and view performance trends — all in one place after your purchase.",
+    color: "bg-teal-100 text-teal-600 dark:bg-teal-900/40 dark:text-teal-400",
+  },
 ] as const
 
 /******************************************************************************
@@ -51,15 +64,15 @@ function FeaturesSection() {
       <div className="mx-auto max-w-7xl px-4 md:px-6">
         <div className="mx-auto mb-12 max-w-2xl text-center">
           <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
-            Everything You Need to Buy Property in Germany
+            Everything You Need — From Search to Portfolio
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
             Purpose-built tools for international buyers navigating the German
-            real estate market.
+            real estate market and managing their investments.
           </p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {FEATURES.map((feature) => (
             <Card
               key={feature.title}

--- a/frontend/src/components/Landing/HeroSection.tsx
+++ b/frontend/src/components/Landing/HeroSection.tsx
@@ -34,8 +34,8 @@ function HeroSection() {
 
           <p className="mt-6 max-w-xl animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards text-lg text-muted-foreground delay-200 duration-500 motion-reduce:animate-none">
             HeimPath guides foreign investors and immigrants through every step
-            of buying property in Germany — from research to closing, in a
-            language you understand.
+            of buying property in Germany — from first research to portfolio
+            management, in a language you understand.
           </p>
 
           <div className="mt-8 flex animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards flex-wrap gap-4 delay-300 duration-500 motion-reduce:animate-none">

--- a/frontend/src/components/Landing/HowItWorksSection.tsx
+++ b/frontend/src/components/Landing/HowItWorksSection.tsx
@@ -1,4 +1,11 @@
-import { ClipboardList, Handshake, KeyRound, Search } from "lucide-react"
+import {
+  Building2,
+  ClipboardList,
+  Handshake,
+  Home,
+  KeyRound,
+  Search,
+} from "lucide-react"
 
 /******************************************************************************
                               Constants
@@ -40,6 +47,23 @@ const PHASES = [
       "bg-green-100 text-green-600 dark:bg-green-900/40 dark:text-green-400",
     ring: "ring-green-200 dark:ring-green-800",
   },
+  {
+    icon: Home,
+    title: "Ownership",
+    description:
+      "Handle land registry, insurance, tax setup, and property management after your purchase.",
+    color: "bg-teal-100 text-teal-600 dark:bg-teal-900/40 dark:text-teal-400",
+    ring: "ring-teal-200 dark:ring-teal-800",
+  },
+  {
+    icon: Building2,
+    title: "Rental Setup",
+    description:
+      "Set up rental operations, understand landlord law, analyse yields, and onboard tenants.",
+    color:
+      "bg-emerald-100 text-emerald-600 dark:bg-emerald-900/40 dark:text-emerald-400",
+    ring: "ring-emerald-200 dark:ring-emerald-800",
+  },
 ] as const
 
 /******************************************************************************
@@ -66,9 +90,7 @@ function PhaseStep(props: { phase: (typeof PHASES)[number]; index: number }) {
       </div>
 
       <h3 className="mt-4 font-semibold">{phase.title}</h3>
-      <p className="mt-1 max-w-48 text-sm text-muted-foreground">
-        {phase.description}
-      </p>
+      <p className="mt-1 text-sm text-muted-foreground">{phase.description}</p>
     </div>
   )
 }
@@ -83,15 +105,22 @@ function HowItWorksSection() {
             How It Works
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-            Four phases guide you from first research to getting your keys.
+            Six phases guide you from first research to managing your portfolio.
           </p>
         </div>
 
         {/* Desktop: horizontal timeline */}
-        <div className="relative hidden gap-8 md:flex">
+        <div className="relative hidden gap-4 lg:flex">
           {/* Dashed connector line */}
-          <div className="pointer-events-none absolute left-[12.5%] right-[12.5%] top-8 border-t-2 border-dashed border-muted-foreground/25" />
+          <div className="pointer-events-none absolute left-[8%] right-[8%] top-8 border-t-2 border-dashed border-muted-foreground/25" />
 
+          {PHASES.map((phase, i) => (
+            <PhaseStep key={phase.title} phase={phase} index={i} />
+          ))}
+        </div>
+
+        {/* Tablet: 3-column grid */}
+        <div className="hidden grid-cols-3 gap-6 md:grid lg:hidden">
           {PHASES.map((phase, i) => (
             <PhaseStep key={phase.title} phase={phase} index={i} />
           ))}

--- a/frontend/src/components/Landing/LandingFooter.tsx
+++ b/frontend/src/components/Landing/LandingFooter.tsx
@@ -14,6 +14,7 @@ const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
     [
       ["Features", "#features"],
       ["How It Works", "#how-it-works"],
+      ["Portfolio", "/portfolio"],
     ],
   ],
   [


### PR DESCRIPTION
## Summary
- Extended "How It Works" timeline from 4 phases to 6 (added Ownership and Rental Setup post-purchase phases)
- Added Portfolio Management feature card to the features section with teal accent
- Added Post-Purchase Support advantage card to the "Why HeimPath?" section
- Updated hero subtitle to communicate full lifecycle ("from first research to portfolio management")
- Added Portfolio CTA card on the dashboard for users with active journeys
- Added "View Portfolio" quick action to the dashboard sidebar
- Added Portfolio link to the landing page footer

## Test plan
- [ ] Landing page: "How It Works" shows 6 phases with responsive layouts (mobile vertical, tablet 3-col grid, desktop horizontal)
- [ ] Landing page: Features section shows 5 cards including Portfolio Management
- [ ] Landing page: Advantages section shows 4 cards including Post-Purchase Support
- [ ] Landing page: Hero subtitle mentions "portfolio management"
- [ ] Landing page: Footer Product column includes Portfolio link
- [ ] Dashboard: Portfolio CTA card appears when user has a journey
- [ ] Dashboard: Quick Actions includes "View Portfolio"
- [ ] All views responsive on mobile (375px) and desktop (1280px)