### PR TITLE
feat(professionals): add admin CRUD endpoints and journey step CTAs

### DIFF
--- a/backend/app/api/routes/professionals.py
+++ b/backend/app/api/routes/professionals.py
@@ -3,17 +3,22 @@
 import uuid
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from app.api.deps import CurrentUser, SessionDep
+from app.api.deps import CurrentUser, SessionDep, get_current_active_superuser
+from app.models import User
 from app.schemas.professional import (
+    ProfessionalCreateRequest,
     ProfessionalDetailResponse,
     ProfessionalListResponse,
     ProfessionalResponse,
+    ProfessionalUpdateRequest,
     ReviewCreateRequest,
     ReviewResponse,
 )
 from app.services import professional_service
+
+SuperUser = Annotated[User, Depends(get_current_active_superuser)]
 
 router = APIRouter(prefix="/professionals", tags=["professionals"])
 
@@ -132,3 +137,83 @@ async def create_review(
         )
 
     return ReviewResponse.model_validate(review)
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints (superuser only)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_professional(
+    request: ProfessionalCreateRequest,
+    session: SessionDep,
+    _current_user: SuperUser,
+) -> ProfessionalResponse:
+    """Create a new professional (admin only)."""
+    professional = professional_service.create_professional(
+        session, request.model_dump()
+    )
+    return ProfessionalResponse.model_validate(professional)
+
+
+@router.put("/{professional_id}")
+async def update_professional(
+    professional_id: uuid.UUID,
+    request: ProfessionalUpdateRequest,
+    session: SessionDep,
+    _current_user: SuperUser,
+) -> ProfessionalResponse:
+    """Update a professional (admin only)."""
+    try:
+        professional = professional_service.update_professional(
+            session,
+            professional_id,
+            request.model_dump(exclude_unset=True),
+        )
+    except professional_service.ProfessionalNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Professional {professional_id} not found",
+        )
+    return ProfessionalResponse.model_validate(professional)
+
+
+@router.delete("/{professional_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_professional(
+    professional_id: uuid.UUID,
+    session: SessionDep,
+    _current_user: SuperUser,
+) -> None:
+    """Delete a professional (admin only)."""
+    try:
+        professional_service.delete_professional(session, professional_id)
+    except professional_service.ProfessionalNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Professional {professional_id} not found",
+        )
+
+
+@router.patch("/{professional_id}/verify")
+async def toggle_verify_professional(
+    professional_id: uuid.UUID,
+    session: SessionDep,
+    _current_user: SuperUser,
+) -> ProfessionalResponse:
+    """Toggle is_verified for a professional (admin only)."""
+    try:
+        professional = professional_service.get_professional_by_id(
+            session, professional_id
+        )
+    except professional_service.ProfessionalNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Professional {professional_id} not found",
+        )
+    professional = professional_service.update_professional(
+        session,
+        professional_id,
+        {"is_verified": not professional.is_verified},
+    )
+    return ProfessionalResponse.model_validate(professional)

--- a/backend/app/schemas/professional.py
+++ b/backend/app/schemas/professional.py
@@ -7,6 +7,37 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.professional import ProfessionalType, ServiceType
 
+# --- Admin Requests ---
+
+
+class ProfessionalCreateRequest(BaseModel):
+    """Request schema for creating a professional (admin only)."""
+
+    name: str = Field(..., max_length=255)
+    type: ProfessionalType
+    city: str = Field(..., max_length=255)
+    languages: str = Field(..., max_length=500)
+    description: str | None = None
+    email: str | None = Field(None, max_length=255)
+    phone: str | None = Field(None, max_length=50)
+    website: str | None = Field(None, max_length=500)
+    is_verified: bool = False
+
+
+class ProfessionalUpdateRequest(BaseModel):
+    """Request schema for updating a professional (admin only). All fields optional."""
+
+    name: str | None = Field(None, max_length=255)
+    type: ProfessionalType | None = None
+    city: str | None = Field(None, max_length=255)
+    languages: str | None = Field(None, max_length=500)
+    description: str | None = None
+    email: str | None = Field(None, max_length=255)
+    phone: str | None = Field(None, max_length=50)
+    website: str | None = Field(None, max_length=500)
+    is_verified: bool | None = None
+
+
 # --- Professional Response ---
 
 

