### PR TITLE
feat(auth): add portfolio management to auth layout features list

### DIFF
--- a/frontend/src/components/Common/AuthLayout.tsx
+++ b/frontend/src/components/Common/AuthLayout.tsx
@@ -1,4 +1,4 @@
-import { Calculator, FileText, Home, Scale } from "lucide-react"
+import { BarChart2, Calculator, FileText, Home, Scale } from "lucide-react"
 
 import { Appearance } from "@/components/Common/Appearance"
 import { Logo } from "@/components/Common/Logo"
@@ -32,6 +32,11 @@ const FEATURES = [
     icon: FileText,
     title: "Document Translation",
     description: "AI-powered translation of German legal documents",
+  },
+  {
+    icon: BarChart2,
+    title: "Portfolio Management",
+    description: "Track and manage all your German property investments",
   },
 ] as const
 


### PR DESCRIPTION
## Summary
- Added "Portfolio Management" as the 5th feature item in the `AuthLayout` left panel, visible on both login and signup pages
- Used `BarChart2` icon from lucide-react (consistent with the existing icon style in the list)
- Description: "Track and manage all your German property investments"

## Test plan
- [ ] Login page left panel shows "Portfolio Management" with BarChart2 icon and description
- [ ] Signup page left panel shows the same entry