### PR TITLE
fix(landing): fix footer anchor links to work from any page

### DIFF
--- a/frontend/src/components/Landing/HowItWorksSection.tsx
+++ b/frontend/src/components/Landing/HowItWorksSection.tsx
@@ -119,7 +119,7 @@ function PhaseStep(props: { phase: (typeof PHASES)[number]; index: number }) {
 /** Default component. How it works timeline section. */
 function HowItWorksSection() {
   return (
-    <section className="bg-muted/50 py-20 md:py-28">
+    <section id="how-it-works" className="bg-muted/50 py-20 md:py-28">
       <div className="mx-auto max-w-7xl px-4 md:px-6">
         <AnimateIn>
           <div className="mx-auto mb-12 max-w-2xl text-center">

--- a/frontend/src/components/Landing/LandingFooter.tsx
+++ b/frontend/src/components/Landing/LandingFooter.tsx
@@ -12,8 +12,8 @@ const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
   [
     "Product",
     [
-      ["Features", "#features"],
-      ["How It Works", "#how-it-works"],
+      ["Features", "/#features"],
+      ["How It Works", "/#how-it-works"],
       ["Portfolio", "/portfolio"],
     ],
   ],
@@ -36,9 +36,11 @@ const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
   ],
 ]
 
-/** Check if href is an internal route (starts with / but not # or mailto:). */
+/** Check if href is an internal route (starts with / but not a hash anchor or mailto:). */
 function isInternalRoute(href: string): boolean {
-  return href.startsWith("/") && !href.startsWith("mailto:")
+  return (
+    href.startsWith("/") && !href.includes("#") && !href.startsWith("mailto:")
+  )
 }
 
 /******************************************************************************


### PR DESCRIPTION
## Summary
- Footer "Features" and "How It Works" links used bare hash anchors (`#features`, `#how-it-works`) which only scroll within the current page — on any non-landing route they do nothing useful
- Changed to `/#features` and `/#how-it-works` so they always navigate to the landing page and scroll to the correct section
- Updated `isInternalRoute` to exclude hrefs containing `#` (so hash-anchors use a plain `<a>` tag, which handles `/#section` correctly across all browsers)
- Added missing `id="how-it-works"` to `HowItWorksSection.tsx`

## Test plan
- [ ] From `/dashboard` (or any non-landing page), click "How It Works" in footer — should navigate to landing page and scroll to the How It Works section
- [ ] From `/dashboard`, click "Features" in footer — should navigate to landing page and scroll to the Features section
- [ ] From the landing page itself, both links still scroll to the correct sections