### PR TITLE
feat(journey): add rental journey path for apartment search to move-in

### DIFF
--- a/backend/app/alembic/versions/c5d6e7f8g9h0_add_rental_journey_type.py
+++ b/backend/app/alembic/versions/c5d6e7f8g9h0_add_rental_journey_type.py
@@ -1,0 +1,53 @@
+"""Add rental journey type
+
+Revision ID: c5d6e7f8g9h0
+Revises: b4c5d6e7f8g9
+Create Date: 2026-04-22 18:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "c5d6e7f8g9h0"
+down_revision = "b4c5d6e7f8g9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create journeytype enum
+    op.execute("CREATE TYPE journeytype AS ENUM ('buying', 'rental')")
+
+    # Add journey_type column to journey table
+    op.add_column(
+        "journey",
+        sa.Column(
+            "journey_type",
+            sa.dialects.postgresql.ENUM(
+                "buying", "rental", name="journeytype", create_type=False
+            ),
+            nullable=False,
+            server_default="buying",
+        ),
+    )
+
+    # Add new rental phases to journeyphase enum
+    op.execute(
+        "ALTER TYPE journeyphase ADD VALUE IF NOT EXISTS 'rental_search'"
+    )
+    op.execute(
+        "ALTER TYPE journeyphase ADD VALUE IF NOT EXISTS 'rental_application'"
+    )
+    op.execute(
+        "ALTER TYPE journeyphase ADD VALUE IF NOT EXISTS 'rental_contract'"
+    )
+    op.execute(
+        "ALTER TYPE journeyphase ADD VALUE IF NOT EXISTS 'rental_move_in'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("journey", "journey_type")
+    op.execute("DROP TYPE journeytype")

--- a/backend/app/api/routes/journeys.py
+++ b/backend/app/api/routes/journeys.py
@@ -92,6 +92,7 @@ def _build_journey_response(journey: Journey) -> JourneyResponse:
     pct = round((completed / total) * 100, 1) if total > 0 else 0
     return JourneyResponse(
         id=journey.id,
+        journey_type=journey.journey_type,
         title=journey.title,
         current_phase=journey.current_phase,
         current_step_number=journey.current_step_number,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -53,6 +53,7 @@ from app.models.journey import (
     JourneyPhase,
     JourneyStep,
     JourneyTask,
+    JourneyType,
     PropertyType,
     StepStatus,
 )
@@ -139,6 +140,7 @@ __all__ = [
     "JourneyPhase",
     "JourneyStep",
     "JourneyTask",
+    "JourneyType",
     "Law",
     "LawBookmark",
     "LawCategory",

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -19,6 +19,13 @@ from sqlalchemy.orm import relationship
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
 
 
+class JourneyType(str, PyEnum):
+    """Types of journeys."""
+
+    BUYING = "buying"
+    RENTAL = "rental"
+
+
 class JourneyPhase(str, PyEnum):
     """Phases of the property buying journey."""
 
@@ -28,6 +35,10 @@ class JourneyPhase(str, PyEnum):
     CLOSING = "closing"
     OWNERSHIP = "ownership"
     RENTAL_SETUP = "rental_setup"
+    RENTAL_SEARCH = "rental_search"
+    RENTAL_APPLICATION = "rental_application"
+    RENTAL_CONTRACT = "rental_contract"
+    RENTAL_MOVE_IN = "rental_move_in"
 
 
 class StepStatus(str, PyEnum):
@@ -58,6 +69,12 @@ class FinancingType(str, PyEnum):
 
 # Define PostgreSQL enum types with create_type=False to prevent auto-creation
 # These will be created by Alembic migration
+_journey_type_enum = PgEnum(
+    "buying",
+    "rental",
+    name="journeytype",
+    create_type=False,
+)
 _journey_phase_enum = PgEnum(
     "research",
     "preparation",
@@ -65,6 +82,10 @@ _journey_phase_enum = PgEnum(
     "closing",
     "ownership",
     "rental_setup",
+    "rental_search",
+    "rental_application",
+    "rental_contract",
+    "rental_move_in",
     name="journeyphase",
     create_type=False,
 )
@@ -103,6 +124,11 @@ class Journey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     # Journey metadata
+    journey_type = Column(
+        _journey_type_enum,
+        default=JourneyType.BUYING.value,
+        nullable=False,
+    )
     title = Column(String(255), nullable=False, default="My Property Journey")
     current_phase = Column(
         _journey_phase_enum,

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.models.journey import (
     FinancingType,
     JourneyPhase,
+    JourneyType,
     PropertyType,
     StepStatus,
 )
@@ -105,9 +106,10 @@ class PropertyGoalsUpdate(BaseModel):
 class QuestionnaireAnswers(BaseModel):
     """Answers from the onboarding questionnaire."""
 
-    property_type: PropertyType
+    journey_type: JourneyType = JourneyType.BUYING
+    property_type: PropertyType | None = None
     property_location: str = Field(..., max_length=255)
-    financing_type: FinancingType
+    financing_type: FinancingType | None = None
     is_first_time_buyer: bool = True
     has_german_residency: bool = False
     budget_euros: int | None = Field(default=None, ge=0)  # max budget
@@ -232,6 +234,7 @@ class JourneyResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
+    journey_type: JourneyType = JourneyType.BUYING
     title: str
     current_phase: JourneyPhase
     current_step_number: int

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -16,6 +16,7 @@ from app.models.journey import (
     JourneyPhase,
     JourneyStep,
     JourneyTask,
+    JourneyType,
     StepStatus,
 )
 from app.schemas.journey import QuestionnaireAnswers
@@ -816,6 +817,375 @@ STEP_TEMPLATES: list[StepTemplate] = [
     ),
 ]
 
+# Step templates for the tenant rental journey (apartment search → move-in).
+RENTAL_STEP_TEMPLATES: list[StepTemplate] = [
+    # RENTAL_SEARCH phase
+    StepTemplate(
+        step_number=1,
+        phase=JourneyPhase.RENTAL_SEARCH,
+        title="Define Your Rental Requirements",
+        description="Clarify your budget, preferred location, apartment size, and must-have features before starting your search.",
+        estimated_duration_days=3,
+        content_key="rental_search_requirements",
+        tasks=[
+            {
+                "title": "Set your monthly rent budget (Kaltmiete + Nebenkosten)",
+                "is_required": True,
+            },
+            {
+                "title": "List preferred neighborhoods or city districts",
+                "is_required": True,
+            },
+            {
+                "title": "Decide on minimum apartment size (sqm) and rooms",
+                "is_required": True,
+            },
+            {
+                "title": "List must-have features (balcony, elevator, fitted kitchen)",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=2,
+        phase=JourneyPhase.RENTAL_SEARCH,
+        title="Understand the German Rental Market",
+        description="Learn key concepts: Kaltmiete vs Warmmiete, Mietspiegel, tenant rights, and how the German rental system works.",
+        estimated_duration_days=3,
+        content_key="rental_market_overview",
+        prerequisites=[1],
+        tasks=[
+            {
+                "title": "Learn the difference between Kaltmiete (cold rent) and Warmmiete (warm rent)",
+                "is_required": True,
+            },
+            {
+                "title": "Look up the local Mietspiegel (rent index) for your target area",
+                "is_required": True,
+            },
+            {
+                "title": "Understand basic tenant rights under BGB Mietrecht (§535-580a)",
+                "is_required": True,
+            },
+            {
+                "title": "Research typical Nebenkosten (utilities) costs in your area",
+                "is_required": False,
+            },
+        ],
+        related_laws=["BGB §535-580a (Mietrecht)"],
+    ),
+    StepTemplate(
+        step_number=3,
+        phase=JourneyPhase.RENTAL_SEARCH,
+        title="Search for Apartments",
+        description="Use online portals, local networks, and agents to find available apartments matching your criteria.",
+        estimated_duration_days=14,
+        content_key="rental_apartment_search",
+        prerequisites=[2],
+        tasks=[
+            {"title": "Set up alerts on ImmoScout24 and Immowelt", "is_required": True},
+            {
+                "title": "Check WG-Gesucht for shared apartments (if applicable)",
+                "is_required": False,
+            },
+            {
+                "title": "Contact local Makler (agents) in your target area",
+                "is_required": False,
+            },
+            {
+                "title": "Check local newspapers and neighborhood bulletin boards",
+                "is_required": False,
+            },
+        ],
+    ),
+    # RENTAL_APPLICATION phase
+    StepTemplate(
+        step_number=4,
+        phase=JourneyPhase.RENTAL_APPLICATION,
+        title="Prepare Application Documents",
+        description="Gather all documents landlords typically require: SCHUFA, income proof, Mietschuldenfreiheitsbescheinigung, and Selbstauskunft.",
+        estimated_duration_days=7,
+        content_key="rental_application_documents",
+        prerequisites=[3],
+        tasks=[
+            {
+                "title": "Request your SCHUFA Auskunft (credit report)",
+                "is_required": True,
+            },
+            {
+                "title": "Get Mietschuldenfreiheitsbescheinigung from previous landlord",
+                "is_required": True,
+            },
+            {
+                "title": "Prepare Selbstauskunft (tenant self-disclosure form)",
+                "is_required": True,
+            },
+            {
+                "title": "Gather income proof (3 recent pay slips or employment contract)",
+                "is_required": True,
+            },
+            {"title": "Prepare copy of ID/passport", "is_required": True},
+        ],
+    ),
+    StepTemplate(
+        step_number=5,
+        phase=JourneyPhase.RENTAL_APPLICATION,
+        title="Attend Viewings (Besichtigung)",
+        description="Visit apartments, evaluate condition, ask the right questions, and watch for red flags.",
+        estimated_duration_days=14,
+        content_key="rental_viewings",
+        prerequisites=[4],
+        tasks=[
+            {"title": "Schedule and attend apartment viewings", "is_required": True},
+            {
+                "title": "Check water pressure, heating, windows, and electrical outlets",
+                "is_required": True,
+            },
+            {
+                "title": "Ask about Nebenkosten breakdown and last Betriebskostenabrechnung",
+                "is_required": True,
+            },
+            {
+                "title": "Note any existing damage or defects for documentation",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=6,
+        phase=JourneyPhase.RENTAL_APPLICATION,
+        title="Submit Applications",
+        description="Send your application package to landlords. Tips for standing out in a competitive market.",
+        estimated_duration_days=7,
+        content_key="rental_submit_application",
+        prerequisites=[5],
+        tasks=[
+            {
+                "title": "Write a brief, polite cover letter introducing yourself",
+                "is_required": True,
+            },
+            {
+                "title": "Attach all required documents (SCHUFA, income, Selbstauskunft)",
+                "is_required": True,
+            },
+            {
+                "title": "Follow up with landlords within 2-3 days if no response",
+                "is_required": False,
+            },
+        ],
+    ),
+    # RENTAL_CONTRACT phase
+    StepTemplate(
+        step_number=7,
+        phase=JourneyPhase.RENTAL_CONTRACT,
+        title="Review the Mietvertrag",
+        description="Carefully review the lease agreement. Understand key clauses, identify red flags, and know your rights.",
+        estimated_duration_days=5,
+        content_key="rental_contract_review",
+        prerequisites=[6],
+        tasks=[
+            {
+                "title": "Review rent amount, payment due date, and bank details",
+                "is_required": True,
+            },
+            {
+                "title": "Check Schonheitsreparaturen (cosmetic repair) clauses",
+                "is_required": True,
+            },
+            {
+                "title": "Understand notice period (Kundigungsfrist) — typically 3 months",
+                "is_required": True,
+            },
+            {
+                "title": "Look for Staffelmiete or Indexmiete (rent escalation) clauses",
+                "is_required": True,
+            },
+            {
+                "title": "Verify pet, subletting, and modification rules",
+                "is_required": False,
+            },
+        ],
+        related_laws=["BGB §535-548 (Mietvertrag)", "BGB §573-574c (Kundigung)"],
+    ),
+    StepTemplate(
+        step_number=8,
+        phase=JourneyPhase.RENTAL_CONTRACT,
+        title="Understand Kaution Requirements",
+        description="Learn about security deposit rules: maximum amount, payment options, and your rights regarding the deposit.",
+        estimated_duration_days=3,
+        content_key="rental_kaution",
+        prerequisites=[7],
+        tasks=[
+            {
+                "title": "Confirm Kaution amount (max 3 months Kaltmiete by law)",
+                "is_required": True,
+            },
+            {
+                "title": "Choose payment method: lump sum, 3 installments, or Kautionskonto",
+                "is_required": True,
+            },
+            {
+                "title": "Ensure landlord will hold deposit in a separate account",
+                "is_required": True,
+            },
+        ],
+        related_laws=["BGB §551 (Begrenzung und Anlage von Mietsicherheiten)"],
+    ),
+    StepTemplate(
+        step_number=9,
+        phase=JourneyPhase.RENTAL_CONTRACT,
+        title="Understand Nebenkosten",
+        description="Learn what's included in Nebenkosten (utility costs), how the annual Betriebskostenabrechnung works, and what landlords can charge.",
+        estimated_duration_days=3,
+        content_key="rental_nebenkosten",
+        prerequisites=[7],
+        tasks=[
+            {
+                "title": "Review the list of Nebenkosten items in your lease",
+                "is_required": True,
+            },
+            {
+                "title": "Understand the difference between warm and cold rent",
+                "is_required": True,
+            },
+            {
+                "title": "Learn about the annual Betriebskostenabrechnung (utility bill settlement)",
+                "is_required": True,
+            },
+            {
+                "title": "Check which costs are legally chargeable (BetrKV)",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "BetrKV (Betriebskostenverordnung)",
+            "HeizkostenV (Heizkostenverordnung)",
+        ],
+    ),
+    StepTemplate(
+        step_number=10,
+        phase=JourneyPhase.RENTAL_CONTRACT,
+        title="Negotiate Terms",
+        description="Know what's negotiable in a German lease and when to push back on unfavorable terms.",
+        estimated_duration_days=3,
+        content_key="rental_negotiate",
+        prerequisites=[7],
+        tasks=[
+            {
+                "title": "Identify clauses you want to negotiate (move-in date, Kaution installments)",
+                "is_required": False,
+            },
+            {
+                "title": "Request removal of unfair Schonheitsreparaturen clauses if present",
+                "is_required": False,
+            },
+            {
+                "title": "Negotiate any necessary apartment modifications or repairs before move-in",
+                "is_required": False,
+            },
+        ],
+    ),
+    # RENTAL_MOVE_IN phase
+    StepTemplate(
+        step_number=11,
+        phase=JourneyPhase.RENTAL_MOVE_IN,
+        title="Sign the Mietvertrag",
+        description="Finalize and sign the lease agreement. Know what to bring and what to verify before signing.",
+        estimated_duration_days=1,
+        content_key="rental_sign_lease",
+        prerequisites=[7, 8],
+        tasks=[
+            {
+                "title": "Bring valid ID and proof of income to signing",
+                "is_required": True,
+            },
+            {
+                "title": "Read through the final version of the contract carefully",
+                "is_required": True,
+            },
+            {"title": "Ensure both parties sign all copies", "is_required": True},
+            {"title": "Receive your signed copy and keep it safe", "is_required": True},
+        ],
+    ),
+    StepTemplate(
+        step_number=12,
+        phase=JourneyPhase.RENTAL_MOVE_IN,
+        title="Pay Kaution & First Rent",
+        description="Transfer the security deposit and first month's rent according to the lease terms.",
+        estimated_duration_days=3,
+        content_key="rental_initial_payment",
+        prerequisites=[11],
+        tasks=[
+            {
+                "title": "Transfer Kaution (or first installment) to landlord's account",
+                "is_required": True,
+            },
+            {
+                "title": "Transfer first month's rent before move-in date",
+                "is_required": True,
+            },
+            {
+                "title": "Keep transfer receipts as proof of payment",
+                "is_required": True,
+            },
+            {
+                "title": "Set up Dauerauftrag (standing order) for monthly rent",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=13,
+        phase=JourneyPhase.RENTAL_MOVE_IN,
+        title="Complete Wohnungsubergabe",
+        description="Conduct the apartment handover with the landlord. Document everything in the Ubergabeprotokoll.",
+        estimated_duration_days=1,
+        content_key="rental_handover",
+        prerequisites=[12],
+        tasks=[
+            {
+                "title": "Walk through every room and document existing defects with photos",
+                "is_required": True,
+            },
+            {
+                "title": "Record all meter readings (electricity, gas, water)",
+                "is_required": True,
+            },
+            {
+                "title": "Complete and sign the Ubergabeprotokoll (handover protocol)",
+                "is_required": True,
+            },
+            {"title": "Collect all keys and test them", "is_required": True},
+        ],
+    ),
+    StepTemplate(
+        step_number=14,
+        phase=JourneyPhase.RENTAL_MOVE_IN,
+        title="Complete Anmeldung & Utilities",
+        description="Register your new address at the Burgeramt and set up utilities, internet, and GEZ.",
+        estimated_duration_days=7,
+        content_key="rental_registration_utilities",
+        prerequisites=[13],
+        tasks=[
+            {
+                "title": "Register at Burgeramt (Anmeldung) within 14 days of moving in",
+                "is_required": True,
+            },
+            {
+                "title": "Get Wohnungsgeberbestatigung (landlord confirmation) for registration",
+                "is_required": True,
+            },
+            {"title": "Set up electricity and gas contracts", "is_required": True},
+            {"title": "Set up internet and phone", "is_required": False},
+            {
+                "title": "Register for GEZ (Rundfunkbeitrag) — 18.36 EUR/month",
+                "is_required": True,
+            },
+        ],
+        related_laws=["BMG §17 (Anmeldung bei der Meldebehorde)"],
+    ),
+]
+
 
 def _format_eur(amount: float) -> str:
     """Format a float as a rounded EUR string (e.g. '18,000 EUR')."""
@@ -981,36 +1351,59 @@ def generate_journey(
     Returns:
         Created Journey with generated steps.
     """
