### PR TITLE
fix(ui): prevent calculator result card from overflowing viewport

### DIFF
--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -179,7 +179,7 @@ function Layout() {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset>
+      <SidebarInset className="overflow-hidden">
         <header className="sticky top-0 z-10 flex h-16 shrink-0 items-center gap-2 bg-background px-4">
           <SidebarTrigger className="-ml-1 text-muted-foreground" />
           <div className="ml-auto flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` to `SidebarInset` in the app layout to prevent content from extending beyond the sidebar-allocated space
- Fixes the right-column result card being cut off on all calculator tab pages when the sidebar is open

## Root Cause
`SidebarInset` (shadcn/ui) uses `flex w-full flex-1 flex-col` but has no overflow constraint. In the flex layout with the sidebar, the inset area can grow beyond its allotted width, causing grid children (like the 2-column calculator layout) to overflow.

## Test plan
- [ ] Open each calculator tab (Hidden Costs, ROI, State Comparison, Financing, Property Evaluation, GmbH vs Private, Mortgage, City Compare, Tax Guide) with sidebar open
- [ ] Verify the right-column result card stays within the viewport
- [ ] Toggle sidebar open/closed — verify layout adapts correctly
- [ ] Test at 1024px, 1280px, 1440px viewport widths
- [ ] Verify no content is clipped unexpectedly on other pages (dashboard, journeys, documents, laws)