### PR TITLE
fix(ui): improve error toast titles for auth flows

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
         working-directory: backend
       - name: Install pip-audit
         run: uv pip install pip-audit

--- a/frontend/src/hooks/useCustomToast.ts
+++ b/frontend/src/hooks/useCustomToast.ts
@@ -7,8 +7,8 @@ const useCustomToast = () => {
     })
   }
 
-  const showErrorToast = (description: string) => {
-    toast.error("Something went wrong!", {
+  const showErrorToast = (description: string, title = "Error") => {
+    toast.error(title, {
       description,
     })
   }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -3,25 +3,46 @@ import { ApiError } from "./client/core/ApiError"
 
 function extractErrorMessage(err: Error): string {
   if (err instanceof AxiosError) {
+    if (err.code === "ERR_NETWORK") {
+      return "Unable to connect to the server. Please check your connection and try again."
+    }
     return err.message
   }
 
   if (err instanceof ApiError) {
     const errDetail = (err.body as Record<string, unknown>)?.detail
     if (Array.isArray(errDetail) && errDetail.length > 0) {
-      return errDetail[0].msg
+      return errDetail[0]?.msg ?? "Validation failed"
     }
     if (typeof errDetail === "string" && errDetail) {
       return errDetail
     }
   }
 
-  return err.message || "Something went wrong."
+  return err.message || "An unexpected error occurred. Please try again."
 }
 
-export const handleError = function (this: (msg: string) => void, err: Error) {
+function extractErrorTitle(err: Error): string {
+  if (err instanceof AxiosError && err.code === "ERR_NETWORK") {
+    return "Connection Error"
+  }
+
+  if (err instanceof ApiError) {
+    if (err.status === 429) return "Too Many Requests"
+    if (err.status === 422) return "Validation Error"
+    if (err.status >= 500) return "Server Error"
+  }
+
+  return "Error"
+}
+
+export const handleError = function (
+  this: (description: string, title?: string) => void,
+  err: Error,
+) {
   const errorMessage = extractErrorMessage(err)
-  this(errorMessage)
+  const errorTitle = extractErrorTitle(err)
+  this(errorMessage, errorTitle)
 }
 
 export const getInitials = (name: string): string => {

--- a/uv.lock
+++ b/uv.lock
@@ -2785,11 +2785,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace hardcoded "Something went wrong!" toast title with contextual titles based on HTTP error type
- Add `extractErrorTitle` function that maps errors to specific titles: Connection Error (network), Validation Error (422), Too Many Requests (429), Server Error (5xx), or generic "Error"
- Update `showErrorToast` to accept optional `title` parameter (defaults to "Error")
- Improve network error message to guide users: "Unable to connect to the server..."

Fixes #93 — Users reported misleading "Something went wrong" on signup page; every API error (400 duplicate email, 422 validation, etc.) showed the same alarming title.

## Test plan
- [ ] Register with duplicate email — toast shows "Error" title with "A user with this email already exists" description
- [ ] Register with weak password — toast shows "Validation Error" title
- [ ] Register with valid data — succeeds, shows verification prompt
- [ ] Stop backend, try register — toast shows "Connection Error" with helpful message
- [ ] All existing error toasts in app still work (no regressions)