### PR TITLE
feat(calculators): update schufa rating to nextgen score system

### DIFF
--- a/backend/app/alembic/versions/a3b4c5d6e7f8_migrate_schufa_to_nextgen_scores.py
+++ b/backend/app/alembic/versions/a3b4c5d6e7f8_migrate_schufa_to_nextgen_scores.py
@@ -1,0 +1,42 @@
+"""Migrate SCHUFA ratings to NextGen Score categories
+
+Revision ID: a3b4c5d6e7f8
+Revises: d6z7a8b9c0e1
+Create Date: 2026-04-22 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3b4c5d6e7f8"
+down_revision = "d6z7a8b9c0e1"
+branch_labels = None
+depends_on = None
+
+# Old category name → new category name
+RENAME_MAP = {
+    "satisfactory": "acceptable",
+    "adequate": "sufficient",
+    "poor": "insufficient",
+}
+
+REVERSE_MAP = {v: k for k, v in RENAME_MAP.items()}
+
+
+def upgrade() -> None:
+    for old_name, new_name in RENAME_MAP.items():
+        op.execute(
+            f"UPDATE financing_assessment "
+            f"SET schufa_rating = '{new_name}' "
+            f"WHERE schufa_rating = '{old_name}'"
+        )
+
+
+def downgrade() -> None:
+    for new_name, old_name in REVERSE_MAP.items():
+        op.execute(
+            f"UPDATE financing_assessment "
+            f"SET schufa_rating = '{old_name}' "
+            f"WHERE schufa_rating = '{new_name}'"
+        )

--- a/backend/app/schemas/financing.py
+++ b/backend/app/schemas/financing.py
@@ -27,8 +27,8 @@ class FinancingAssessmentCreate(BaseModel):
         ..., ge=0, description="Available down payment in EUR"
     )
     schufa_rating: Literal[
-        "excellent", "good", "satisfactory", "adequate", "poor", "unknown"
-    ] = Field(..., description="SCHUFA credit rating category")
+        "excellent", "good", "acceptable", "sufficient", "insufficient", "unknown"
+    ] = Field(..., description="SCHUFA NextGen Score rating category")
     residency_status: Literal[
         "german_citizen",
         "eu_citizen",

--- a/backend/app/services/financing_service.py
+++ b/backend/app/services/financing_service.py
@@ -106,13 +106,22 @@ def _score_down_payment(available_dp: float) -> float:
 
 
 def _score_schufa(rating: str) -> float:
-    """Score SCHUFA rating on 0-15 scale."""
+    """Score SCHUFA NextGen Score rating on 0-15 scale.
+
+    Based on SCHUFA NextGen Score 1.0 (launched March 2026):
+    - Excellent (776-999): 15 pts
+    - Good (709-775): 12 pts
+    - Acceptable (642-708): 9 pts
+    - Sufficient (100-641): 5 pts
+    - Insufficient (no score): 2 pts
+    - Unknown: 3 pts
+    """
     scores = {
         "excellent": 15.0,
         "good": 12.0,
-        "satisfactory": 9.0,
-        "adequate": 5.0,
-        "poor": 2.0,
+        "acceptable": 9.0,
+        "sufficient": 5.0,
+        "insufficient": 2.0,
         "unknown": 3.0,
     }
     return scores.get(rating, 3.0)
@@ -187,7 +196,7 @@ def _recommended_dp_percent(residency_status: str, schufa_rating: str) -> float:
         base = 30.0
     else:
         base = 20.0
-    if schufa_rating in ("poor", "unknown"):
+    if schufa_rating in ("insufficient", "unknown"):
         base += 5.0
     if residency_status == "german_citizen" and schufa_rating in ("excellent", "good"):
         base = 15.0

--- a/backend/tests/services/test_financing_service.py
+++ b/backend/tests/services/test_financing_service.py
@@ -95,8 +95,17 @@ class TestScoreSchufa:
     def test_excellent(self) -> None:
         assert _score_schufa("excellent") == 15.0
 
-    def test_poor(self) -> None:
-        assert _score_schufa("poor") == 2.0
+    def test_good(self) -> None:
+        assert _score_schufa("good") == 12.0
+
+    def test_acceptable(self) -> None:
+        assert _score_schufa("acceptable") == 9.0
+
+    def test_sufficient(self) -> None:
+        assert _score_schufa("sufficient") == 5.0
+
+    def test_insufficient(self) -> None:
+        assert _score_schufa("insufficient") == 2.0
 
     def test_unknown_default(self) -> None:
         assert _score_schufa("unknown") == 3.0
@@ -167,6 +176,10 @@ class TestEstimates:
     def test_recommended_dp_german_excellent(self) -> None:
         result = _recommended_dp_percent("german_citizen", "excellent")
         assert result == 15.0
+
+    def test_recommended_dp_insufficient_penalty(self) -> None:
+        result = _recommended_dp_percent("eu_citizen", "insufficient")
+        assert result == 25.0
 
     def test_ltv(self) -> None:
         result = _estimate_ltv(50000, 200000)
@@ -271,7 +284,7 @@ class TestAssess:
             monthly_net_income=2000,
             monthly_debt=1200,
             available_down_payment=5000,
-            schufa_rating="poor",
+            schufa_rating="insufficient",
             residency_status="non_eu",
         )
         result = assess(inputs)

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2066,9 +2066,9 @@ export const FinancingAssessmentCreateSchema = {
         },
         schufa_rating: {
             type: 'string',
-            enum: ['excellent', 'good', 'satisfactory', 'adequate', 'poor', 'unknown'],
+            enum: ['excellent', 'good', 'acceptable', 'sufficient', 'insufficient', 'unknown'],
             title: 'Schufa Rating',
-            description: 'SCHUFA credit rating category'
+            description: 'SCHUFA NextGen Score rating category'
         },
         residency_status: {
             type: 'string',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -621,9 +621,9 @@ export type FinancingAssessmentCreate = {
      */
     available_down_payment: number;
     /**
-     * SCHUFA credit rating category
+     * SCHUFA NextGen Score rating category
      */
-    schufa_rating: 'excellent' | 'good' | 'satisfactory' | 'adequate' | 'poor' | 'unknown';
+    schufa_rating: 'excellent' | 'good' | 'acceptable' | 'sufficient' | 'insufficient' | 'unknown';
     /**
      * Residency or citizenship status
      */
@@ -636,9 +636,9 @@ export type FinancingAssessmentCreate = {
 export type employment_status = 'permanent' | 'fixed_term' | 'self_employed' | 'freelance' | 'civil_servant';
 
 /**
- * SCHUFA credit rating category
+ * SCHUFA NextGen Score rating category
  */
-export type schufa_rating = 'excellent' | 'good' | 'satisfactory' | 'adequate' | 'poor' | 'unknown';
+export type schufa_rating = 'excellent' | 'good' | 'acceptable' | 'sufficient' | 'insufficient' | 'unknown';
 
 /**
  * Residency or citizenship status

--- a/frontend/src/components/Calculators/FinancingWizard.tsx
+++ b/frontend/src/components/Calculators/FinancingWizard.tsx
@@ -117,11 +117,11 @@ const EMPLOYMENT_OPTIONS: { value: EmploymentStatus; label: string }[] = [
 ]
 
 const SCHUFA_OPTIONS: { value: SchufaRating; label: string }[] = [
-  { value: "excellent", label: "Excellent (97.5%+)" },
-  { value: "good", label: "Good (95-97.5%)" },
-  { value: "satisfactory", label: "Satisfactory (90-95%)" },
-  { value: "adequate", label: "Adequate (80-90%)" },
-  { value: "poor", label: "Poor (<80%)" },
+  { value: "excellent", label: "Excellent — 776-999 pts" },
+  { value: "good", label: "Good — 709-775 pts" },
+  { value: "acceptable", label: "Acceptable — 642-708 pts" },
+  { value: "sufficient", label: "Sufficient — 100-641 pts" },
+  { value: "insufficient", label: "Insufficient — no score" },
   { value: "unknown", label: "Unknown / Not yet obtained" },
 ]
 
@@ -292,9 +292,9 @@ function scoreSchufa(rating: SchufaRating): number {
   const scores: Record<SchufaRating, number> = {
     excellent: 15,
     good: 12,
-    satisfactory: 9,
-    adequate: 5,
-    poor: 2,
+    acceptable: 9,
+    sufficient: 5,
+    insufficient: 2,
     unknown: 3,
   }
   return scores[rating] ?? 3
@@ -346,7 +346,7 @@ function recommendedDpPercent(
   } else {
     base = 20
   }
-  if (schufa === "poor" || schufa === "unknown") base += 5
+  if (schufa === "insufficient" || schufa === "unknown") base += 5
   if (
     residency === "german_citizen" &&
     (schufa === "excellent" || schufa === "good")

--- a/frontend/src/models/calculator.ts
+++ b/frontend/src/models/calculator.ts
@@ -178,9 +178,9 @@ export type EmploymentStatus =
 export type SchufaRating =
   | "excellent"
   | "good"
-  | "satisfactory"
-  | "adequate"
-  | "poor"
+  | "acceptable"
+  | "sufficient"
+  | "insufficient"
   | "unknown"
 
 export type FinancingResidencyStatus =


### PR DESCRIPTION
## Summary
- Updates SCHUFA rating categories from the old percentage-based system to the new NextGen Score 1.0 point-based system (launched March 2026)
- Renames categories: satisfactory→acceptable, adequate→sufficient, poor→insufficient
- Updates backend schema, service scoring logic, tests, frontend types, and wizard UI labels with new point ranges (e.g. "Excellent — 776-999 pts")
- Includes reversible Alembic data migration for existing records

## Test plan
- [x] All 54 financing service tests pass
- [x] TypeScript compiles with no errors
- [x] Pre-commit hooks pass (biome, ruff, SDK generation)
- [ ] Verify calculator financing tab shows new SCHUFA labels
- [ ] Verify scoring logic unchanged (same point values per category)
- [ ] Verify `recommendedDpPercent` uses "insufficient" instead of "poor"