### PR TITLE
fix(calculator): allow 0 down payment in mortgage calculator

### DIFF
--- a/frontend/src/components/Calculators/MortgageAmortisation/MortgageAmortisationForm.tsx
+++ b/frontend/src/components/Calculators/MortgageAmortisation/MortgageAmortisationForm.tsx
@@ -131,7 +131,6 @@ function MortgageAmortisationForm(props: Readonly<IProps>) {
 
   const errors = {
     propertyPrice: parseNum(fields.propertyPrice) <= 0,
-    downPayment: parseNum(fields.downPaymentAmount) <= 0,
     interestRate: parseNum(fields.interestRate) <= 0,
     repaymentRate: parseNum(fields.initialRepaymentRate) <= 0,
   }
@@ -203,12 +202,7 @@ function MortgageAmortisationForm(props: Readonly<IProps>) {
           <FormRow
             htmlFor="downPayment"
             label="Down Payment"
-            tooltip="Your equity contribution (Eigenkapital)"
-            error={
-              showErrors && errors.downPayment
-                ? "Enter a down payment amount"
-                : undefined
-            }
+            tooltip="Your equity contribution (Eigenkapital) — enter 0 for 100% financing"
           >
             <div className="flex gap-2">
               <div className="flex-1">
@@ -216,12 +210,9 @@ function MortgageAmortisationForm(props: Readonly<IProps>) {
                   id="downPayment"
                   type="text"
                   inputMode="numeric"
-                  placeholder="80.000"
+                  placeholder="0"
                   value={formatPrice(fields.downPaymentAmount)}
                   onChange={handleDownPaymentAmountChange}
-                  className={cn(
-                    showErrors && errors.downPayment && "border-destructive",
-                  )}
                 />
               </div>
               <div className="w-20">


### PR DESCRIPTION
## Summary

- Removes the validation that required down payment > 0
- Allows 0 down payment (100% financing) as a valid input
- Updates tooltip to hint that 0 is accepted
- Updates placeholder from "80.000" to "0"
- The calculation engine already handles 0 down payment correctly (loanAmount = propertyPrice, no division by zero)

## Test plan

- [ ] Enter 0 in the down payment EUR field → calculator computes with full property price as loan
- [ ] Enter 0% in the down payment percent field → same result
- [ ] Empty down payment field still calculates (treated as 0)
- [ ] Other validations (property price, interest rate, repayment rate) still work