### PR TITLE
feat(ui): add decorative svg patterns to advantage cards

### DIFF
--- a/frontend/src/components/Landing/AdvantagePatterns.tsx
+++ b/frontend/src/components/Landing/AdvantagePatterns.tsx
@@ -1,0 +1,229 @@
+/**
+ * Decorative inline SVG background patterns for each "Why HeimPath?" advantage card.
+ * Positioned absolutely in the bottom-right corner at low opacity.
+ * Dark-mode aware via Tailwind classes.
+ */
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Globe/world pattern for International Buyers card. */
+function GlobePattern() {
+  return (
+    <svg
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className="h-28 w-28 opacity-[0.08] dark:opacity-[0.06]"
+    >
+      <circle
+        cx="60"
+        cy="60"
+        r="50"
+        fill="none"
+        strokeWidth="2"
+        className="stroke-blue-500 dark:stroke-blue-400"
+      />
+      {/* Latitude lines */}
+      <ellipse
+        cx="60"
+        cy="60"
+        rx="50"
+        ry="20"
+        fill="none"
+        strokeWidth="1.5"
+        className="stroke-blue-500 dark:stroke-blue-400"
+      />
+      <ellipse
+        cx="60"
+        cy="60"
+        rx="50"
+        ry="38"
+        fill="none"
+        strokeWidth="1.5"
+        className="stroke-blue-500 dark:stroke-blue-400"
+      />
+      {/* Meridian lines */}
+      <ellipse
+        cx="60"
+        cy="60"
+        rx="20"
+        ry="50"
+        fill="none"
+        strokeWidth="1.5"
+        className="stroke-blue-500 dark:stroke-blue-400"
+      />
+      <line
+        x1="10"
+        y1="60"
+        x2="110"
+        y2="60"
+        strokeWidth="1.5"
+        className="stroke-blue-500 dark:stroke-blue-400"
+      />
+    </svg>
+  )
+}
+
+/** Shield/checkmark pattern for Risk-Aware Guidance card. */
+function ShieldPattern() {
+  return (
+    <svg
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className="h-28 w-28 opacity-[0.08] dark:opacity-[0.06]"
+    >
+      {/* Shield shape */}
+      <path
+        d="M60 10 L100 30 L100 65 Q100 95 60 110 Q20 95 20 65 L20 30 Z"
+        fill="none"
+        strokeWidth="2.5"
+        className="stroke-purple-500 dark:stroke-purple-400"
+      />
+      {/* Checkmark */}
+      <polyline
+        points="42,60 55,75 80,45"
+        fill="none"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="stroke-purple-500 dark:stroke-purple-400"
+      />
+    </svg>
+  )
+}
+
+/** Euro/chart pattern for Cost Transparency card. */
+function ChartPattern() {
+  return (
+    <svg
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className="h-28 w-28 opacity-[0.08] dark:opacity-[0.06]"
+    >
+      {/* Bar chart bars */}
+      <rect
+        x="15"
+        y="70"
+        width="16"
+        height="40"
+        rx="2"
+        className="fill-orange-500 dark:fill-orange-400"
+      />
+      <rect
+        x="37"
+        y="45"
+        width="16"
+        height="65"
+        rx="2"
+        className="fill-orange-500 dark:fill-orange-400"
+      />
+      <rect
+        x="59"
+        y="55"
+        width="16"
+        height="55"
+        rx="2"
+        className="fill-orange-500 dark:fill-orange-400"
+      />
+      <rect
+        x="81"
+        y="25"
+        width="16"
+        height="85"
+        rx="2"
+        className="fill-orange-500 dark:fill-orange-400"
+      />
+      {/* Trend line */}
+      <polyline
+        points="23,65 45,40 67,50 89,20"
+        fill="none"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="stroke-orange-500 dark:stroke-orange-400"
+      />
+    </svg>
+  )
+}
+
+/** Dashboard/grid pattern for Post-Purchase Support card. */
+function DashboardPattern() {
+  return (
+    <svg
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className="h-28 w-28 opacity-[0.08] dark:opacity-[0.06]"
+    >
+      {/* Dashboard grid */}
+      <rect
+        x="10"
+        y="10"
+        width="45"
+        height="45"
+        rx="4"
+        fill="none"
+        strokeWidth="2.5"
+        className="stroke-teal-500 dark:stroke-teal-400"
+      />
+      <rect
+        x="65"
+        y="10"
+        width="45"
+        height="20"
+        rx="4"
+        fill="none"
+        strokeWidth="2.5"
+        className="stroke-teal-500 dark:stroke-teal-400"
+      />
+      <rect
+        x="65"
+        y="40"
+        width="45"
+        height="15"
+        rx="4"
+        className="fill-teal-500 dark:fill-teal-400"
+      />
+      <rect
+        x="10"
+        y="65"
+        width="100"
+        height="45"
+        rx="4"
+        fill="none"
+        strokeWidth="2.5"
+        className="stroke-teal-500 dark:stroke-teal-400"
+      />
+      {/* Mini line chart inside bottom panel */}
+      <polyline
+        points="20,95 40,80 60,88 80,75 100,82"
+        fill="none"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="stroke-teal-500 dark:stroke-teal-400"
+      />
+    </svg>
+  )
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const ADVANTAGE_PATTERNS = [
+  GlobePattern,
+  ShieldPattern,
+  ChartPattern,
+  DashboardPattern,
+] as const
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ADVANTAGE_PATTERNS }

