### PR TITLE
fix(journey): hide phase completion banner if next phase is started

### DIFF
--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -270,10 +270,13 @@ function StepListView(props: {
         onPhaseClick={(key) => handleContinueToPhase(key as JourneyPhase)}
       />
 
-      {phaseGroups.map((group) => {
+      {phaseGroups.map((group, groupIndex) => {
         const isComplete = group.steps.every(
           (s) => s.status === "completed" || s.status === "skipped",
         )
+        const nextGroup = phaseGroups[groupIndex + 1]
+        const nextPhaseStarted =
+          nextGroup?.steps.some((s) => s.status !== "not_started") ?? false
         const phaseLabel =
           JOURNEY_PHASES.find((p) => p.key === group.phase)?.label ??
           group.phase
@@ -308,7 +311,7 @@ function StepListView(props: {
                 onStepOpen={onStepOpen}
               />
             ))}
-            {isComplete && (
+            {isComplete && !nextPhaseStarted && (
               <PhaseCompletionCta
                 currentPhase={group.phase}
                 activePhaseKeys={navPhases.map((p) => p.key)}

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -60,6 +60,16 @@ function StepTabView(props: IProps) {
     phaseSteps.length > 0 &&
     phaseSteps.every((s) => s.status === "completed" || s.status === "skipped")
 
+  const effectivePhaseIndex = visiblePhases.findIndex(
+    (p) => p.key === effectivePhase,
+  )
+  const nextPhaseKey = visiblePhases[effectivePhaseIndex + 1]?.key as
+    | JourneyPhase
+    | undefined
+  const nextPhaseStarted = nextPhaseKey
+    ? stepsByPhase[nextPhaseKey].some((s) => s.status !== "not_started")
+    : false
+
   const handleContinueToPhase = (nextPhase: JourneyPhase) => {
     setSelectedPhase(nextPhase)
   }
@@ -90,7 +100,7 @@ function StepTabView(props: IProps) {
       ))}
 
       {/* Phase completion CTA */}
-      {isPhaseComplete && (
+      {isPhaseComplete && !nextPhaseStarted && (
         <PhaseCompletionCta
           currentPhase={effectivePhase}
           activePhaseKeys={visiblePhases.map((p) => p.key)}


### PR DESCRIPTION
## Summary
- Suppresses the "Continue to [Next Phase]" CTA banner when any step in the next phase already has a status other than `not_started` (i.e. `in_progress`, `completed`, or `skipped`)
- This prevents the banner from appearing redundantly after a user has already moved on to the next phase
- Change is confined to `StepListView` in `JourneyDetail.tsx` — 5 lines added

## Test plan
- [ ] Complete all steps in a phase — banner appears if next phase is untouched
- [ ] Start any step in the next phase — banner no longer appears on the completed phase
- [ ] Last phase complete — "Journey complete" card still appears (unaffected, uses `isLastPhase` path in `PhaseCompletionCta`)