### PR TITLE
fix(calculator): constrain year column width in amortisation table

### DIFF
--- a/frontend/src/components/Calculators/MortgageAmortisation/MortgageAmortisationTable.tsx
+++ b/frontend/src/components/Calculators/MortgageAmortisation/MortgageAmortisationTable.tsx
@@ -39,7 +39,9 @@ function MortgageAmortisationTable(props: Readonly<IProps>) {
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b text-muted-foreground">
-              <th className="py-2 text-left font-medium">Year</th>
+              <th className="w-px whitespace-nowrap py-2 text-left font-medium">
+                Year
+              </th>
               <th className="py-2 text-right font-medium">Payment</th>
               <th className="py-2 text-right font-medium">Interest</th>
               <th className="py-2 text-right font-medium">Principal</th>
@@ -59,7 +61,7 @@ function MortgageAmortisationTable(props: Readonly<IProps>) {
                       "bg-blue-50/50 dark:bg-blue-950/20 font-medium",
                   )}
                 >
-                  <td className="py-2">
+                  <td className="w-px whitespace-nowrap py-2 pr-4">
                     Year {row.year}
                     {isFixedEnd && (
                       <span className="ml-1 text-xs text-blue-600 dark:text-blue-400">


### PR DESCRIPTION
## Summary
- Adds `w-px whitespace-nowrap` to the Year column header and cells so it shrinks to its content width instead of taking disproportionate space
- Adds `pr-4` to Year cells to provide a small gap before the numeric columns
- All other columns share the remaining table width equally

## Test plan
- [ ] Open Mortgage Calculator, enter values, click Calculate
- [ ] Year column is narrow (fits "Year N" text), other columns are evenly balanced
- [ ] Fixed-rate end row still shows "(Zinsbindung)" badge inline without wrapping