### PR TITLE
fix(ui): handle notification bell api errors gracefully

### DIFF
--- a/frontend/src/components/Notifications/NotificationBell.tsx
+++ b/frontend/src/components/Notifications/NotificationBell.tsx
@@ -116,7 +116,7 @@ function NotificationBell() {
   const [open, setOpen] = useState(false)
   const navigate = useNavigate()
 
-  const { data } = useNotifications()
+  const { data, isError } = useNotifications()
   const markRead = useMarkNotificationRead()
   const markAllRead = useMarkAllNotificationsRead()
 
@@ -168,7 +168,11 @@ function NotificationBell() {
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <div className="max-h-96 overflow-y-auto">
-            {notifications.length === 0 ? (
+            {isError ? (
+              <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+                Unable to load notifications
+              </div>
+            ) : notifications.length === 0 ? (
               <div className="px-3 py-8 text-center text-sm text-muted-foreground">
                 No notifications yet
               </div>

--- a/frontend/src/hooks/queries/useNotificationQueries.ts
+++ b/frontend/src/hooks/queries/useNotificationQueries.ts
@@ -9,6 +9,8 @@ export function useNotifications(limit = 20, offset = 0, unreadOnly = false) {
     queryFn: () =>
       NotificationService.getNotifications(limit, offset, unreadOnly),
     refetchInterval: 30000,
+    retry: false,
+    throwOnError: false,
   })
 }
 


### PR DESCRIPTION
## Summary
- Fix "something went wrong" error when clicking notification bell icon
- Add error state handling in `NotificationBell` — shows "Unable to load notifications" instead of crashing
- Set `retry: false` and `throwOnError: false` on the notifications query to prevent error boundary triggers and aggressive retries

## Test plan
- [ ] Click notification bell — dropdown opens without error, shows "Unable to load notifications" if API unavailable
- [ ] When API is healthy, notifications load and display correctly
- [ ] Mark as read and mark all read still work
- [ ] No "something went wrong" error page when notification API fails