### PR TITLE
feat(journey): add financing calculator cta to check your finances step

### DIFF
--- a/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
+++ b/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
@@ -47,7 +47,7 @@ function FinanceCheck(_props: Readonly<IProps>) {
             "A rough rule: banks lend up to 4–5x your annual gross income. Monthly repayments should stay below 35% of your net income.",
         },
       ]}
-      tip="Use the Financing Eligibility calculator below to get a personalised estimate of how much you may be able to borrow before approaching lenders."
+      tip="Use the Financing Eligibility calculator to get a personalised estimate of how much you may be able to borrow before approaching lenders."
       ctaLabel="Check Financing Eligibility"
       ctaHref="/calculators?tab=financing"
     />

--- a/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
+++ b/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
@@ -1,0 +1,61 @@
+/**
+ * Finance Check Step Content
+ * Guidance for assessing financial situation before property purchase
+ */
+
+import { BadgeCheck, CreditCard, FileText, PiggyBank } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function FinanceCheck(_props: Readonly<IProps>) {
+  return (
+    <GuidanceCard
+      title="Assess Your Financial Position"
+      description="Understanding your financial situation is the foundation for a successful property purchase."
+      items={[
+        {
+          icon: PiggyBank,
+          label: "Equity & Savings",
+          detail:
+            "German banks typically require 20–30% of the purchase price as equity (including closing costs). Add up all liquid savings, investments, and gifts you can use.",
+        },
+        {
+          icon: FileText,
+          label: "Income Documentation",
+          detail:
+            "Gather your last 3 salary slips, tax returns, and employment contract. Self-employed buyers need 2–3 years of profit-and-loss statements.",
+        },
+        {
+          icon: BadgeCheck,
+          label: "SCHUFA Credit Score",
+          detail:
+            "Request a free SCHUFA self-disclosure once per year at schufa.de. A score above 97% is considered excellent for mortgage applications.",
+        },
+        {
+          icon: CreditCard,
+          label: "Borrowing Capacity",
+          detail:
+            "A rough rule: banks lend up to 4–5x your annual gross income. Monthly repayments should stay below 35% of your net income.",
+        },
+      ]}
+      tip="Use the Financing Eligibility calculator below to get a personalised estimate of how much you may be able to borrow before approaching lenders."
+      ctaLabel="Check Financing Eligibility"
+      ctaHref="/calculators?tab=financing"
+    />
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { FinanceCheck }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -17,6 +17,7 @@ import type {
 import { useJourneyContext } from "../JourneyContext"
 import { ProgressBar } from "../ProgressBar"
 import { TaskCheckbox } from "../TaskCheckbox"
+import { FinanceCheck } from "./FinanceCheck"
 import { MarketInsights } from "./MarketInsights"
 import { OwnershipInsurance } from "./OwnershipInsurance"
 import { OwnershipManagement } from "./OwnershipManagement"
@@ -59,6 +60,7 @@ const STEP_CONTENT_REGISTRY: Record<
   string,
   (props: IStepContentProps) => ReactNode
 > = {
+  finance_check: (p) => <FinanceCheck step={p.step} />,
   research_goals: (p) => (
     <PropertyGoalsForm
       journeyId={p.journeyId}


### PR DESCRIPTION
## Summary

- Adds a new `FinanceCheck` step content component for the `finance_check` content key
- Displays contextual guidance (equity, income docs, SCHUFA, borrowing capacity) as a `GuidanceCard`
- Includes a **"Check Financing Eligibility"** CTA that deep-links to `/calculators?tab=financing`
- Registers the component in `STEP_CONTENT_REGISTRY` in `StepBody.tsx`

## Test plan

- [ ] Open a buying/mortgage journey and expand the "Check Your Finances" step
- [ ] Verify the guidance card renders with all 4 items and the tip
- [ ] Click "Check Financing Eligibility" → lands on Calculators page with Financing tab active
- [ ] No regression on other step content renderers