### PR TITLE
fix(auth): use client-side router links for terms and privacy

### DIFF
--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -283,19 +283,19 @@ function SignUp() {
 
           <p className="text-center text-xs text-muted-foreground">
             By creating an account, you agree to our{" "}
-            <a
-              href="/terms"
+            <RouterLink
+              to="/terms"
               className="underline underline-offset-4 hover:text-foreground"
             >
               Terms of Service
-            </a>{" "}
+            </RouterLink>{" "}
             and{" "}
-            <a
-              href="/privacy"
+            <RouterLink
+              to="/privacy"
               className="underline underline-offset-4 hover:text-foreground"
             >
               Privacy Policy
-            </a>
+            </RouterLink>
           </p>
 
           <div className="text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Signup page had plain `<a href="/terms">` and `<a href="/privacy">` tags causing full page reloads when users click these links
- Replaced with TanStack Router `<RouterLink>` (already imported in the file) for instant client-side navigation
- The landing/tools footer Terms link was already correct (`FooterLink` uses TanStack `Link` for internal routes)

## Test plan
- [ ] On signup page, click "Terms of Service" — navigates instantly without full page reload
- [ ] On signup page, click "Privacy Policy" — navigates instantly without full page reload
- [ ] Navigating back returns to signup form with state preserved