--- a/backend/app/services/professional_service.py
+++ b/backend/app/services/professional_service.py
@@ -235,6 +235,37 @@ def recompute_professional_stats(session: Session, professional_id: uuid.UUID) -
     _update_trust_signals(session, professional_id)
 
 
+def create_professional(session: Session, data: dict) -> Professional:
+    """Create a new professional (admin)."""
+    professional = Professional(**data)
+    session.add(professional)
+    session.commit()
+    session.refresh(professional)
+    return professional
+
+
+def update_professional(
+    session: Session, professional_id: uuid.UUID, data: dict
+) -> Professional:
+    """Update a professional (admin). Supports partial update."""
+    professional = get_professional_by_id(session, professional_id)
+
+    for key, value in data.items():
+        setattr(professional, key, value)
+
+    session.add(professional)
+    session.commit()
+    session.refresh(professional)
+    return professional
+
+
+def delete_professional(session: Session, professional_id: uuid.UUID) -> None:
+    """Delete a professional and cascade reviews (admin)."""
+    professional = get_professional_by_id(session, professional_id)
+    session.delete(professional)
+    session.commit()
+
+
 def get_available_cities(session: Session) -> list[str]:
     """Get distinct cities that have professionals."""
     query = select(Professional.city).distinct().order_by(Professional.city)