--- a/frontend/src/components/Landing/AdvantagesSection.tsx
+++ b/frontend/src/components/Landing/AdvantagesSection.tsx
@@ -2,6 +2,7 @@ import { Globe, LayoutDashboard, ShieldCheck, TrendingUp } from "lucide-react"
 
 import { Card, CardContent } from "@/components/ui/card"
 
+import { ADVANTAGE_PATTERNS } from "./AdvantagePatterns"
 import { AnimateIn } from "./AnimateIn"
 
 /******************************************************************************
@@ -63,23 +64,29 @@ function AdvantagesSection() {
         </AnimateIn>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {ADVANTAGES.map((advantage, i) => (
-            <AnimateIn key={advantage.title} delayMs={(i + 1) * 100}>
-              <Card className="h-full transition-shadow hover:shadow-md">
-                <CardContent className="p-6">
-                  <div
-                    className={`mb-4 flex h-12 w-12 items-center justify-center rounded-full ${advantage.color}`}
-                  >
-                    <advantage.icon className="h-6 w-6" />
+          {ADVANTAGES.map((advantage, i) => {
+            const Pattern = ADVANTAGE_PATTERNS[i]
+            return (
+              <AnimateIn key={advantage.title} delayMs={(i + 1) * 100}>
+                <Card className="relative h-full overflow-hidden transition-shadow hover:shadow-md">
+                  <CardContent className="relative z-10 p-6">
+                    <div
+                      className={`mb-4 flex h-12 w-12 items-center justify-center rounded-full ${advantage.color}`}
+                    >
+                      <advantage.icon className="h-6 w-6" />
+                    </div>
+                    <h3 className="font-semibold">{advantage.title}</h3>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {advantage.description}
+                    </p>
+                  </CardContent>
+                  <div className="pointer-events-none absolute -bottom-2 -right-2">
+                    <Pattern />
                   </div>
-                  <h3 className="font-semibold">{advantage.title}</h3>
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    {advantage.description}
-                  </p>
-                </CardContent>
-              </Card>
-            </AnimateIn>
-          ))}
+                </Card>
+              </AnimateIn>
+            )
+          })}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Create inline SVG decorative background patterns for each "Why HeimPath?" advantage card
- Globe wireframe (International Buyers), shield with checkmark (Risk-Aware), bar chart with trend line (Cost Transparency), dashboard grid (Post-Purchase)
- Patterns positioned absolutely in bottom-right corner at 8% opacity (6% in dark mode)
- Each pattern uses the card's accent color (blue, purple, orange, teal)
- All decorative SVGs use `aria-hidden="true"` for accessibility
- Card content layered above patterns with `z-10`, patterns clipped with `overflow-hidden`

## Test plan
- [ ] Scroll to "Why HeimPath?" section — each card has a distinct subtle background pattern
- [ ] Patterns don't interfere with card text readability (very low opacity)
- [ ] Each pattern matches its card theme (globe=international, shield=risk, chart=cost, dashboard=post-purchase)
- [ ] Toggle dark mode — patterns remain subtle and adapt
- [ ] Test at mobile (375px) — patterns don't overflow or create visual clutter
- [ ] Inspect DOM — all SVGs have `aria-hidden="true"`