-    # Create the journey, pre-filling property_goals from questionnaire so
-    # Research Step 1 "Define Your Property Goals" loads with the type already selected.
-    journey = Journey(
-        user_id=user_id,
-        title=title,
-        property_type=answers.property_type,
-        property_location=answers.property_location,
-        financing_type=answers.financing_type,
-        is_first_time_buyer=answers.is_first_time_buyer,
-        has_german_residency=answers.has_german_residency,
-        budget_euros=answers.budget_euros,
-        target_purchase_date=answers.target_purchase_date,
-        property_use=answers.property_use,
-        started_at=datetime.now(timezone.utc),
-        property_goals={
-            "preferred_property_type": answers.property_type.value,
-            "budget_min_euros": answers.budget_min_euros,
-            "budget_max_euros": answers.budget_euros,
-            "property_use": answers.property_use,
-        },
-    )
+    is_rental = answers.journey_type == JourneyType.RENTAL
+
+    if is_rental:
+        journey = Journey(
+            user_id=user_id,
+            journey_type=JourneyType.RENTAL,
+            title=title or "My Rental Journey",
+            property_location=answers.property_location,
+            is_first_time_buyer=answers.is_first_time_buyer,
+            has_german_residency=answers.has_german_residency,
+            budget_euros=answers.budget_euros,
+            target_purchase_date=answers.target_purchase_date,
+            current_phase=JourneyPhase.RENTAL_SEARCH,
+            started_at=datetime.now(timezone.utc),
+        )
+    else:
+        # Create the journey, pre-filling property_goals from questionnaire so
+        # Research Step 1 "Define Your Property Goals" loads with the type already
+        # selected.
+        journey = Journey(
+            user_id=user_id,
+            journey_type=JourneyType.BUYING,
+            title=title or "My Property Journey",
+            property_type=answers.property_type,
+            property_location=answers.property_location,
+            financing_type=answers.financing_type,
+            is_first_time_buyer=answers.is_first_time_buyer,
+            has_german_residency=answers.has_german_residency,
+            budget_euros=answers.budget_euros,
+            target_purchase_date=answers.target_purchase_date,
+            property_use=answers.property_use,
+            started_at=datetime.now(timezone.utc),
+            property_goals={
+                "preferred_property_type": answers.property_type.value
+                if answers.property_type
+                else None,
+                "budget_min_euros": answers.budget_min_euros,
+                "budget_max_euros": answers.budget_euros,
+                "property_use": answers.property_use,
+            },
+        )
     session.add(journey)
     session.flush()  # Get journey ID
