### PR TITLE
fix(journey): pass cta search params separately in guidance card links

### DIFF
--- a/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
+++ b/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
@@ -49,7 +49,8 @@ function FinanceCheck(_props: Readonly<IProps>) {
       ]}
       tip="Use the Financing Eligibility calculator to get a personalised estimate of how much you may be able to borrow before approaching lenders."
       ctaLabel="Check Financing Eligibility"
-      ctaHref="/calculators?tab=financing"
+      ctaHref="/calculators"
+      ctaSearch={{ tab: "financing" }}
     />
   )
 }

--- a/frontend/src/components/Journey/StepContent/GuidanceCard.tsx
+++ b/frontend/src/components/Journey/StepContent/GuidanceCard.tsx
@@ -28,6 +28,7 @@ interface IProps {
   tip?: string
   ctaLabel?: string
   ctaHref?: string
+  ctaSearch?: Record<string, string>
 }
 
 /******************************************************************************
@@ -35,7 +36,7 @@ interface IProps {
 ******************************************************************************/
 
 function GuidanceCard(props: Readonly<IProps>) {
-  const { title, description, items, tip, ctaLabel, ctaHref } = props
+  const { title, description, items, tip, ctaLabel, ctaHref, ctaSearch } = props
 
   return (
     <Card>
@@ -62,6 +63,7 @@ function GuidanceCard(props: Readonly<IProps>) {
         {ctaLabel && ctaHref && (
           <Link
             to={ctaHref}
+            search={ctaSearch}
             className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
           >
             {ctaLabel}

--- a/frontend/src/components/Journey/StepContent/OwnershipRegistration.tsx
+++ b/frontend/src/components/Journey/StepContent/OwnershipRegistration.tsx
@@ -38,7 +38,8 @@ function OwnershipRegistration(_props: Readonly<IProps>) {
         ]}
         tip="Keep your Grundbuchauszug (land registry extract) in a safe place — you'll need it for insurance, tax, and any future sale."
         ctaLabel="Find a Notary"
-        ctaHref="/professionals?type=notary"
+        ctaHref="/professionals"
+        ctaSearch={{ type: "notary" }}
       />
       <GuidanceCard
         title="Registrations & Utilities"

--- a/frontend/src/components/Journey/StepContent/OwnershipTaxFinance.tsx
+++ b/frontend/src/components/Journey/StepContent/OwnershipTaxFinance.tsx
@@ -50,7 +50,8 @@ function OwnershipTaxFinance(_props: Readonly<IProps>) {
         ]}
         tip="Since the 2025 Grundsteuer reform, tax assessments are based on new property valuations. Check your Grundsteuerwertbescheid for accuracy and file an objection (Einspruch) within one month if incorrect."
         ctaLabel="Find a Tax Advisor"
-        ctaHref="/professionals?type=tax_advisor"
+        ctaHref="/professionals"
+        ctaSearch={{ type: "tax_advisor" }}
       />
       <GuidanceCard
         title="Ongoing Financial Management"

--- a/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
@@ -50,7 +50,8 @@ function RentalContractReview(_props: Readonly<IProps>) {
         ]}
         tip="If anything is unclear, consider consulting a Mieterverein (tenant association) before signing. Membership costs 50-100 EUR/year and includes legal advice on lease matters."
         ctaLabel="Find a Lawyer"
-        ctaHref="/professionals?type=lawyer"
+        ctaHref="/professionals"
+        ctaSearch={{ type: "lawyer" }}
       />
     </div>
   )

--- a/frontend/src/components/Journey/StepContent/RentalTaxStrategy.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalTaxStrategy.tsx
@@ -44,7 +44,8 @@ function RentalTaxStrategy(_props: Readonly<IProps>) {
         ]}
         tip="Consider hiring a Steuerberater (tax advisor) experienced in rental income. Their fees are tax-deductible, and they often save more than they cost through optimized deductions."
         ctaLabel="Find a Tax Advisor"
-        ctaHref="/professionals?type=tax_advisor"
+        ctaHref="/professionals"
+        ctaSearch={{ type: "tax_advisor" }}
       />
       <GuidanceCard
         title="Tax Optimization"


### PR DESCRIPTION
## Summary

- Fixes 404 when clicking "Check Financing Eligibility" CTA from the "Check Your Finances" step card
- Root cause: TanStack Router's `Link` does not accept query strings embedded in the `to` prop — `/calculators?tab=financing` was treated as a literal path with no matching route
- Fix: add `ctaSearch?: Record<string, string>` prop to `GuidanceCard` and pass it to the TanStack Router `Link` `search` prop
- Also fixes all other `GuidanceCard` CTA call sites that had the same bug (`/professionals?type=notary`, `/professionals?type=tax_advisor`, `/professionals?type=lawyer`)

## Test plan

- [ ] Open "Check Your Finances" step → click "Check Financing Eligibility" → lands on Calculators with Financing tab active (not 404)
- [ ] Open "Transfer Ownership" step → click "Find a Notary" → lands on Professionals filtered to notaries
- [ ] Open "Tax & Finance" step → click "Find a Tax Advisor" → lands on Professionals filtered to tax advisors
- [ ] Open "Rental Contract Review" step → click "Find a Lawyer" → lands on Professionals filtered to lawyers