### PR TITLE
fix(journey): update schufa description to new 100-999 point scale

### DIFF
--- a/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
+++ b/frontend/src/components/Journey/StepContent/FinanceCheck.tsx
@@ -38,7 +38,7 @@ function FinanceCheck(_props: Readonly<IProps>) {
           icon: BadgeCheck,
           label: "SCHUFA Credit Score",
           detail:
-            "Request a free SCHUFA self-disclosure once per year at schufa.de. A score above 97% is considered excellent for mortgage applications.",
+            "Request a free SCHUFA self-disclosure once per year at schufa.de. The new score runs from 100–999 pts — lenders typically want 776+ (Excellent) or 709+ (Good) for competitive mortgage terms.",
         },
         {
           icon: CreditCard,


### PR DESCRIPTION
## Summary

Updates the SCHUFA Credit Score description in the "Check Your Finances" step card to reflect the new scoring system.

- **Before:** "A score above 97% is considered excellent" (old percentage-based system)
- **After:** "The new score runs from 100–999 pts — lenders typically want 776+ (Excellent) or 709+ (Good)" (new point-based system, consistent with the Financing Eligibility calculator)

The score bands match the `SCHUFA_OPTIONS` already used in `FinancingWizard.tsx`.