### PR TITLE
feat(journey): add phase completion cta with next phase navigation

### DIFF
--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -5,7 +5,7 @@
 
 import { Link } from "@tanstack/react-router"
 import { ArrowLeft, Calendar, Home, MapPin, Trash2, Wallet } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import {
   FINANCING_TYPES,
   GERMAN_STATES,
@@ -19,9 +19,15 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { JourneyProgress, JourneyPublic } from "@/models/journey"
+import type {
+  JourneyPhase,
+  JourneyProgress,
+  JourneyPublic,
+  JourneyStep,
+} from "@/models/journey"
 import { JourneyCompletionCta } from "./JourneyCompletionCta"
 import { JourneyProvider } from "./JourneyContext"
+import { PhaseCompletionCta } from "./PhaseCompletionCta"
 import { PhaseIndicator } from "./PhaseIndicator"
 import { ProgressBar } from "./ProgressBar"
 import { StepCard } from "./StepCard"
@@ -164,6 +170,73 @@ function JourneyDetailSkeleton() {
   )
 }
 
+/** List view with phase completion CTAs between phase groups. */
+function StepListView(props: {
+  steps: JourneyStep[]
+  activeStepNumber: number
+  onTaskToggle: (stepId: string, taskId: string, isCompleted: boolean) => void
+  onStepOpen?: (stepId: string) => void
+}) {
+  const { steps, activeStepNumber, onTaskToggle, onStepOpen } = props
+  const phaseRefs = useRef<Record<string, HTMLDivElement | null>>({})
+
+  const handleContinueToPhase = useCallback((nextPhase: JourneyPhase) => {
+    phaseRefs.current[nextPhase]?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    })
+  }, [])
+
+  // Group steps by phase in order
+  const phaseGroups = useMemo(() => {
+    const groups: { phase: JourneyPhase; steps: JourneyStep[] }[] = []
+    for (const step of steps) {
+      const lastGroup = groups[groups.length - 1]
+      if (lastGroup && lastGroup.phase === step.phase) {
+        lastGroup.steps.push(step)
+      } else {
+        groups.push({ phase: step.phase, steps: [step] })
+      }
+    }
+    return groups
+  }, [steps])
+
+  return (
+    <>
+      {phaseGroups.map((group) => {
+        const isComplete = group.steps.every(
+          (s) => s.status === "completed" || s.status === "skipped",
+        )
+        return (
+          <div
+            key={group.phase}
+            ref={(el) => {
+              phaseRefs.current[group.phase] = el
+            }}
+            className="space-y-4"
+          >
+            {group.steps.map((step) => (
+              <StepCard
+                key={step.id}
+                step={step}
+                isActive={step.step_number === activeStepNumber}
+                onTaskToggle={onTaskToggle}
+                onStepOpen={onStepOpen}
+              />
+            ))}
+            {isComplete && (
+              <PhaseCompletionCta
+                currentPhase={group.phase}
+                onContinue={handleContinueToPhase}
+              />
+            )}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
 /** Default component. Full journey detail view. */
 function JourneyDetail(props: IProps) {
   const {
@@ -277,15 +350,12 @@ function JourneyDetail(props: IProps) {
           {/* Steps */}
           <div className="lg:col-span-2 space-y-4">
             {viewMode === "list" ? (
-              journey.steps.map((step) => (
-                <StepCard
-                  key={step.id}
-                  step={step}
-                  isActive={step.step_number === journey.current_step_number}
-                  onTaskToggle={onTaskToggle}
-                  onStepOpen={onStepOpen}
-                />
-              ))
+              <StepListView
+                steps={journey.steps}
+                activeStepNumber={journey.current_step_number}
+                onTaskToggle={onTaskToggle}
+                onStepOpen={onStepOpen}
+              />
             ) : (
               <StepTabView
                 steps={journey.steps}

--- a/frontend/src/components/Journey/PhaseCompletionCta.tsx
+++ b/frontend/src/components/Journey/PhaseCompletionCta.tsx
@@ -1,0 +1,90 @@
+/**
+ * Phase Completion CTA
+ * Shows a "Continue to Next Phase" prompt when all steps in a phase are complete,
+ * or a "Journey Complete" message on the last phase.
+ */
+
+import { ArrowRight, CheckCircle2, PartyPopper } from "lucide-react"
+
+import { JOURNEY_PHASES } from "@/common/constants"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import type { JourneyPhase } from "@/models/journey"
+
+interface IProps {
+  currentPhase: JourneyPhase
+  onContinue: (nextPhase: JourneyPhase) => void
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const VISIBLE_PHASES = JOURNEY_PHASES.filter((p) => p.key !== "rental_setup")
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Phase completion CTA card. */
+function PhaseCompletionCta(props: Readonly<IProps>) {
+  const { currentPhase, onContinue } = props
+
+  const phaseIndex = VISIBLE_PHASES.findIndex((p) => p.key === currentPhase)
+  const isLastPhase =
+    phaseIndex === -1 || phaseIndex === VISIBLE_PHASES.length - 1
+  const nextPhase = isLastPhase ? null : VISIBLE_PHASES[phaseIndex + 1]
+  const currentLabel = VISIBLE_PHASES[phaseIndex]?.label ?? currentPhase
+
+  if (isLastPhase) {
+    return (
+      <Card className="border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30">
+        <CardContent className="flex flex-col items-center gap-3 py-5 text-center sm:flex-row sm:text-left">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/50">
+            <PartyPopper className="h-5 w-5 text-green-600 dark:text-green-400" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="font-semibold text-green-900 dark:text-green-100">
+              All phases complete!
+            </h3>
+            <p className="mt-0.5 text-sm text-green-700 dark:text-green-300">
+              Congratulations — you've completed every phase of your property
+              journey.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30">
+      <CardContent className="flex flex-col items-center gap-3 py-5 text-center sm:flex-row sm:text-left">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/50">
+          <CheckCircle2 className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold text-blue-900 dark:text-blue-100">
+            {currentLabel} phase complete!
+          </h3>
+          <p className="mt-0.5 text-sm text-blue-700 dark:text-blue-300">
+            Great progress — ready to move on to the {nextPhase?.label} phase?
+          </p>
+        </div>
+        <Button
+          className="shrink-0 gap-2"
+          onClick={() => onContinue(nextPhase!.key as JourneyPhase)}
+        >
+          Continue to {nextPhase?.label}
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { PhaseCompletionCta }

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -10,6 +10,7 @@ import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
 import { cn } from "@/common/utils"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { JourneyPhase, JourneyStep } from "@/models/journey"
+import { PhaseCompletionCta } from "./PhaseCompletionCta"
 import { StepCard } from "./StepCard"
 
 interface IProps {
@@ -54,6 +55,14 @@ function StepTabView(props: IProps) {
 
   const phaseSteps = stepsByPhase[effectivePhase]
 
+  const isPhaseComplete =
+    phaseSteps.length > 0 &&
+    phaseSteps.every((s) => s.status === "completed" || s.status === "skipped")
+
+  const handleContinueToPhase = (nextPhase: JourneyPhase) => {
+    setSelectedPhase(nextPhase)
+  }
+
   return (
     <div className="space-y-4">
       {/* Phase pills */}
@@ -90,6 +99,14 @@ function StepTabView(props: IProps) {
           onStepOpen={onStepOpen}
         />
       ))}
+
+      {/* Phase completion CTA */}
+      {isPhaseComplete && (
+        <PhaseCompletionCta
+          currentPhase={effectivePhase}
+          onContinue={handleContinueToPhase}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add `PhaseCompletionCta` component that shows "Continue to Next Phase" when all steps in a phase are completed/skipped
- In **tab view**: clicking the CTA switches to the next phase tab
- In **list view**: clicking the CTA smooth-scrolls to the next phase group
- On the **last phase**: shows a "All phases complete!" congratulatory message instead of a button
- Respects `rental_setup` as an excluded phase (not counted as a main phase)

## Test plan
- [ ] Complete all steps in a phase (e.g. Research) — verify CTA appears below the steps
- [ ] Click "Continue to [Next Phase]" in tab view — verify it switches to the next tab
- [ ] Click "Continue to [Next Phase]" in list view — verify smooth scroll to next phase
- [ ] On last phase (Ownership), complete all steps — verify "All phases complete!" message
- [ ] Partially complete a phase — verify CTA does NOT appear
- [ ] Test on mobile and desktop viewports