### PR TITLE
fix(ui): wrap calculator tabs into rows instead of horizontal scroll

### DIFF
--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -64,7 +64,7 @@ function CalculatorsPage() {
       </div>
 
       <Tabs defaultValue={tab || "costs"}>
-        <TabsList className="flex w-full overflow-x-auto">
+        <TabsList className="flex h-auto w-full flex-wrap gap-1">
           <TabsTrigger
             value="costs"
             className="gap-2"


### PR DESCRIPTION
## Summary
- Replace horizontal scrolling tab bar with wrapping flex layout for the 9 calculator tabs
- Tabs now wrap into multiple rows so all are visible without scrolling

## Changes
- `TabsList`: `flex w-full overflow-x-auto` → `flex h-auto w-full flex-wrap gap-1`
- `h-auto` overrides TabsList's fixed height to allow multi-row
- `flex-wrap` enables natural wrapping
- `gap-1` adds spacing between wrapped rows

## Test plan
- [ ] Open calculators page — verify all 9 tabs visible without horizontal scroll
- [ ] Verify tabs wrap into ~2 rows on desktop, more on narrow viewports
- [ ] Click each tab — verify correct calculator loads
- [ ] Test on mobile — verify tabs are still usable