### PR TITLE
fix(ui): invalidate journey list cache on step/task update

### DIFF
--- a/frontend/src/hooks/mutations/useJourneyMutations.ts
+++ b/frontend/src/hooks/mutations/useJourneyMutations.ts
@@ -67,6 +67,9 @@ export function useUpdateStep(journeyId: string) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.journeys.progress(journeyId),
       })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.journeys.list(),
+      })
     },
   })
 }
@@ -194,6 +197,9 @@ export function useUpdateTask(journeyId: string) {
       })
       queryClient.invalidateQueries({
         queryKey: queryKeys.journeys.progress(journeyId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.journeys.list(),
       })
     },
   })


### PR DESCRIPTION
## Summary
- Fix stale journey progress on My Journeys page after completing steps
- Add `queryKeys.journeys.list()` invalidation to `useUpdateStep` and `useUpdateTask` mutations
- Previously only `detail` and `progress` queries were invalidated, leaving the list view with cached progress data

## Test plan
- [ ] Complete a journey step, navigate to My Journeys — card progress updates without refresh
- [ ] Toggle a task checkbox, go back to My Journeys — progress percentage reflects the change
- [ ] Verify journey detail page still updates optimistically (no regression)