### PR TITLE
feat(ui): add dot grid pattern overlay to cta banner

### DIFF
--- a/frontend/src/components/Landing/CtaSection.tsx
+++ b/frontend/src/components/Landing/CtaSection.tsx
@@ -14,7 +14,27 @@ function CtaSection() {
   const loggedIn = isLoggedIn()
 
   return (
-    <section className="bg-gradient-to-r from-blue-600 to-purple-600 py-20 md:py-28">
+    <section className="relative overflow-hidden bg-gradient-to-r from-blue-600 to-purple-600 py-20 md:py-28">
+      {/* Geometric dot grid overlay — hidden on mobile */}
+      <svg
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 hidden h-full w-full md:block"
+      >
+        <defs>
+          <pattern
+            id="cta-dot-grid"
+            x="0"
+            y="0"
+            width="24"
+            height="24"
+            patternUnits="userSpaceOnUse"
+          >
+            <circle cx="2" cy="2" r="1.5" fill="white" fillOpacity="0.07" />
+          </pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#cta-dot-grid)" />
+      </svg>
+
       <AnimateIn>
         <div className="mx-auto max-w-3xl px-4 text-center md:px-6">
           <h2 className="text-3xl font-bold tracking-tight text-white md:text-4xl">


### PR DESCRIPTION
## Summary
- Add subtle repeating dot grid SVG pattern overlay to the CTA banner section
- White dots at 7% opacity over the blue-purple gradient for texture without reducing readability
- Hidden on mobile (`hidden md:block`) to avoid visual clutter on small screens
- Pattern uses SVG `<pattern>` element for efficient repeating, `pointer-events-none` to preserve click targets, `aria-hidden="true"` for accessibility

## Test plan
- [ ] Scroll to CTA banner — subtle dot grid visible over gradient background
- [ ] CTA heading, description, and button remain fully readable
- [ ] Pattern doesn't interfere with button clicks or text selection
- [ ] Resize to <768px — dot grid hidden on mobile
- [ ] Inspect DOM — SVG has `aria-hidden="true"`
- [ ] No overflow or scroll issues from the pattern layer