### PR TITLE
feat(ui): add parallax scroll effect to hero background blobs

### DIFF
--- a/frontend/src/components/Landing/HeroSection.tsx
+++ b/frontend/src/components/Landing/HeroSection.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { useParallax } from "@/hooks/useParallax"
 
 import { HeroPhoto } from "./HeroPhoto"
 
@@ -11,11 +12,20 @@ import { HeroPhoto } from "./HeroPhoto"
 
 /** Default component. Hero section with headline, CTAs, and property illustration. */
 function HeroSection() {
+  const blobTopRef = useParallax(0.3)
+  const blobBottomRef = useParallax(0.5)
+
   return (
     <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20">
-      {/* Decorative blur blobs */}
-      <div className="pointer-events-none absolute -left-20 -top-20 h-72 w-72 rounded-full bg-blue-400/10 blur-3xl" />
-      <div className="pointer-events-none absolute -bottom-20 -right-20 h-72 w-72 rounded-full bg-purple-400/10 blur-3xl" />
+      {/* Decorative blur blobs — parallax on md+ screens */}
+      <div
+        ref={blobTopRef}
+        className="pointer-events-none absolute -left-20 -top-20 h-72 w-72 rounded-full bg-blue-400/10 blur-3xl will-change-transform"
+      />
+      <div
+        ref={blobBottomRef}
+        className="pointer-events-none absolute -bottom-20 -right-20 h-72 w-72 rounded-full bg-purple-400/10 blur-3xl will-change-transform"
+      />
 
       <div className="mx-auto flex max-w-7xl flex-col items-center gap-12 px-4 py-20 md:flex-row md:px-6 md:py-28 lg:py-32">
         {/* Text content */}

--- a/frontend/src/hooks/useParallax.ts
+++ b/frontend/src/hooks/useParallax.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef } from "react"
+
+/******************************************************************************
+                              Hook
+******************************************************************************/
+
+/**
+ * Applies a subtle parallax translate to the referenced element based on scroll.
+ * Disabled on mobile (<768px) and when `prefers-reduced-motion` is enabled.
+ * Uses `requestAnimationFrame` for smooth 60fps updates.
+ *
+ * @param speed - Multiplier for scroll offset (0.3 = blob moves at 30% of scroll speed)
+ */
+function useParallax(speed = 0.3) {
+  const ref = useRef<HTMLDivElement>(null)
+  const rafRef = useRef<number>(0)
+
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+
+  const isMobile = typeof window !== "undefined" && window.innerWidth < 768
+
+  const handleScroll = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+    }
+
+    rafRef.current = requestAnimationFrame(() => {
+      if (ref.current) {
+        const offset = window.scrollY * speed
+        ref.current.style.transform = `translateY(${offset}px)`
+      }
+    })
+  }, [speed])
+
+  useEffect(() => {
+    if (prefersReducedMotion || isMobile) {
+      return
+    }
+
+    window.addEventListener("scroll", handleScroll, { passive: true })
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll)
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+      }
+    }
+  }, [handleScroll, prefersReducedMotion, isMobile])
+
+  return ref
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { useParallax }


### PR DESCRIPTION
## Summary
- Create `useParallax` hook using `requestAnimationFrame` for smooth scroll-linked `translateY` transforms
- Apply to hero section decorative blur blobs at 0.3x (top blob) and 0.5x (bottom blob) scroll speeds for subtle depth effect
- Disabled on mobile (<768px) to avoid touch scroll jank
- Respects `prefers-reduced-motion` — parallax fully disabled when enabled
- Uses `will-change-transform` hint for GPU-accelerated compositing

## Test plan
- [ ] Scroll landing page on desktop — hero blur blobs shift subtly (slower than content scroll)
- [ ] Bottom blob moves slightly faster (0.5x) than top blob (0.3x) for layered depth
- [ ] Resize to <768px — parallax stops, blobs stay in original position
- [ ] Enable `prefers-reduced-motion` — parallax disabled, blobs static
- [ ] No layout shift or scroll jank during parallax
- [ ] Hero section `overflow-hidden` clips blobs that translate out of bounds