### PR TITLE
fix(journey): reduce step card height when collapsed

### DIFF
--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -108,7 +108,7 @@ function StepCard(props: IProps) {
   return (
     <Card
       className={cn(
-        "overflow-hidden transition-all",
+        "overflow-hidden py-3 transition-all",
         isActive && "ring-2 ring-blue-600 ring-offset-2",
         step.status === "completed" &&
           "border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20",
@@ -116,10 +116,10 @@ function StepCard(props: IProps) {
       )}
     >
       <CardHeader
-        className={cn("pb-3", hasBody && "cursor-pointer select-none")}
+        className={cn("pb-2", hasBody && "cursor-pointer select-none")}
         onClick={handleToggleExpanded}
       >
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex items-center gap-2">
               {hasBody && (
@@ -142,7 +142,9 @@ function StepCard(props: IProps) {
               </span>
             </div>
             <CardTitle className="text-base sm:text-lg">{step.title}</CardTitle>
-            <CardDescription>{step.description}</CardDescription>
+            {isExpanded && (
+              <CardDescription>{step.description}</CardDescription>
+            )}
           </div>
           <div className="self-start">
             <StatusBadge status={step.status} />


### PR DESCRIPTION
## Summary
- Reduces collapsed step card height by ~50% so users can see more steps at a glance
- Overrides Card padding from `py-6` to `py-3`, reduces header padding and flex gaps
- Hides step description when collapsed (reveals on expand) — biggest space saver
- Title, phase badge, step number, and status badge remain visible when collapsed

## Test plan
- [x] TypeScript compiles with no errors
- [x] Pre-commit hooks pass
- [ ] Collapsed steps are visibly more compact
- [ ] Expanding a step reveals the description and content
- [ ] Expand/collapse animation still smooth
- [ ] Verify on mobile and desktop viewports