--- a/backend/tests/api/routes/test_professionals.py
+++ b/backend/tests/api/routes/test_professionals.py
@@ -512,3 +512,171 @@ def test_language_filter_escapes_wildcards(client: TestClient, db: Session) -> N
     assert r.status_code == 200
     data = r.json()
     assert data["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_professional_requires_superuser(
+    client: TestClient, db: Session
+) -> None:
+    """Test that creating a professional requires superuser privileges."""
+    headers, _ = get_auth_headers(client, db)
+
+    r = client.post(
+        f"{settings.API_V1_STR}/professionals/",
+        json={
+            "name": "Test Lawyer",
+            "type": "lawyer",
+            "city": "Berlin",
+            "languages": "German",
+        },
+        headers=headers,
+    )
+
+    assert r.status_code == 403
+
+
+def test_create_professional_as_superuser(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test creating a professional as superuser returns 201 with correct data."""
+    r = client.post(
+        f"{settings.API_V1_STR}/professionals/",
+        json={
+            "name": "Notary Weber",
+            "type": "notary",
+            "city": "Hamburg",
+            "languages": "German, English",
+            "email": "weber@notary.de",
+            "is_verified": True,
+        },
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 201
+    data = r.json()
+    assert data["name"] == "Notary Weber"
+    assert data["type"] == "notary"
+    assert data["city"] == "Hamburg"
+    assert data["is_verified"] is True
+    assert "id" in data
+
+
+def test_update_professional_requires_superuser(
+    client: TestClient, db: Session
+) -> None:
+    """Test that updating a professional requires superuser privileges."""
+    professional = create_sample_professional(db)
+    headers, _ = get_auth_headers(client, db)
+
+    r = client.put(
+        f"{settings.API_V1_STR}/professionals/{professional.id}",
+        json={"name": "Updated Name"},
+        headers=headers,
+    )
+
+    assert r.status_code == 403
+
+
+def test_update_professional_as_superuser(
+    client: TestClient, db: Session, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test updating a professional as superuser performs partial update."""
+    professional = create_sample_professional(db, name="Original Name", city="Berlin")
+
+    r = client.put(
+        f"{settings.API_V1_STR}/professionals/{professional.id}",
+        json={"name": "Updated Name"},
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["name"] == "Updated Name"
+    assert data["city"] == "Berlin"
+
+
+def test_update_professional_not_found(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test updating a non-existent professional returns 404."""
+    r = client.put(
+        f"{settings.API_V1_STR}/professionals/{uuid.uuid4()}",
+        json={"name": "Ghost"},
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 404
+
+
+def test_delete_professional_requires_superuser(
+    client: TestClient, db: Session
+) -> None:
+    """Test that deleting a professional requires superuser privileges."""
+    professional = create_sample_professional(db)
+    headers, _ = get_auth_headers(client, db)
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/professionals/{professional.id}",
+        headers=headers,
+    )
+
+    assert r.status_code == 403
+
+
+def test_delete_professional_as_superuser(
+    client: TestClient, db: Session, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test deleting a professional as superuser returns 204."""
+    professional = create_sample_professional(db)
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/professionals/{professional.id}",
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 204
+
+
+def test_delete_professional_not_found(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test deleting a non-existent professional returns 404."""
+    r = client.delete(
+        f"{settings.API_V1_STR}/professionals/{uuid.uuid4()}",
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 404
+
+
+def test_toggle_verify_professional_as_superuser(
+    client: TestClient, db: Session, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test toggling is_verified for a professional as superuser."""
+    professional = create_sample_professional(db)
+    original_verified = professional.is_verified
+
+    r = client.patch(
+        f"{settings.API_V1_STR}/professionals/{professional.id}/verify",
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["is_verified"] is not original_verified
+
+
+def test_toggle_verify_professional_not_found(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    """Test toggling verify for a non-existent professional returns 404."""
+    r = client.patch(
+        f"{settings.API_V1_STR}/professionals/{uuid.uuid4()}/verify",
+        headers=superuser_token_headers,
+    )
+
+    assert r.status_code == 404

--- a/backend/tests/services/test_professional_service.py
+++ b/backend/tests/services/test_professional_service.py
@@ -1,0 +1,138 @@
+"""Tests for the Professional Service admin functions."""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.professional import Professional, ProfessionalType
+from app.services.professional_service import (
+    ProfessionalNotFoundError,
+    create_professional,
+    delete_professional,
+    update_professional,
+)
+
+
+def _make_professional(**overrides: object) -> MagicMock:
+    """Create a mock Professional with default test values."""
+    defaults: dict[str, object] = {
+        "id": uuid.uuid4(),
+        "name": "Test Lawyer",
+        "type": ProfessionalType.LAWYER.value,
+        "city": "Berlin",
+        "languages": "German, English",
+        "description": "Test description",
+        "email": "test@example.de",
+        "phone": None,
+        "website": None,
+        "is_verified": False,
+        "average_rating": 0.0,
+        "review_count": 0,
+        "recommendation_rate": None,
+        "review_highlights": None,
+    }
+    defaults.update(overrides)
+    mock = MagicMock(spec=Professional)
+    for key, value in defaults.items():
+        setattr(mock, key, value)
+    return mock
+
+
+class TestCreateProfessional:
+    """Tests for create_professional."""
+
+    def test_create_professional(self) -> None:
+        """Creating a professional adds it to the session and commits."""
+        session = MagicMock(spec=["add", "commit", "refresh"])
+        data = {
+            "name": "Dr. Mueller",
+            "type": ProfessionalType.LAWYER.value,
+            "city": "Munich",
+            "languages": "German, English",
+            "is_verified": False,
+        }
+
+        result = create_professional(session, data)
+
+        session.add.assert_called_once()
+        session.commit.assert_called_once()
+        session.refresh.assert_called_once_with(result)
+        assert result.name == "Dr. Mueller"
+        assert result.city == "Munich"
+
+    def test_create_professional_with_optional_fields(self) -> None:
+        """Creating a professional with all optional fields populated."""
+        session = MagicMock(spec=["add", "commit", "refresh"])
+        data = {
+            "name": "Steuerberater Schmidt",
+            "type": ProfessionalType.TAX_ADVISOR.value,
+            "city": "Frankfurt",
+            "languages": "German",
+            "description": "Experienced tax advisor",
+            "email": "schmidt@tax.de",
+            "phone": "+49 69 123456",
+            "website": "https://schmidt-tax.de",
+            "is_verified": True,
+        }
+
+        result = create_professional(session, data)
+
+        assert result.email == "schmidt@tax.de"
+        assert result.phone == "+49 69 123456"
+        assert result.website == "https://schmidt-tax.de"
+
+
+class TestUpdateProfessional:
+    """Tests for update_professional."""
+
+    def test_update_professional(self) -> None:
+        """Partial update sets only the provided fields."""
+        professional = _make_professional(name="Old Name", city="Berlin")
+        session = MagicMock(spec=["execute", "add", "commit", "refresh"])
+        scalars_mock = MagicMock()
+        scalars_mock.first.return_value = professional
+        session.execute.return_value.scalars.return_value = scalars_mock
+
+        result = update_professional(session, professional.id, {"name": "New Name"})
+
+        assert result.name == "New Name"
+        assert result.city == "Berlin"
+        session.commit.assert_called_once()
+
+    def test_update_professional_not_found(self) -> None:
+        """Updating a non-existent professional raises ProfessionalNotFoundError."""
+        session = MagicMock(spec=["execute"])
+        scalars_mock = MagicMock()
+        scalars_mock.first.return_value = None
+        session.execute.return_value.scalars.return_value = scalars_mock
+
+        with pytest.raises(ProfessionalNotFoundError):
+            update_professional(session, uuid.uuid4(), {"name": "X"})
+
+
+class TestDeleteProfessional:
+    """Tests for delete_professional."""
+
+    def test_delete_professional(self) -> None:
+        """Deleting a professional removes it and commits."""
+        professional = _make_professional()
+        session = MagicMock(spec=["execute", "delete", "commit"])
+        scalars_mock = MagicMock()
+        scalars_mock.first.return_value = professional
+        session.execute.return_value.scalars.return_value = scalars_mock
+
+        delete_professional(session, professional.id)
+
+        session.delete.assert_called_once_with(professional)
+        session.commit.assert_called_once()
+
+    def test_delete_professional_not_found(self) -> None:
+        """Deleting a non-existent professional raises ProfessionalNotFoundError."""
+        session = MagicMock(spec=["execute"])
+        scalars_mock = MagicMock()
+        scalars_mock.first.return_value = None
+        session.execute.return_value.scalars.return_value = scalars_mock
+
+        with pytest.raises(ProfessionalNotFoundError):
+            delete_professional(session, uuid.uuid4())

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5887,6 +5887,85 @@ export const PrivateUserCreateSchema = {
     title: 'PrivateUserCreate'
 } as const;
 
+export const ProfessionalCreateRequestSchema = {
+    properties: {
+        name: {
+            type: 'string',
+            maxLength: 255,
+            title: 'Name'
+        },
+        type: {
+            '$ref': '#/components/schemas/ProfessionalType'
+        },
+        city: {
+            type: 'string',
+            maxLength: 255,
+            title: 'City'
+        },
+        languages: {
+            type: 'string',
+            maxLength: 500,
+            title: 'Languages'
+        },
+        description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Description'
+        },
+        email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
+        },
+        phone: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 50
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Phone'
+        },
+        website: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 500
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Website'
+        },
+        is_verified: {
+            type: 'boolean',
+            title: 'Is Verified',
+            default: false
+        }
+    },
+    type: 'object',
+    required: ['name', 'type', 'city', 'languages'],
+    title: 'ProfessionalCreateRequest',
+    description: 'Request schema for creating a professional (admin only).'
+} as const;
+
 export const ProfessionalDetailResponseSchema = {
     properties: {
         id: {
@@ -6158,6 +6237,118 @@ export const ProfessionalTypeSchema = {
     enum: ['lawyer', 'notary', 'tax_advisor', 'mortgage_broker', 'real_estate_agent'],
     title: 'ProfessionalType',
     description: 'Types of professionals in the directory.'
+} as const;
+
+export const ProfessionalUpdateRequestSchema = {
+    properties: {
+        name: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Name'
+        },
+        type: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/ProfessionalType'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        },
+        city: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'City'
+        },
+        languages: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 500
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Languages'
+        },
+        description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Description'
+        },
+        email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
+        },
+        phone: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 50
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Phone'
+        },
+        website: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 500
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Website'
+        },
+        is_verified: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Is Verified'
+        }
+    },
+    type: 'object',
+    title: 'ProfessionalUpdateRequest',
+    description: 'Request schema for updating a professional (admin only). All fields optional.'
 } as const;
 
 export const ProjectionYearSchema = {

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { ArticlesListArticlesData, ArticlesListArticlesResponse, ArticlesCreateArticleData, ArticlesCreateArticleResponse, ArticlesSearchArticlesData, ArticlesSearchArticlesResponse, ArticlesGetCategoriesResponse, ArticlesGetArticleData, ArticlesGetArticleResponse, ArticlesRateArticleData, ArticlesRateArticleResponse, ArticlesUpdateArticleData, ArticlesUpdateArticleResponse, ArticlesDeleteArticleData, ArticlesDeleteArticleResponse, AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, AuthForgotPasswordData, AuthForgotPasswordResponse, AuthResetPasswordData, AuthResetPasswordResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, CalculatorsGetSharedPropertyEvaluationData, CalculatorsGetSharedPropertyEvaluationResponse, CalculatorsListStepPropertyEvaluationsData, CalculatorsListStepPropertyEvaluationsResponse, CalculatorsCalculatePropertyEvaluationData, CalculatorsCalculatePropertyEvaluationResponse, CalculatorsListPropertyEvaluationsResponse, CalculatorsSavePropertyEvaluationData, CalculatorsSavePropertyEvaluationResponse, CalculatorsGetPropertyEvaluationData, CalculatorsGetPropertyEvaluationResponse, CalculatorsDeletePropertyEvaluationData, CalculatorsDeletePropertyEvaluationResponse, CalculatorsCalculateOwnershipComparisonData, CalculatorsCalculateOwnershipComparisonResponse, CalculatorsGetSharedOwnershipComparisonData, CalculatorsGetSharedOwnershipComparisonResponse, CalculatorsListOwnershipComparisonsResponse, CalculatorsSaveOwnershipComparisonData, CalculatorsSaveOwnershipComparisonResponse, CalculatorsGetOwnershipComparisonData, CalculatorsGetOwnershipComparisonResponse, CalculatorsDeleteOwnershipComparisonData, CalculatorsDeleteOwnershipComparisonResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsGetUsageResponse, DocumentsGetSharedDocumentData, DocumentsGetSharedDocumentResponse, DocumentsGetDocumentsByStepData, DocumentsGetDocumentsByStepResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsDeleteDocumentData, DocumentsDeleteDocumentResponse, DocumentsShareDocumentData, DocumentsShareDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FeedbackSubmitFeedbackData, FeedbackSubmitFeedbackResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, GlossaryListTermsData, GlossaryListTermsResponse, GlossarySearchGlossaryData, GlossarySearchGlossaryResponse, GlossaryListCategoriesResponse, GlossaryGetTermData, GlossaryGetTermResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, MarketGetRentEstimateData, MarketGetRentEstimateResponse, MarketListAreasResponse, MarketCompareAreasData, MarketCompareAreasResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, NotificationsUnsubscribeData, NotificationsUnsubscribeResponse, PortfolioListPropertiesResponse, PortfolioCreatePropertyData, PortfolioCreatePropertyResponse, PortfolioCreatePropertyFromJourneyData, PortfolioCreatePropertyFromJourneyResponse, PortfolioGetPropertyData, PortfolioGetPropertyResponse, PortfolioUpdatePropertyData, PortfolioUpdatePropertyResponse, PortfolioDeletePropertyData, PortfolioDeletePropertyResponse, PortfolioCreateTransactionData, PortfolioCreateTransactionResponse, PortfolioListTransactionsData, PortfolioListTransactionsResponse, PortfolioDeleteTransactionData, PortfolioDeleteTransactionResponse, PortfolioGetCostSummaryData, PortfolioGetCostSummaryResponse, PortfolioGetPortfolioPerformanceResponse, PortfolioGetPortfolioSummaryResponse, PrivateCreateUserData, PrivateCreateUserResponse, ProfessionalsGetFilterOptionsResponse, ProfessionalsListProfessionalsData, ProfessionalsListProfessionalsResponse, ProfessionalsGetProfessionalData, ProfessionalsGetProfessionalResponse, ProfessionalsCreateReviewData, ProfessionalsCreateReviewResponse, SearchSearchData, SearchSearchResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersUploadAvatarData, UsersUploadAvatarResponse, UsersDeleteAvatarResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
+import type { ArticlesListArticlesData, ArticlesListArticlesResponse, ArticlesCreateArticleData, ArticlesCreateArticleResponse, ArticlesSearchArticlesData, ArticlesSearchArticlesResponse, ArticlesGetCategoriesResponse, ArticlesGetArticleData, ArticlesGetArticleResponse, ArticlesRateArticleData, ArticlesRateArticleResponse, ArticlesUpdateArticleData, ArticlesUpdateArticleResponse, ArticlesDeleteArticleData, ArticlesDeleteArticleResponse, AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, AuthForgotPasswordData, AuthForgotPasswordResponse, AuthResetPasswordData, AuthResetPasswordResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, CalculatorsGetSharedPropertyEvaluationData, CalculatorsGetSharedPropertyEvaluationResponse, CalculatorsListStepPropertyEvaluationsData, CalculatorsListStepPropertyEvaluationsResponse, CalculatorsCalculatePropertyEvaluationData, CalculatorsCalculatePropertyEvaluationResponse, CalculatorsListPropertyEvaluationsResponse, CalculatorsSavePropertyEvaluationData, CalculatorsSavePropertyEvaluationResponse, CalculatorsGetPropertyEvaluationData, CalculatorsGetPropertyEvaluationResponse, CalculatorsDeletePropertyEvaluationData, CalculatorsDeletePropertyEvaluationResponse, CalculatorsCalculateOwnershipComparisonData, CalculatorsCalculateOwnershipComparisonResponse, CalculatorsGetSharedOwnershipComparisonData, CalculatorsGetSharedOwnershipComparisonResponse, CalculatorsListOwnershipComparisonsResponse, CalculatorsSaveOwnershipComparisonData, CalculatorsSaveOwnershipComparisonResponse, CalculatorsGetOwnershipComparisonData, CalculatorsGetOwnershipComparisonResponse, CalculatorsDeleteOwnershipComparisonData, CalculatorsDeleteOwnershipComparisonResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsGetUsageResponse, DocumentsGetSharedDocumentData, DocumentsGetSharedDocumentResponse, DocumentsGetDocumentsByStepData, DocumentsGetDocumentsByStepResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsDeleteDocumentData, DocumentsDeleteDocumentResponse, DocumentsShareDocumentData, DocumentsShareDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FeedbackSubmitFeedbackData, FeedbackSubmitFeedbackResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, GlossaryListTermsData, GlossaryListTermsResponse, GlossarySearchGlossaryData, GlossarySearchGlossaryResponse, GlossaryListCategoriesResponse, GlossaryGetTermData, GlossaryGetTermResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, MarketGetRentEstimateData, MarketGetRentEstimateResponse, MarketListAreasResponse, MarketCompareAreasData, MarketCompareAreasResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, NotificationsUnsubscribeData, NotificationsUnsubscribeResponse, PortfolioListPropertiesResponse, PortfolioCreatePropertyData, PortfolioCreatePropertyResponse, PortfolioCreatePropertyFromJourneyData, PortfolioCreatePropertyFromJourneyResponse, PortfolioGetPropertyData, PortfolioGetPropertyResponse, PortfolioUpdatePropertyData, PortfolioUpdatePropertyResponse, PortfolioDeletePropertyData, PortfolioDeletePropertyResponse, PortfolioCreateTransactionData, PortfolioCreateTransactionResponse, PortfolioListTransactionsData, PortfolioListTransactionsResponse, PortfolioDeleteTransactionData, PortfolioDeleteTransactionResponse, PortfolioGetCostSummaryData, PortfolioGetCostSummaryResponse, PortfolioGetPortfolioPerformanceResponse, PortfolioGetPortfolioSummaryResponse, PrivateCreateUserData, PrivateCreateUserResponse, ProfessionalsGetFilterOptionsResponse, ProfessionalsListProfessionalsData, ProfessionalsListProfessionalsResponse, ProfessionalsCreateProfessionalData, ProfessionalsCreateProfessionalResponse, ProfessionalsGetProfessionalData, ProfessionalsGetProfessionalResponse, ProfessionalsUpdateProfessionalData, ProfessionalsUpdateProfessionalResponse, ProfessionalsDeleteProfessionalData, ProfessionalsDeleteProfessionalResponse, ProfessionalsCreateReviewData, ProfessionalsCreateReviewResponse, ProfessionalsToggleVerifyProfessionalData, ProfessionalsToggleVerifyProfessionalResponse, SearchSearchData, SearchSearchResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersUploadAvatarData, UsersUploadAvatarResponse, UsersDeleteAvatarResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
 
 export class ArticlesService {
     /**
@@ -2484,6 +2484,26 @@ export class ProfessionalsService {
     }
     
     /**
+     * Create Professional
+     * Create a new professional (admin only).
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns ProfessionalResponse Successful Response
+     * @throws ApiError
+     */
+    public static createProfessional(data: ProfessionalsCreateProfessionalData): CancelablePromise<ProfessionalsCreateProfessionalResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/professionals/',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
      * Get Professional
      * Get professional detail with reviews.
      * @param data The data for the request.
@@ -2494,6 +2514,51 @@ export class ProfessionalsService {
     public static getProfessional(data: ProfessionalsGetProfessionalData): CancelablePromise<ProfessionalsGetProfessionalResponse> {
         return __request(OpenAPI, {
             method: 'GET',
+            url: '/api/v1/professionals/{professional_id}',
+            path: {
+                professional_id: data.professionalId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Update Professional
+     * Update a professional (admin only).
+     * @param data The data for the request.
+     * @param data.professionalId
+     * @param data.requestBody
+     * @returns ProfessionalResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateProfessional(data: ProfessionalsUpdateProfessionalData): CancelablePromise<ProfessionalsUpdateProfessionalResponse> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/v1/professionals/{professional_id}',
+            path: {
+                professional_id: data.professionalId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Delete Professional
+     * Delete a professional (admin only).
+     * @param data The data for the request.
+     * @param data.professionalId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static deleteProfessional(data: ProfessionalsDeleteProfessionalData): CancelablePromise<ProfessionalsDeleteProfessionalResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
             url: '/api/v1/professionals/{professional_id}',
             path: {
                 professional_id: data.professionalId
@@ -2522,6 +2587,27 @@ export class ProfessionalsService {
             },
             body: data.requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Toggle Verify Professional
+     * Toggle is_verified for a professional (admin only).
+     * @param data The data for the request.
+     * @param data.professionalId
+     * @returns ProfessionalResponse Successful Response
+     * @throws ApiError
+     */
+    public static toggleVerifyProfessional(data: ProfessionalsToggleVerifyProfessionalData): CancelablePromise<ProfessionalsToggleVerifyProfessionalResponse> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/v1/professionals/{professional_id}/verify',
+            path: {
+                professional_id: data.professionalId
+            },
             errors: {
                 422: 'Validation Error'
             }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1651,6 +1651,21 @@ export type PrivateUserCreate = {
 };
 
 /**
+ * Request schema for creating a professional (admin only).
+ */
+export type ProfessionalCreateRequest = {
+    name: string;
+    type: ProfessionalType;
+    city: string;
+    languages: string;
+    description?: (string | null);
+    email?: (string | null);
+    phone?: (string | null);
+    website?: (string | null);
+    is_verified?: boolean;
+};
+
+/**
  * Professional detail with reviews.
  */
 export type ProfessionalDetailResponse = {
@@ -1712,6 +1727,21 @@ export type ProfessionalResponse = {
  * Types of professionals in the directory.
  */
 export type ProfessionalType = 'lawyer' | 'notary' | 'tax_advisor' | 'mortgage_broker' | 'real_estate_agent';
+
+/**
+ * Request schema for updating a professional (admin only). All fields optional.
+ */
+export type ProfessionalUpdateRequest = {
+    name?: (string | null);
+    type?: (ProfessionalType | null);
+    city?: (string | null);
+    languages?: (string | null);
+    description?: (string | null);
+    email?: (string | null);
+    phone?: (string | null);
+    website?: (string | null);
+    is_verified?: (boolean | null);
+};
 
 /**
  * Single year projection data.
@@ -3211,11 +3241,30 @@ export type ProfessionalsListProfessionalsData = {
 
 export type ProfessionalsListProfessionalsResponse = (ProfessionalListResponse);
 
+export type ProfessionalsCreateProfessionalData = {
+    requestBody: ProfessionalCreateRequest;
+};
+
+export type ProfessionalsCreateProfessionalResponse = (ProfessionalResponse);
+
 export type ProfessionalsGetProfessionalData = {
     professionalId: string;
 };
 
 export type ProfessionalsGetProfessionalResponse = (ProfessionalDetailResponse);
+
+export type ProfessionalsUpdateProfessionalData = {
+    professionalId: string;
+    requestBody: ProfessionalUpdateRequest;
+};
+
+export type ProfessionalsUpdateProfessionalResponse = (ProfessionalResponse);
+
+export type ProfessionalsDeleteProfessionalData = {
+    professionalId: string;
+};
+
+export type ProfessionalsDeleteProfessionalResponse = (void);
 
 export type ProfessionalsCreateReviewData = {
     professionalId: string;
@@ -3223,6 +3272,12 @@ export type ProfessionalsCreateReviewData = {
 };
 
 export type ProfessionalsCreateReviewResponse = (ReviewResponse);
+
+export type ProfessionalsToggleVerifyProfessionalData = {
+    professionalId: string;
+};
+
+export type ProfessionalsToggleVerifyProfessionalResponse = (ProfessionalResponse);
 
 export type SearchSearchData = {
     /**

--- a/frontend/src/components/Journey/StepContent/GuidanceCard.tsx
+++ b/frontend/src/components/Journey/StepContent/GuidanceCard.tsx
@@ -3,8 +3,9 @@
  * Reusable informational card for journey step content
  */
 
+import { Link } from "@tanstack/react-router"
 import type { LucideIcon } from "lucide-react"
-import { Lightbulb } from "lucide-react"
+import { ArrowRight, Lightbulb } from "lucide-react"
 
 import {
   Card,
@@ -25,6 +26,8 @@ interface IProps {
   description: string
   items: IGuidanceItem[]
   tip?: string
+  ctaLabel?: string
+  ctaHref?: string
 }
 
 /******************************************************************************
@@ -32,7 +35,7 @@ interface IProps {
 ******************************************************************************/
 
 function GuidanceCard(props: Readonly<IProps>) {
-  const { title, description, items, tip } = props
+  const { title, description, items, tip, ctaLabel, ctaHref } = props
 
   return (
     <Card>
@@ -55,6 +58,15 @@ function GuidanceCard(props: Readonly<IProps>) {
             <Lightbulb className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
             <p className="text-xs text-amber-800 dark:text-amber-200">{tip}</p>
           </div>
+        )}
+        {ctaLabel && ctaHref && (
+          <Link
+            to={ctaHref}
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+          >
+            {ctaLabel}
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/components/Journey/StepContent/OwnershipRegistration.tsx
+++ b/frontend/src/components/Journey/StepContent/OwnershipRegistration.tsx
@@ -37,6 +37,8 @@ function OwnershipRegistration(_props: Readonly<IProps>) {
           },
         ]}
         tip="Keep your Grundbuchauszug (land registry extract) in a safe place — you'll need it for insurance, tax, and any future sale."
+        ctaLabel="Find a Notary"
+        ctaHref="/professionals?type=notary"
       />
       <GuidanceCard
         title="Registrations & Utilities"

--- a/frontend/src/components/Journey/StepContent/OwnershipTaxFinance.tsx
+++ b/frontend/src/components/Journey/StepContent/OwnershipTaxFinance.tsx
@@ -49,6 +49,8 @@ function OwnershipTaxFinance(_props: Readonly<IProps>) {
           },
         ]}
         tip="Since the 2025 Grundsteuer reform, tax assessments are based on new property valuations. Check your Grundsteuerwertbescheid for accuracy and file an objection (Einspruch) within one month if incorrect."
+        ctaLabel="Find a Tax Advisor"
+        ctaHref="/professionals?type=tax_advisor"
       />
       <GuidanceCard
         title="Ongoing Financial Management"

--- a/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
@@ -49,6 +49,8 @@ function RentalContractReview(_props: Readonly<IProps>) {
           },
         ]}
         tip="If anything is unclear, consider consulting a Mieterverein (tenant association) before signing. Membership costs 50-100 EUR/year and includes legal advice on lease matters."
+        ctaLabel="Find a Lawyer"
+        ctaHref="/professionals?type=lawyer"
       />
     </div>
   )

--- a/frontend/src/components/Journey/StepContent/RentalTaxStrategy.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalTaxStrategy.tsx
@@ -43,6 +43,8 @@ function RentalTaxStrategy(_props: Readonly<IProps>) {
           },
         ]}
         tip="Consider hiring a Steuerberater (tax advisor) experienced in rental income. Their fees are tax-deductible, and they often save more than they cost through optimized deductions."
+        ctaLabel="Find a Tax Advisor"
+        ctaHref="/professionals?type=tax_advisor"
       />
       <GuidanceCard
         title="Tax Optimization"


### PR DESCRIPTION
## Summary
- Add superuser-protected admin endpoints for managing professionals: create (POST), update (PUT), delete (DELETE), and toggle verification (PATCH /verify)
- Add `ProfessionalCreateRequest` and `ProfessionalUpdateRequest` schemas with validation
- Add `create_professional`, `update_professional`, `delete_professional` service functions
- Extend `GuidanceCard` with optional CTA link support (`ctaLabel` + `ctaHref` props)
- Add contextual "Find a Professional" CTAs to 4 journey step components linking to the filtered professional directory

## Test plan
- [x] 6 new service unit tests for create/update/delete (including not-found cases)
- [x] 24 existing professional route tests pass (no regressions)
- [x] Frontend TypeScript type check passes (`tsc --noEmit`)
- [x] Pre-commit hooks pass (SDK regenerated for new endpoints)
- [ ] CI: commitlint, pre-commit, test-backend, SonarCloud pass