### PR TITLE
feat(ui): add gradient continuity between hero and cta

### DIFF
--- a/frontend/src/components/Landing/HeroSection.tsx
+++ b/frontend/src/components/Landing/HeroSection.tsx
@@ -16,15 +16,21 @@ function HeroSection() {
   const blobBottomRef = useParallax(0.5)
 
   return (
-    <section className="relative overflow-hidden bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20">
+    <section className="relative overflow-hidden bg-gradient-to-br from-blue-100/50 to-purple-100/50 dark:from-blue-950/30 dark:to-purple-950/30">
+      {/* Gradient accent bar — echoes CTA gradient for visual bookend */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-blue-600 to-purple-600"
+      />
+
       {/* Decorative blur blobs — parallax on md+ screens */}
       <div
         ref={blobTopRef}
-        className="pointer-events-none absolute -left-20 -top-20 h-72 w-72 rounded-full bg-blue-400/10 blur-3xl will-change-transform"
+        className="pointer-events-none absolute -left-20 -top-20 h-72 w-72 rounded-full bg-blue-400/15 blur-3xl will-change-transform"
       />
       <div
         ref={blobBottomRef}
-        className="pointer-events-none absolute -bottom-20 -right-20 h-72 w-72 rounded-full bg-purple-400/10 blur-3xl will-change-transform"
+        className="pointer-events-none absolute -bottom-20 -right-20 h-72 w-72 rounded-full bg-purple-400/15 blur-3xl will-change-transform"
       />
 
       <div className="mx-auto flex max-w-7xl flex-col items-center gap-12 px-4 py-20 md:flex-row md:px-6 md:py-28 lg:py-32">


### PR DESCRIPTION
## Summary
- Add thin (4px) gradient accent bar at top of hero section matching the CTA section's `from-blue-600 to-purple-600` gradient, creating a visual bookend effect
- Boost hero background gradient from `from-blue-50 to-purple-50` to `from-blue-100/50 to-purple-100/50` for slightly stronger blue-purple color presence
- In dark mode, boost from `/20` to `/30` opacity for more visible gradient coherence
- Increase blur blob opacity from 10% to 15% to reinforce the blue-purple color theme

## Test plan
- [ ] Hero section has a thin gradient bar at the very top matching the CTA gradient
- [ ] Hero background gradient is subtly more colorful but still readable
- [ ] Scroll full page — top-to-bottom blue-purple visual continuity (hero → CTA)
- [ ] Dark mode — both hero and CTA gradients remain cohesive
- [ ] Hero text (h1, paragraph) maintains strong contrast and readability
- [ ] Blur blobs are slightly more visible but still subtle decoration