+
+    # Select template list based on journey type
+    templates = RENTAL_STEP_TEMPLATES if is_rental else STEP_TEMPLATES
 
     # Generate steps based on conditions
     step_number_map: dict[int, int] = {}  # Original -> New step number
     current_step = 0
 
-    for template in STEP_TEMPLATES:
-        if not _should_include_step(template, answers):
+    for template in templates:
+        if not is_rental and not _should_include_step(template, answers):
             continue
 
         current_step += 1
@@ -1030,7 +1423,7 @@ def generate_journey(
         # Personalize buying costs step with user's budget and state
         tasks_data = template.tasks
         step_estimated_costs = template.estimated_costs
-        if template.content_key == "buying_costs":
+        if not is_rental and template.content_key == "buying_costs":
             tasks_data, step_estimated_costs = _personalize_buying_costs(
                 template, answers
             )
@@ -1053,7 +1446,9 @@ def generate_journey(
         # Create tasks for this step, filtering by task-level conditions
         task_order = 0
         for task_data in tasks_data:
-            if not _matches_conditions(task_data.get("conditions"), answers):
+            if not is_rental and not _matches_conditions(
+                task_data.get("conditions"), answers
+            ):
                 continue
             task = JourneyTask(
                 step_id=step.id,

--- a/backend/tests/services/test_rental_journey_service.py
+++ b/backend/tests/services/test_rental_journey_service.py
@@ -1,0 +1,269 @@
+"""Tests for the Rental Journey Service."""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.journey import (
+    FinancingType,
+    JourneyPhase,
+    JourneyStep,
+    JourneyTask,
+    JourneyType,
+    PropertyType,
+)
+from app.schemas.journey import QuestionnaireAnswers
+from app.services.journey_service import (
+    RENTAL_STEP_TEMPLATES,
+    STEP_TEMPLATES,
+    generate_journey,
+)
+
+
+@pytest.fixture
+def rental_answers() -> QuestionnaireAnswers:
+    """Create questionnaire answers for a rental journey."""
+    return QuestionnaireAnswers(
+        journey_type=JourneyType.RENTAL,
+        property_location="Berlin",
+        is_first_time_buyer=True,
+        has_german_residency=False,
+        budget_euros=1200,
+    )
+
+
+@pytest.fixture
+def buying_answers() -> QuestionnaireAnswers:
+    """Create questionnaire answers for a buying journey (regression test)."""
+    return QuestionnaireAnswers(
+        journey_type=JourneyType.BUYING,
+        property_type=PropertyType.APARTMENT,
+        property_location="Berlin",
+        financing_type=FinancingType.MORTGAGE,
+        is_first_time_buyer=True,
+        has_german_residency=True,
+        budget_euros=300000,
+    )
+
+
+class TestRentalStepTemplates:
+    """Tests for RENTAL_STEP_TEMPLATES structure."""
+
+    def test_has_14_steps(self) -> None:
+        assert len(RENTAL_STEP_TEMPLATES) == 14
+
+    def test_covers_all_rental_phases(self) -> None:
+        phases = {t.phase for t in RENTAL_STEP_TEMPLATES}
+        assert phases == {
+            JourneyPhase.RENTAL_SEARCH,
+            JourneyPhase.RENTAL_APPLICATION,
+            JourneyPhase.RENTAL_CONTRACT,
+            JourneyPhase.RENTAL_MOVE_IN,
+        }
+
+    def test_rental_search_has_3_steps(self) -> None:
+        search_steps = [
+            t for t in RENTAL_STEP_TEMPLATES if t.phase == JourneyPhase.RENTAL_SEARCH
+        ]
+        assert len(search_steps) == 3
+
+    def test_rental_application_has_3_steps(self) -> None:
+        app_steps = [
+            t
+            for t in RENTAL_STEP_TEMPLATES
+            if t.phase == JourneyPhase.RENTAL_APPLICATION
+        ]
+        assert len(app_steps) == 3
+
+    def test_rental_contract_has_4_steps(self) -> None:
+        contract_steps = [
+            t for t in RENTAL_STEP_TEMPLATES if t.phase == JourneyPhase.RENTAL_CONTRACT
+        ]
+        assert len(contract_steps) == 4
+
+    def test_rental_move_in_has_4_steps(self) -> None:
+        move_in_steps = [
+            t for t in RENTAL_STEP_TEMPLATES if t.phase == JourneyPhase.RENTAL_MOVE_IN
+        ]
+        assert len(move_in_steps) == 4
+
+    def test_all_steps_have_tasks(self) -> None:
+        for template in RENTAL_STEP_TEMPLATES:
+            assert len(template.tasks) > 0, f"Step '{template.title}' has no tasks"
+
+    def test_no_buying_specific_content_keys(self) -> None:
+        buying_keys = {t.content_key for t in STEP_TEMPLATES}
+        rental_keys = {t.content_key for t in RENTAL_STEP_TEMPLATES}
+        assert buying_keys.isdisjoint(rental_keys), (
+            f"Overlap: {buying_keys & rental_keys}"
+        )
+
+
+class TestGenerateRentalJourney:
+    """Tests for generating a rental journey."""
+
+    def test_rental_journey_sets_journey_type(
+        self, rental_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(
+            session, user_id, "My Rental Journey", rental_answers
+        )
+
+        assert journey.journey_type == JourneyType.RENTAL
+
+    def test_rental_journey_sets_rental_search_phase(
+        self, rental_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(
+            session, user_id, "My Rental Journey", rental_answers
+        )
+
+        assert journey.current_phase == JourneyPhase.RENTAL_SEARCH
+
+    def test_rental_journey_creates_14_steps(
+        self, rental_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        generate_journey(session, user_id, "My Rental Journey", rental_answers)
+
+        # Count JourneyStep objects added to session
+        step_calls = [
+            call
+            for call in session.add.call_args_list
+            if isinstance(call[0][0], JourneyStep)
+        ]
+        assert len(step_calls) == 14
+
+    def test_rental_journey_creates_tasks(
+        self, rental_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        generate_journey(session, user_id, "My Rental Journey", rental_answers)
+
+        task_calls = [
+            call
+            for call in session.add.call_args_list
+            if isinstance(call[0][0], JourneyTask)
+        ]
+        assert len(task_calls) > 0
+
+    def test_rental_journey_has_no_buying_fields(
+        self, rental_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(
+            session, user_id, "My Rental Journey", rental_answers
+        )
+
+        assert journey.property_type is None
+        assert journey.financing_type is None
+        assert journey.property_use is None
+        assert journey.property_goals is None
+
+    def test_rental_journey_default_title(
+        self, rental_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(session, user_id, "", rental_answers)
+
+        assert journey.title == "My Rental Journey"
+
+    def test_rental_journey_phases_in_order(
+        self, rental_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        generate_journey(session, user_id, "My Rental Journey", rental_answers)
+
+        step_calls = [
+            call[0][0]
+            for call in session.add.call_args_list
+            if isinstance(call[0][0], JourneyStep)
+        ]
+        phases = [s.phase for s in step_calls]
+        expected_order = [
+            JourneyPhase.RENTAL_SEARCH,
+            JourneyPhase.RENTAL_SEARCH,
+            JourneyPhase.RENTAL_SEARCH,
+            JourneyPhase.RENTAL_APPLICATION,
+            JourneyPhase.RENTAL_APPLICATION,
+            JourneyPhase.RENTAL_APPLICATION,
+            JourneyPhase.RENTAL_CONTRACT,
+            JourneyPhase.RENTAL_CONTRACT,
+            JourneyPhase.RENTAL_CONTRACT,
+            JourneyPhase.RENTAL_CONTRACT,
+            JourneyPhase.RENTAL_MOVE_IN,
+            JourneyPhase.RENTAL_MOVE_IN,
+            JourneyPhase.RENTAL_MOVE_IN,
+            JourneyPhase.RENTAL_MOVE_IN,
+        ]
+        assert phases == expected_order
+
+
+class TestBuyingJourneyRegression:
+    """Ensure buying journeys still work unchanged."""
+
+    def test_buying_journey_sets_buying_type(
+        self, buying_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(
+            session, user_id, "My Property Journey", buying_answers
+        )
+
+        assert journey.journey_type == JourneyType.BUYING
+
+    def test_buying_journey_does_not_set_rental_phase(
+        self, buying_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(
+            session, user_id, "My Property Journey", buying_answers
+        )
+
+        # Buying journey relies on model default (research) — not explicitly set
+        # in code. Verify it's not a rental phase.
+        assert journey.current_phase != JourneyPhase.RENTAL_SEARCH
+
+    def test_buying_journey_has_property_goals(
+        self, buying_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(
+            session, user_id, "My Property Journey", buying_answers
+        )
+
+        assert journey.property_goals is not None
+        assert journey.property_goals["preferred_property_type"] == "apartment"
+
+    def test_buying_journey_default_title(
+        self, buying_answers: QuestionnaireAnswers
+    ) -> None:
+        session = MagicMock(spec=["add", "flush", "commit", "refresh"])
+        user_id = uuid.uuid4()
+
+        journey = generate_journey(session, user_id, "", buying_answers)
+
+        assert journey.title == "My Property Journey"

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2896,6 +2896,10 @@ export const JourneyDetailResponseSchema = {
             format: 'uuid',
             title: 'Id'
         },
+        journey_type: {
+            '$ref': '#/components/schemas/JourneyType',
+            default: 'buying'
+        },
         title: {
             type: 'string',
             title: 'Title'
@@ -3204,7 +3208,7 @@ export const JourneyOverviewSchema = {
 
 export const JourneyPhaseSchema = {
     type: 'string',
-    enum: ['research', 'preparation', 'buying', 'closing', 'ownership', 'rental_setup'],
+    enum: ['research', 'preparation', 'buying', 'closing', 'ownership', 'rental_setup', 'rental_search', 'rental_application', 'rental_contract', 'rental_move_in'],
     title: 'JourneyPhase',
     description: 'Phases of the property buying journey.'
 } as const;
@@ -3269,6 +3273,10 @@ export const JourneyResponseSchema = {
             type: 'string',
             format: 'uuid',
             title: 'Id'
+        },
+        journey_type: {
+            '$ref': '#/components/schemas/JourneyType',
+            default: 'buying'
         },
         title: {
             type: 'string',
@@ -3740,6 +3748,13 @@ export const JourneyTaskUpdateSchema = {
     required: ['is_completed'],
     title: 'JourneyTaskUpdate',
     description: 'Schema for updating a journey task.'
+} as const;
+
+export const JourneyTypeSchema = {
+    type: 'string',
+    enum: ['buying', 'rental'],
+    title: 'JourneyType',
+    description: 'Types of journeys.'
 } as const;
 
 export const JourneyUpdateSchema = {
@@ -7107,8 +7122,19 @@ export const PropertyTypeApplicabilitySchema = {
 
 export const QuestionnaireAnswersSchema = {
     properties: {
+        journey_type: {
+            '$ref': '#/components/schemas/JourneyType',
+            default: 'buying'
+        },
         property_type: {
-            '$ref': '#/components/schemas/PropertyType'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/PropertyType'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         property_location: {
             type: 'string',
@@ -7116,7 +7142,14 @@ export const QuestionnaireAnswersSchema = {
             title: 'Property Location'
         },
         financing_type: {
-            '$ref': '#/components/schemas/FinancingType'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/FinancingType'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         is_first_time_buyer: {
             type: 'boolean',
@@ -7178,7 +7211,7 @@ export const QuestionnaireAnswersSchema = {
         }
     },
     type: 'object',
-    required: ['property_type', 'property_location', 'financing_type'],
+    required: ['property_location'],
     title: 'QuestionnaireAnswers',
     description: 'Answers from the onboarding questionnaire.'
 } as const;

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -908,6 +908,7 @@ export type JourneyCreate = {
  */
 export type JourneyDetailResponse = {
     id: string;
+    journey_type?: JourneyType;
     title: string;
     current_phase: JourneyPhase;
     current_step_number: number;
@@ -960,7 +961,7 @@ export type JourneyOverview = {
 /**
  * Phases of the property buying journey.
  */
-export type JourneyPhase = 'research' | 'preparation' | 'buying' | 'closing' | 'ownership' | 'rental_setup';
+export type JourneyPhase = 'research' | 'preparation' | 'buying' | 'closing' | 'ownership' | 'rental_setup' | 'rental_search' | 'rental_application' | 'rental_contract' | 'rental_move_in';
 
 /**
  * Schema for journey progress.
@@ -985,6 +986,7 @@ export type JourneyProgressResponse = {
  */
 export type JourneyResponse = {
     id: string;
+    journey_type?: JourneyType;
     title: string;
     current_phase: JourneyPhase;
     current_step_number: number;
@@ -1094,6 +1096,11 @@ export type JourneyTaskResponse = {
 export type JourneyTaskUpdate = {
     is_completed: boolean;
 };
+
+/**
+ * Types of journeys.
+ */
+export type JourneyType = 'buying' | 'rental';
 
 /**
  * Schema for updating journey metadata.
@@ -1902,9 +1909,10 @@ export type PropertyTypeApplicability = 'all' | 'apartment' | 'house' | 'land' |
  * Answers from the onboarding questionnaire.
  */
 export type QuestionnaireAnswers = {
-    property_type: PropertyType;
+    journey_type?: JourneyType;
+    property_type?: (PropertyType | null);
     property_location: string;
-    financing_type: FinancingType;
+    financing_type?: (FinancingType | null);
     is_first_time_buyer?: boolean;
     has_german_residency?: boolean;
     budget_euros?: (number | null);

--- a/frontend/src/common/constants/index.ts
+++ b/frontend/src/common/constants/index.ts
@@ -54,6 +54,10 @@ export const JOURNEY_PHASES = [
   { key: "closing", label: "Closing", order: 4 },
   { key: "ownership", label: "Ownership", order: 5 },
   { key: "rental_setup", label: "Rental Setup", order: 6 },
+  { key: "rental_search", label: "Apartment Search", order: 7 },
+  { key: "rental_application", label: "Application", order: 8 },
+  { key: "rental_contract", label: "Lease Review", order: 9 },
+  { key: "rental_move_in", label: "Move-In", order: 10 },
 ] as const
 
 // Journey phase colors (used for phase badges across components)
@@ -69,6 +73,14 @@ export const PHASE_COLORS: Record<string, string> = {
     "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
   rental_setup:
     "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400",
+  rental_search:
+    "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400",
+  rental_application:
+    "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400",
+  rental_contract:
+    "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-400",
+  rental_move_in:
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
 }
 
 // Law categories

--- a/frontend/src/components/Dashboard/JourneyRingChart.tsx
+++ b/frontend/src/components/Dashboard/JourneyRingChart.tsx
@@ -29,9 +29,13 @@ const PHASE_CHART_COLORS: Record<string, { stroke: string; bg: string }> = {
   preparation: { stroke: Colors.Journey.Preparation, bg: "#f3e8ff" },
   buying: { stroke: Colors.Journey.Buying, bg: "#ffedd5" },
   closing: { stroke: Colors.Journey.Closing, bg: "#dcfce7" },
-  // ownership and rental_setup are not in Colors.Journey — defined locally
+  // ownership and rental phases are not in Colors.Journey — defined locally
   ownership: { stroke: "#f59e0b", bg: "#fef3c7" },
   rental_setup: { stroke: "#14b8a6", bg: "#ccfbf1" },
+  rental_search: { stroke: "#6366f1", bg: "#e0e7ff" },
+  rental_application: { stroke: "#06b6d4", bg: "#cffafe" },
+  rental_contract: { stroke: "#f43f5e", bg: "#ffe4e6" },
+  rental_move_in: { stroke: "#10b981", bg: "#d1fae5" },
 }
 
 const DEFAULT_COLOR = { stroke: "#6b7280", bg: "#f3f4f6" }

--- a/frontend/src/components/Journey/JourneyGenerating.tsx
+++ b/frontend/src/components/Journey/JourneyGenerating.tsx
@@ -35,6 +35,10 @@ const PHASE_LABELS: Record<JourneyPhase, string> = {
   closing: "Closing",
   ownership: "Ownership",
   rental_setup: "Rental Setup",
+  rental_search: "Apartment Search",
+  rental_application: "Application",
+  rental_contract: "Lease Review",
+  rental_move_in: "Move-In",
 }
 
 /******************************************************************************
@@ -77,6 +81,10 @@ function JourneyGenerating(props: IProps) {
       closing: 0,
       ownership: 0,
       rental_setup: 0,
+      rental_search: 0,
+      rental_application: 0,
+      rental_contract: 0,
+      rental_move_in: 0,
     }
     for (const step of journey.steps) {
       counts[step.phase]++

--- a/frontend/src/components/Journey/JourneySummary.tsx
+++ b/frontend/src/components/Journey/JourneySummary.tsx
@@ -6,17 +6,23 @@
 import { Sparkles } from "lucide-react"
 import { GERMAN_STATES } from "@/common/constants"
 import { formatDate, formatEur } from "@/common/utils"
-import type { ResidencyStatus } from "@/models/journey"
+import type {
+  FinancingType,
+  JourneyType,
+  PropertyType,
+  ResidencyStatus,
+} from "@/models/journey"
 
 /******************************************************************************
                               Types
 ******************************************************************************/
 
 export interface WizardState {
-  propertyType?: string
+  journeyType?: JourneyType
+  propertyType?: PropertyType
   propertyUse?: "live_in" | "rent_out"
   targetState?: string
-  financingType?: string
+  financingType?: FinancingType
   budgetMin?: number
   budgetMax?: number
   targetDate?: string
@@ -51,6 +57,8 @@ const PROPERTY_USE_LABELS: Record<string, string> = {
 function JourneySummary(props: IProps) {
   const { state } = props
 
+  const isRental = state.journeyType === "rental"
+
   const stateName =
     GERMAN_STATES.find((s) => s.code === state.targetState)?.name ||
     state.targetState
@@ -63,37 +71,53 @@ function JourneySummary(props: IProps) {
       <div>
         <h3 className="text-lg font-semibold">Review Your Journey</h3>
         <p className="text-sm text-muted-foreground">
-          Here's a summary of your property buying journey
+          {isRental
+            ? "Here's a summary of your apartment rental journey"
+            : "Here's a summary of your property buying journey"}
         </p>
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <div className="rounded-lg border p-4">
-          <p className="text-sm text-muted-foreground">Property Type</p>
-          <p className="font-medium capitalize">
-            {state.propertyType?.replace("_", " ")}
-          </p>
-        </div>
-        <div className="rounded-lg border p-4">
-          <p className="text-sm text-muted-foreground">Purpose</p>
+          <p className="text-sm text-muted-foreground">Journey Type</p>
           <p className="font-medium">
-            {state.propertyUse
-              ? PROPERTY_USE_LABELS[state.propertyUse]
-              : "Not specified"}
+            {isRental ? "Rent Apartment" : "Buy Property"}
           </p>
         </div>
+        {!isRental && (
+          <div className="rounded-lg border p-4">
+            <p className="text-sm text-muted-foreground">Property Type</p>
+            <p className="font-medium capitalize">
+              {state.propertyType?.replace("_", " ")}
+            </p>
+          </div>
+        )}
+        {!isRental && (
+          <div className="rounded-lg border p-4">
+            <p className="text-sm text-muted-foreground">Purpose</p>
+            <p className="font-medium">
+              {state.propertyUse
+                ? PROPERTY_USE_LABELS[state.propertyUse]
+                : "Not specified"}
+            </p>
+          </div>
+        )}
         <div className="rounded-lg border p-4">
           <p className="text-sm text-muted-foreground">Location</p>
           <p className="font-medium">{stateName}</p>
         </div>
+        {!isRental && (
+          <div className="rounded-lg border p-4">
+            <p className="text-sm text-muted-foreground">Financing</p>
+            <p className="font-medium capitalize">
+              {state.financingType?.replace("_", " ")}
+            </p>
+          </div>
+        )}
         <div className="rounded-lg border p-4">
-          <p className="text-sm text-muted-foreground">Financing</p>
-          <p className="font-medium capitalize">
-            {state.financingType?.replace("_", " ")}
+          <p className="text-sm text-muted-foreground">
+            {isRental ? "Monthly Budget" : "Budget Range"}
           </p>
-        </div>
-        <div className="rounded-lg border p-4">
-          <p className="text-sm text-muted-foreground">Budget Range</p>
           <p className="font-medium">
             {state.budgetMin || state.budgetMax
               ? `${formatEur(state.budgetMin)} - ${formatEur(state.budgetMax)}`

--- a/frontend/src/components/Journey/JourneyTypeSelector.tsx
+++ b/frontend/src/components/Journey/JourneyTypeSelector.tsx
@@ -1,0 +1,114 @@
+/**
+ * Journey Type Selector Component
+ * Allows user to select between buying a property or renting an apartment
+ */
+
+import { Building2, Key } from "lucide-react"
+import { cn } from "@/common/utils"
+import type { JourneyType } from "@/models/journey"
+
+interface IProps {
+  value?: JourneyType
+  onChange: (value: JourneyType) => void
+  className?: string
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const JOURNEY_TYPE_OPTIONS = [
+  {
+    value: "buying" as const,
+    label: "Buy Property",
+    description:
+      "You want to purchase a property in Germany. We'll guide you through research, financing, the buying process, and ownership.",
+    Icon: Building2,
+  },
+  {
+    value: "rental" as const,
+    label: "Rent Apartment",
+    description:
+      "You're looking to rent an apartment in Germany. We'll guide you through searching, applying, reviewing the lease, and moving in.",
+    Icon: Key,
+  },
+]
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Single journey type option card. */
+function JourneyTypeOption(props: {
+  option: (typeof JOURNEY_TYPE_OPTIONS)[number]
+  isSelected: boolean
+  onSelect: () => void
+}) {
+  const { option, isSelected, onSelect } = props
+  const { Icon } = option
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "flex flex-col items-start gap-3 rounded-lg border-2 p-6 transition-all hover:border-blue-400 hover:bg-blue-50/50 dark:hover:bg-blue-950/20 text-left",
+        isSelected
+          ? "border-blue-600 bg-blue-50 dark:bg-blue-950/30"
+          : "border-muted",
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <Icon
+          className={cn(
+            "h-8 w-8",
+            isSelected ? "text-blue-600" : "text-muted-foreground",
+          )}
+        />
+        <span
+          className={cn(
+            "text-lg font-medium",
+            isSelected ? "text-blue-600" : "text-foreground",
+          )}
+        >
+          {option.label}
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground">{option.description}</p>
+    </button>
+  )
+}
+
+/** Default component. Journey type selector (buy vs rent). */
+function JourneyTypeSelector(props: IProps) {
+  const { value, onChange, className } = props
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div>
+        <h3 className="text-lg font-semibold">What would you like to do?</h3>
+        <p className="text-sm text-muted-foreground">
+          Choose whether you want to buy a property or rent an apartment in
+          Germany
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {JOURNEY_TYPE_OPTIONS.map((option) => (
+          <JourneyTypeOption
+            key={option.value}
+            option={option}
+            isSelected={value === option.value}
+            onSelect={() => onChange(option.value)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { JourneyTypeSelector }

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -11,16 +11,15 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { useCreateJourney } from "@/hooks/mutations"
 import type {
-  FinancingType,
   JourneyCreate,
   JourneyPublic,
-  PropertyType,
-  ResidencyStatus,
+  JourneyType,
 } from "@/models/journey"
 import { BudgetInput } from "./BudgetInput"
 import { FinancingSelector } from "./FinancingSelector"
 import { JourneyGenerating } from "./JourneyGenerating"
-import { JourneySummary } from "./JourneySummary"
+import { JourneySummary, type WizardState } from "./JourneySummary"
+import { JourneyTypeSelector } from "./JourneyTypeSelector"
 import { LocationSelector } from "./LocationSelector"
 import { PropertyTypeSelector } from "./PropertyTypeSelector"
 import { PropertyUseSelector } from "./PropertyUseSelector"
@@ -36,33 +35,27 @@ interface IProps {
                               Constants
 ******************************************************************************/
 
-const WIZARD_STEPS = [
-  { id: 1, title: "Property" },
-  { id: 2, title: "Purpose" },
-  { id: 3, title: "Location" },
-  { id: 4, title: "Financing" },
-  { id: 5, title: "Budget" },
-  { id: 6, title: "Timeline" },
-  { id: 7, title: "Status" },
+const BUYING_WIZARD_STEPS = [
+  { id: 1, title: "Journey" },
+  { id: 2, title: "Property" },
+  { id: 3, title: "Purpose" },
+  { id: 4, title: "Location" },
+  { id: 5, title: "Financing" },
+  { id: 6, title: "Budget" },
+  { id: 7, title: "Timeline" },
+  { id: 8, title: "Status" },
+] as const
+
+const RENTAL_WIZARD_STEPS = [
+  { id: 1, title: "Journey" },
+  { id: 2, title: "Location" },
+  { id: 3, title: "Budget" },
+  { id: 4, title: "Timeline" },
+  { id: 5, title: "Status" },
 ] as const
 
 const STORAGE_STATE_KEY = "heimpath-wizard-state"
 const STORAGE_STEP_KEY = "heimpath-wizard-step"
-
-/******************************************************************************
-                              Types
-******************************************************************************/
-
-interface WizardState {
-  propertyType?: PropertyType
-  propertyUse?: "live_in" | "rent_out"
-  targetState?: string
-  financingType?: FinancingType
-  budgetMin?: number
-  budgetMax?: number
-  targetDate?: string
-  residencyStatus?: ResidencyStatus
-}
 
 /******************************************************************************
                               Components
@@ -98,6 +91,9 @@ function JourneyWizard(props: IProps) {
     null,
   )
 
+  const isRental = state.journeyType === "rental"
+  const wizardSteps = isRental ? RENTAL_WIZARD_STEPS : BUYING_WIZARD_STEPS
+
   // Persist selections to sessionStorage so Back navigation restores them
   useEffect(() => {
     try {
@@ -119,26 +115,56 @@ function JourneyWizard(props: IProps) {
     setState((prev) => ({ ...prev, ...updates }))
   }
 
+  const handleJourneyTypeChange = (v: JourneyType) => {
+    // When switching journey type, reset step to 1 and clear type-specific fields
+    updateState({
+      journeyType: v,
+      propertyType: undefined,
+      propertyUse: undefined,
+      financingType: undefined,
+    })
+  }
+
   const canProceed = (): boolean => {
+    if (currentStep === 1) return !!state.journeyType
+
+    if (isRental) {
+      switch (currentStep) {
+        case 2:
+          return !!state.targetState
+        case 3:
+          // Budget is optional
+          if (state.budgetMin && state.budgetMax) {
+            return state.budgetMax >= state.budgetMin
+          }
+          return true
+        case 4:
+          return true // Timeline optional
+        case 5:
+          return !!state.residencyStatus
+        default:
+          return false
+      }
+    }
+
+    // Buying flow
     switch (currentStep) {
-      case 1:
-        return !!state.propertyType
       case 2:
-        return !!state.propertyUse
+        return !!state.propertyType
       case 3:
-        return !!state.targetState
+        return !!state.propertyUse
       case 4:
-        return !!state.financingType
+        return !!state.targetState
       case 5:
-        // Budget is optional, but if provided, max should be >= min
+        return !!state.financingType
+      case 6:
         if (state.budgetMin && state.budgetMax) {
           return state.budgetMax >= state.budgetMin
         }
         return true
-      case 6:
-        // Timeline is optional
-        return true
       case 7:
+        return true
+      case 8:
         return !!state.residencyStatus
       default:
         return false
@@ -146,9 +172,9 @@ function JourneyWizard(props: IProps) {
   }
 
   const handleNext = () => {
-    if (currentStep < WIZARD_STEPS.length) {
+    if (currentStep < wizardSteps.length) {
       setCurrentStep((prev) => prev + 1)
-    } else if (currentStep === WIZARD_STEPS.length && !showSummary) {
+    } else if (currentStep === wizardSteps.length && !showSummary) {
       setShowSummary(true)
     }
   }
@@ -171,33 +197,33 @@ function JourneyWizard(props: IProps) {
   }
 
   const handleSubmit = async () => {
-    if (
-      !state.propertyType ||
-      !state.targetState ||
-      !state.financingType ||
-      !state.residencyStatus
-    ) {
+    if (!state.targetState || !state.residencyStatus || !state.journeyType) {
       return
     }
 
-    // Transform wizard state to backend-compatible format
+    // Buying requires additional fields
+    if (!isRental && (!state.propertyType || !state.financingType)) {
+      return
+    }
+
     const hasGermanResidency =
       state.residencyStatus === "german_citizen" ||
       state.residencyStatus === "eu_citizen" ||
       state.residencyStatus === "non_eu_resident"
 
     const journeyData: JourneyCreate = {
-      title: "My Property Journey",
+      title: isRental ? "My Rental Journey" : "My Property Journey",
       questionnaire: {
-        property_type: state.propertyType,
+        journey_type: state.journeyType,
+        property_type: isRental ? undefined : state.propertyType,
         property_location: state.targetState,
-        financing_type: state.financingType,
-        is_first_time_buyer: true, // Default value, can be added to wizard later
+        financing_type: isRental ? undefined : state.financingType,
+        is_first_time_buyer: true,
         has_german_residency: hasGermanResidency,
         budget_euros: state.budgetMax || state.budgetMin,
         budget_min_euros: state.budgetMin,
         target_purchase_date: state.targetDate,
-        property_use: state.propertyUse,
+        property_use: isRental ? undefined : state.propertyUse,
       },
     }
 
@@ -214,16 +240,24 @@ function JourneyWizard(props: IProps) {
   // Steps with a confirmed selection — drives the green checkmark in the indicator
   const completedSteps = useMemo((): Set<number> => {
     const done = new Set<number>()
-    if (state.propertyType) done.add(1)
-    if (state.propertyUse) done.add(2)
-    if (state.targetState) done.add(3)
-    if (state.financingType) done.add(4)
-    // Budget and Timeline are optional; mark done once the user moves past them
-    if (currentStep > 5) done.add(5)
-    if (currentStep > 6) done.add(6)
-    if (state.residencyStatus) done.add(7)
+    if (state.journeyType) done.add(1)
+
+    if (isRental) {
+      if (state.targetState) done.add(2)
+      if (currentStep > 3) done.add(3) // Budget optional
+      if (currentStep > 4) done.add(4) // Timeline optional
+      if (state.residencyStatus) done.add(5)
+    } else {
+      if (state.propertyType) done.add(2)
+      if (state.propertyUse) done.add(3)
+      if (state.targetState) done.add(4)
+      if (state.financingType) done.add(5)
+      if (currentStep > 6) done.add(6) // Budget optional
+      if (currentStep > 7) done.add(7) // Timeline optional
+      if (state.residencyStatus) done.add(8)
+    }
     return done
-  }, [state, currentStep])
+  }, [state, currentStep, isRental])
 
   // Transition from generating animation to complete after 2 seconds
   useEffect(() => {
@@ -245,36 +279,84 @@ function JourneyWizard(props: IProps) {
       return <JourneySummary state={state} />
     }
 
+    // Step 1 is always journey type selection
+    if (currentStep === 1) {
+      return (
+        <JourneyTypeSelector
+          value={state.journeyType}
+          onChange={handleJourneyTypeChange}
+        />
+      )
+    }
+
+    if (isRental) {
+      switch (currentStep) {
+        case 2:
+          return (
+            <LocationSelector
+              value={state.targetState}
+              onChange={(v) => updateState({ targetState: v })}
+            />
+          )
+        case 3:
+          return (
+            <BudgetInput
+              budgetMin={state.budgetMin}
+              budgetMax={state.budgetMax}
+              onBudgetMinChange={(v) => updateState({ budgetMin: v })}
+              onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
+            />
+          )
+        case 4:
+          return (
+            <TimelineSelector
+              value={state.targetDate}
+              onChange={(v) => updateState({ targetDate: v })}
+            />
+          )
+        case 5:
+          return (
+            <ResidencySelector
+              value={state.residencyStatus}
+              onChange={(v) => updateState({ residencyStatus: v })}
+            />
+          )
+        default:
+          return null
+      }
+    }
+
+    // Buying flow
     switch (currentStep) {
-      case 1:
+      case 2:
         return (
           <PropertyTypeSelector
             value={state.propertyType}
             onChange={(v) => updateState({ propertyType: v })}
           />
         )
-      case 2:
+      case 3:
         return (
           <PropertyUseSelector
             value={state.propertyUse}
             onChange={(v) => updateState({ propertyUse: v })}
           />
         )
-      case 3:
+      case 4:
         return (
           <LocationSelector
             value={state.targetState}
             onChange={(v) => updateState({ targetState: v })}
           />
         )
-      case 4:
+      case 5:
         return (
           <FinancingSelector
             value={state.financingType}
             onChange={(v) => updateState({ financingType: v })}
           />
         )
-      case 5:
+      case 6:
         return (
           <BudgetInput
             budgetMin={state.budgetMin}
@@ -283,14 +365,14 @@ function JourneyWizard(props: IProps) {
             onBudgetMaxChange={(v) => updateState({ budgetMax: v })}
           />
         )
-      case 6:
+      case 7:
         return (
           <TimelineSelector
             value={state.targetDate}
             onChange={(v) => updateState({ targetDate: v })}
           />
         )
-      case 7:
+      case 8:
         return (
           <ResidencySelector
             value={state.residencyStatus}
@@ -313,14 +395,14 @@ function JourneyWizard(props: IProps) {
     )
   }
 
-  const isLastStep = currentStep === WIZARD_STEPS.length && !showSummary
+  const isLastStep = currentStep === wizardSteps.length && !showSummary
   const isSubmitStep = showSummary
 
   return (
     <div className={cn("space-y-8 overflow-hidden", className)}>
       <WizardStepIndicator
-        steps={WIZARD_STEPS.map((s) => ({ id: s.id, title: s.title }))}
-        currentStep={showSummary ? WIZARD_STEPS.length + 1 : currentStep}
+        steps={wizardSteps.map((s) => ({ id: s.id, title: s.title }))}
+        currentStep={showSummary ? wizardSteps.length + 1 : currentStep}
         completedSteps={completedSteps}
       />
 

--- a/frontend/src/components/Journey/StepContent/RentalApplicationGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalApplicationGuide.tsx
@@ -1,0 +1,61 @@
+/**
+ * Rental Application Guide Step Content
+ * Guidance on SCHUFA, Selbstauskunft, application documents, and cover letters
+ */
+
+import { CreditCard, FileCheck, FileText, UserCheck } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function RentalApplicationGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Essential Application Documents"
+        description="German landlords expect a complete application package. Having all documents ready gives you a significant advantage."
+        items={[
+          {
+            icon: CreditCard,
+            label: "SCHUFA Auskunft",
+            detail:
+              "Request your SCHUFA credit report at meineschufa.de. The 'SCHUFA-BonitatsAuskunft' (29.95 EUR) is specifically designed for landlords. Free annual report (Datenkopie) is also available but less accepted.",
+          },
+          {
+            icon: FileText,
+            label: "Mietschuldenfreiheitsbescheinigung",
+            detail:
+              "A confirmation from your previous landlord that you have no outstanding rent debts. If you're new to Germany, a bank statement showing regular rent payments may substitute.",
+          },
+          {
+            icon: UserCheck,
+            label: "Selbstauskunft (Self-Disclosure)",
+            detail:
+              "A standardized form with your personal and financial details. Download a template or use the one provided by the landlord. Include employment status and monthly net income.",
+          },
+          {
+            icon: FileCheck,
+            label: "Income Proof",
+            detail:
+              "Last 3 months' pay slips (Gehaltsabrechnungen) and/or employment contract. Landlords typically expect rent to be no more than 1/3 of your net income.",
+          },
+        ]}
+        tip="Write a brief, friendly cover letter introducing yourself. Mention your profession, why you're moving, and that you're a reliable tenant. A personal touch can make the difference."
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { RentalApplicationGuide }

--- a/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
@@ -1,0 +1,61 @@
+/**
+ * Rental Contract Review Step Content
+ * Guidance on Mietvertrag clauses, red flags, and tenant rights
+ */
+
+import { AlertTriangle, FileText, Scale, ShieldCheck } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function RentalContractReview(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Key Mietvertrag Clauses"
+        description="German lease agreements contain important clauses that affect your rights and obligations. Review each section carefully before signing."
+        items={[
+          {
+            icon: FileText,
+            label: "Rent & Payment Terms",
+            detail:
+              "Verify the Kaltmiete (base rent), Nebenkosten (utilities advance), total Warmmiete, payment due date, and landlord's bank details. Rent is typically due on the 3rd business day of each month.",
+          },
+          {
+            icon: AlertTriangle,
+            label: "Schonheitsreparaturen (Cosmetic Repairs)",
+            detail:
+              "Clauses requiring you to repaint or repair at set intervals are often invalid under German law (BGH rulings). Rigid renovation schedules are unenforceable — negotiate removal if present.",
+          },
+          {
+            icon: Scale,
+            label: "Rent Escalation Clauses",
+            detail:
+              "Staffelmiete (step rent) has pre-agreed increases. Indexmiete ties rent to inflation. Standard leases allow increases only up to the Mietspiegel. Know which type your lease uses.",
+          },
+          {
+            icon: ShieldCheck,
+            label: "Notice Period (Kundigungsfrist)",
+            detail:
+              "Standard tenant notice period is 3 months. Landlord notice periods increase with tenancy length (3-9 months). Minimum lease terms (Mindestmietdauer) should be checked carefully.",
+          },
+        ]}
+        tip="If anything is unclear, consider consulting a Mieterverein (tenant association) before signing. Membership costs 50-100 EUR/year and includes legal advice on lease matters."
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { RentalContractReview }

--- a/frontend/src/components/Journey/StepContent/RentalMoveInGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalMoveInGuide.tsx
@@ -1,0 +1,61 @@
+/**
+ * Rental Move-In Guide Step Content
+ * Guidance on Ubergabeprotokoll, Anmeldung, utilities, and GEZ
+ */
+
+import { ClipboardCheck, Home, MapPin, Zap } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function RentalMoveInGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Moving In Checklist"
+        description="Complete these essential steps to settle into your new apartment and meet all legal obligations."
+        items={[
+          {
+            icon: ClipboardCheck,
+            label: "Ubergabeprotokoll (Handover Protocol)",
+            detail:
+              "Walk through every room with the landlord. Document all existing defects with photos and written notes. Record meter readings for electricity, gas, and water. Both parties must sign.",
+          },
+          {
+            icon: MapPin,
+            label: "Anmeldung (Address Registration)",
+            detail:
+              "Register your new address at the Burgeramt within 14 days. You'll need the Wohnungsgeberbestatigung (landlord confirmation form) and your ID. Book an appointment online — walk-ins have long waits.",
+          },
+          {
+            icon: Zap,
+            label: "Utilities & Internet",
+            detail:
+              "Set up electricity and gas contracts (compare at Check24.de or Verivox.de). Arrange internet installation — book early as it can take 2-4 weeks. Default utility providers are often more expensive.",
+          },
+          {
+            icon: Home,
+            label: "GEZ (Rundfunkbeitrag)",
+            detail:
+              "Register at rundfunkbeitrag.de — 18.36 EUR/month per household, regardless of whether you own a TV or radio. This is mandatory for every household in Germany.",
+          },
+        ]}
+        tip="The Ubergabeprotokoll protects you from being charged for pre-existing damage when you move out. Be thorough — photograph everything, including walls, floors, and appliances."
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { RentalMoveInGuide }

--- a/frontend/src/components/Journey/StepContent/RentalSearchGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalSearchGuide.tsx
@@ -1,0 +1,61 @@
+/**
+ * Rental Search Guide Step Content
+ * Guidance on apartment search portals, requirements, and what to look for
+ */
+
+import { Globe, ListChecks, MapPin, Newspaper } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function RentalSearchGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Finding an Apartment in Germany"
+        description="The German rental market can be competitive, especially in major cities. Preparation and quick responses are key."
+        items={[
+          {
+            icon: Globe,
+            label: "Online Portals",
+            detail:
+              "ImmoScout24 and Immowelt are the main platforms. Set up alerts for new listings matching your criteria. WG-Gesucht is popular for shared apartments.",
+          },
+          {
+            icon: MapPin,
+            label: "Location Research",
+            detail:
+              "Research neighborhoods by commute time, amenities, and safety. Rent varies significantly between city districts — check the local Mietspiegel for fair prices.",
+          },
+          {
+            icon: Newspaper,
+            label: "Local Networks",
+            detail:
+              "Check local newspaper classifieds, Facebook groups, and community bulletin boards. Some landlords don't advertise online.",
+          },
+          {
+            icon: ListChecks,
+            label: "Requirements Checklist",
+            detail:
+              "Know your budget (Kaltmiete + Nebenkosten), minimum size, preferred room count, and must-have features before you start searching.",
+          },
+        ]}
+        tip="In competitive markets like Berlin or Munich, respond to listings within hours and have your application documents ready to send immediately."
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { RentalSearchGuide }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -24,9 +24,13 @@ import { OwnershipRegistration } from "./OwnershipRegistration"
 import { OwnershipTaxFinance } from "./OwnershipTaxFinance"
 import { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
 import { PropertyGoalsForm } from "./PropertyGoalsForm"
+import { RentalApplicationGuide } from "./RentalApplicationGuide"
+import { RentalContractReview } from "./RentalContractReview"
 import { RentalLandlordLaw } from "./RentalLandlordLaw"
+import { RentalMoveInGuide } from "./RentalMoveInGuide"
 import { RentalOperationsSetup } from "./RentalOperationsSetup"
 import { RentalPropertyManagement } from "./RentalPropertyManagement"
+import { RentalSearchGuide } from "./RentalSearchGuide"
 import { RentalTaxStrategy } from "./RentalTaxStrategy"
 import { RentalYieldAnalysis } from "./RentalYieldAnalysis"
 import { StepDocumentReview } from "./StepDocumentReview"
@@ -85,6 +89,10 @@ const STEP_CONTENT_REGISTRY: Record<
   ownership_insurance: (p) => <OwnershipInsurance step={p.step} />,
   ownership_management: (p) => <OwnershipManagement step={p.step} />,
   ownership_tax_finance: (p) => <OwnershipTaxFinance step={p.step} />,
+  rental_search_requirements: (p) => <RentalSearchGuide step={p.step} />,
+  rental_application_documents: (p) => <RentalApplicationGuide step={p.step} />,
+  rental_contract_review: (p) => <RentalContractReview step={p.step} />,
+  rental_move_in_checklist: (p) => <RentalMoveInGuide step={p.step} />,
 }
 
 /******************************************************************************

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -39,6 +39,10 @@ function StepTabView(props: IProps) {
     closing: [],
     ownership: [],
     rental_setup: [],
+    rental_search: [],
+    rental_application: [],
+    rental_contract: [],
+    rental_move_in: [],
   }
   for (const step of steps) {
     stepsByPhase[step.phase].push(step)

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -4,6 +4,8 @@
  * Note: Uses snake_case to match backend API response
  */
 
+export type JourneyType = "buying" | "rental"
+
 export type JourneyPhase =
   | "research"
   | "preparation"
@@ -11,6 +13,10 @@ export type JourneyPhase =
   | "closing"
   | "ownership"
   | "rental_setup"
+  | "rental_search"
+  | "rental_application"
+  | "rental_contract"
+  | "rental_move_in"
 
 export type StepStatus = "not_started" | "in_progress" | "completed" | "skipped"
 
@@ -59,6 +65,7 @@ export interface JourneyStep {
 
 export interface JourneyPublic {
   id: string
+  journey_type?: JourneyType
   title: string
   current_phase: JourneyPhase
   current_step_number: number
@@ -95,9 +102,10 @@ export interface JourneyWizardData {
 
 /** Backend-compatible questionnaire answers */
 export interface QuestionnaireAnswers {
-  property_type: PropertyType
+  journey_type?: JourneyType
+  property_type?: PropertyType
   property_location: string
-  financing_type: FinancingType
+  financing_type?: FinancingType
   is_first_time_buyer: boolean
   has_german_residency: boolean
   budget_euros?: number


### PR DESCRIPTION
## Summary
- Adds a tenant-focused rental journey type alongside the existing property buying journey
- Guides users through 14 steps across 4 new phases: Apartment Search, Application, Lease Review, and Move-In
- Dynamic wizard branches based on journey type — rental path has a streamlined 5-step wizard (vs 8 for buying)

## Changes

### Backend
- **Model**: Added `JourneyType` enum (`buying`/`rental`) and `journey_type` column on `Journey`
- **Phases**: Added 4 rental-specific `JourneyPhase` values: `rental_search`, `rental_application`, `rental_contract`, `rental_move_in`
- **Migration**: Alembic migration creates `journeytype` enum, adds column, extends `journeyphase` enum
- **Service**: Added `RENTAL_STEP_TEMPLATES` (14 steps) and updated `generate_journey()` to branch on journey type
- **Schema**: Made `property_type` and `financing_type` optional in `QuestionnaireAnswers` for rental journeys
- **API**: `_build_journey_response()` now includes `journey_type` field

### Frontend
- **JourneyTypeSelector**: New Step 1 component — two cards: "Buy Property" / "Rent Apartment"
- **JourneyWizard**: Dynamic step list based on journey type (buying: 8 steps, rental: 5 steps)
- **JourneySummary**: Conditionally shows buying-specific fields (property type, purpose, financing)
- **Step Content**: 4 new GuidanceCard components registered in `StepBody`:
  - `RentalSearchGuide` — portals, location research, requirements
  - `RentalApplicationGuide` — SCHUFA, Selbstauskunft, income proof
  - `RentalContractReview` — Mietvertrag clauses, red flags, Schonheitsreparaturen
  - `RentalMoveInGuide` — Ubergabeprotokoll, Anmeldung, utilities, GEZ
- **Phase colors**: Added distinct colors for rental phases (indigo, cyan, rose, emerald)
- Updated `JourneyGenerating`, `StepTabView`, `JourneyRingChart` for new phases

### Tests
- 19 new unit tests covering template structure, generation logic, and buying regression

## Test plan
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] All 19 new rental journey tests pass
- [ ] All 108 existing journey service tests pass (no regression)
- [ ] Pre-commit hooks pass
- [ ] Create a **buying** journey — verify existing flow unchanged
- [ ] Create a **rental** journey — verify 5-step wizard and 14 generated steps with correct phases
- [ ] Verify rental step content renders GuidanceCard components
- [ ] Verify phase indicators show rental phases with correct colors