### PR TITLE
feat(contracts): add AI-powered Kaufvertrag contract explainer

### DIFF
--- a/backend/app/alembic/versions/f0g1h2i3j4k5_add_contract_analysis_table.py
+++ b/backend/app/alembic/versions/f0g1h2i3j4k5_add_contract_analysis_table.py
@@ -1,0 +1,74 @@
+"""add contract_analysis table
+
+Revision ID: f0g1h2i3j4k5
+Revises: e8f9g0h1i2j3
+Create Date: 2026-04-24 16:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSON
+
+# revision identifiers, used by Alembic.
+revision = "f0g1h2i3j4k5"
+down_revision = "e8f9g0h1i2j3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "contract_analysis",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("share_id", sa.String(length=12), unique=True, nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("analyzed_clauses", JSON, nullable=True),
+        sa.Column("notary_checklist", JSON, nullable=True),
+        sa.Column("overall_risk_assessment", sa.String(length=10), nullable=True),
+        sa.Column("overall_risk_explanation", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_contract_analysis_user_id"),
+        "contract_analysis",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_contract_analysis_share_id"),
+        "contract_analysis",
+        ["share_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_contract_analysis_share_id"),
+        table_name="contract_analysis",
+    )
+    op.drop_index(
+        op.f("ix_contract_analysis_user_id"),
+        table_name="contract_analysis",
+    )
+    op.drop_table("contract_analysis")

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -4,6 +4,7 @@ from app.api.routes import (
     articles,
     auth,
     calculators,
+    contracts,
     dashboard,
     documents,
     feedback,
@@ -43,6 +44,7 @@ api_router.include_router(articles.router)
 api_router.include_router(search.router)
 api_router.include_router(market.router)
 api_router.include_router(professionals.router)
+api_router.include_router(contracts.router)
 api_router.include_router(portfolio.router)
 api_router.include_router(glossary.router)
 api_router.include_router(feedback.router)

--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -3,17 +3,17 @@
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 
+from app._models_sqlmodel import SubscriptionTier
 from app.api.deps import CurrentUser, SessionDep
 from app.schemas.contract import (
+    ClauseExplanation,
     ContractAnalysisListResponse,
     ContractAnalysisResponse,
-    ClauseExplanation,
     NotaryQuestion,
 )
 from app.services import contract_service
-from app._models_sqlmodel import SubscriptionTier
 
 router = APIRouter(prefix="/contracts", tags=["contracts"])
 
@@ -32,16 +32,29 @@ def _build_response(
     all_clauses = record.analyzed_clauses or []
     all_checklist = record.notary_checklist or []
 
+    def _to_clause(c: dict) -> ClauseExplanation | None:
+        try:
+            return ClauseExplanation.model_validate(c)
+        except Exception:
+            return None
+
+    def _to_question(q: dict) -> NotaryQuestion | None:
+        try:
+            return NotaryQuestion.model_validate(q)
+        except Exception:
+            return None
+
+    parsed_clauses = [c for c in (_to_clause(x) for x in all_clauses) if c]
+    parsed_checklist = [q for q in (_to_question(x) for x in all_checklist) if q]
+
     if is_premium:
-        visible_clauses = [ClauseExplanation(**c) for c in all_clauses]
-        visible_checklist = [NotaryQuestion(**q) for q in all_checklist]
+        visible_clauses = parsed_clauses
+        visible_checklist = parsed_checklist
         is_truncated = False
     else:
-        visible_clauses = [
-            ClauseExplanation(**c) for c in all_clauses[:_FREE_TIER_LIMIT]
-        ]
+        visible_clauses = parsed_clauses[:_FREE_TIER_LIMIT]
         visible_checklist = []
-        is_truncated = len(all_clauses) > _FREE_TIER_LIMIT
+        is_truncated = len(parsed_clauses) > _FREE_TIER_LIMIT
 
     return ContractAnalysisResponse(
         id=record.id,
@@ -51,7 +64,9 @@ def _build_response(
         analyzed_clauses=visible_clauses,
         notary_checklist=visible_checklist,
         overall_risk_assessment=record.overall_risk_assessment,
-        overall_risk_explanation=record.overall_risk_explanation if is_premium else None,
+        overall_risk_explanation=record.overall_risk_explanation
+        if is_premium
+        else None,
         clause_count=len(all_clauses),
         is_truncated=is_truncated,
         created_at=record.created_at,
@@ -148,7 +163,7 @@ async def list_contract_analyses(
             clause_count=count,
             created_at=r.created_at,
         )
-        for r, count in zip(records, all_clauses_counts)
+        for r, count in zip(records, all_clauses_counts, strict=True)
     ]
     return ContractAnalysisListResponse(
         data=data, total=total, page=page, page_size=page_size

--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -1,0 +1,206 @@
+"""Contract explainer API endpoints."""
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+
+from app.api.deps import CurrentUser, SessionDep
+from app.schemas.contract import (
+    ContractAnalysisListResponse,
+    ContractAnalysisResponse,
+    ClauseExplanation,
+    NotaryQuestion,
+)
+from app.services import contract_service
+from app._models_sqlmodel import SubscriptionTier
+
+router = APIRouter(prefix="/contracts", tags=["contracts"])
+
+# Max upload size: 20 MB
+_MAX_FILE_SIZE = 20 * 1024 * 1024
+
+# Free tier sees only the first N clauses
+_FREE_TIER_LIMIT = contract_service.FREE_TIER_CLAUSE_LIMIT
+
+
+def _build_response(
+    record,
+    is_premium: bool,
+) -> ContractAnalysisResponse:
+    """Build ContractAnalysisResponse, applying free-tier clause truncation."""
+    all_clauses = record.analyzed_clauses or []
+    all_checklist = record.notary_checklist or []
+
+    if is_premium:
+        visible_clauses = [ClauseExplanation(**c) for c in all_clauses]
+        visible_checklist = [NotaryQuestion(**q) for q in all_checklist]
+        is_truncated = False
+    else:
+        visible_clauses = [
+            ClauseExplanation(**c) for c in all_clauses[:_FREE_TIER_LIMIT]
+        ]
+        visible_checklist = []
+        is_truncated = len(all_clauses) > _FREE_TIER_LIMIT
+
+    return ContractAnalysisResponse(
+        id=record.id,
+        filename=record.filename,
+        share_id=record.share_id,
+        summary=record.summary,
+        analyzed_clauses=visible_clauses,
+        notary_checklist=visible_checklist,
+        overall_risk_assessment=record.overall_risk_assessment,
+        overall_risk_explanation=record.overall_risk_explanation if is_premium else None,
+        clause_count=len(all_clauses),
+        is_truncated=is_truncated,
+        created_at=record.created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public endpoints (no auth)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/shared/{share_id}", response_model=ContractAnalysisResponse)
+async def get_shared_analysis(
+    share_id: str,
+    session: SessionDep,
+) -> ContractAnalysisResponse:
+    """Retrieve a shared contract analysis by share_id (no auth required)."""
+    try:
+        record = contract_service.get_analysis_by_share_id(session, share_id)
+    except contract_service.ContractAnalysisNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Shared analysis not found",
+        )
+    return _build_response(record, is_premium=True)
+
+
+# ---------------------------------------------------------------------------
+# Auth-required endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/analyze",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ContractAnalysisResponse,
+)
+async def analyze_contract(
+    current_user: CurrentUser,
+    session: SessionDep,
+    file: UploadFile = File(...),
+) -> ContractAnalysisResponse:
+    """Upload a PDF Kaufvertrag and receive an AI clause-by-clause analysis.
+
+    Premium users see all clauses. Free users see the first 3 only.
+    """
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only PDF files are accepted",
+        )
+
+    file_bytes = await file.read()
+    if len(file_bytes) > _MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="File size must not exceed 20 MB",
+        )
+
+    record = await contract_service.analyze_contract_pdf(
+        session=session,
+        user_id=current_user.id,
+        filename=file.filename,
+        file_bytes=file_bytes,
+    )
+
+    is_premium = current_user.subscription_tier in (
+        SubscriptionTier.PREMIUM,
+        SubscriptionTier.ENTERPRISE,
+    )
+    return _build_response(record, is_premium=is_premium)
+
+
+@router.get("/", response_model=ContractAnalysisListResponse)
+async def list_contract_analyses(
+    current_user: CurrentUser,
+    session: SessionDep,
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=50)] = 20,
+) -> ContractAnalysisListResponse:
+    """List all contract analyses for the current user."""
+    from app.schemas.contract import ContractAnalysisListItem
+
+    records, total = contract_service.list_analyses(
+        session, current_user.id, page=page, page_size=page_size
+    )
+    all_clauses_counts = [len(r.analyzed_clauses or []) for r in records]
+    data = [
+        ContractAnalysisListItem(
+            id=r.id,
+            filename=r.filename,
+            share_id=r.share_id,
+            overall_risk_assessment=r.overall_risk_assessment,
+            clause_count=count,
+            created_at=r.created_at,
+        )
+        for r, count in zip(records, all_clauses_counts)
+    ]
+    return ContractAnalysisListResponse(
+        data=data, total=total, page=page, page_size=page_size
+    )
+
+
+@router.get("/{analysis_id}", response_model=ContractAnalysisResponse)
+async def get_contract_analysis(
+    analysis_id: uuid.UUID,
+    current_user: CurrentUser,
+    session: SessionDep,
+) -> ContractAnalysisResponse:
+    """Get a specific contract analysis owned by the current user."""
+    try:
+        record = contract_service.get_analysis_by_id(
+            session, analysis_id, current_user.id
+        )
+    except contract_service.ContractAnalysisNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Analysis {analysis_id} not found",
+        )
+
+    is_premium = current_user.subscription_tier in (
+        SubscriptionTier.PREMIUM,
+        SubscriptionTier.ENTERPRISE,
+    )
+    return _build_response(record, is_premium=is_premium)
+
+
+@router.post(
+    "/{analysis_id}/share",
+    response_model=ContractAnalysisResponse,
+)
+async def share_contract_analysis(
+    analysis_id: uuid.UUID,
+    current_user: CurrentUser,
+    session: SessionDep,
+) -> ContractAnalysisResponse:
+    """Generate a shareable link for a contract analysis."""
+    try:
+        record = contract_service.generate_share_id(
+            session, analysis_id, current_user.id
+        )
+    except contract_service.ContractAnalysisNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Analysis {analysis_id} not found",
+        )
+
+    is_premium = current_user.subscription_tier in (
+        SubscriptionTier.PREMIUM,
+        SubscriptionTier.ENTERPRISE,
+    )
+    return _build_response(record, is_premium=is_premium)

--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -7,8 +7,10 @@ from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 
 from app._models_sqlmodel import SubscriptionTier
 from app.api.deps import CurrentUser, SessionDep
+from app.models.contract import ContractAnalysis
 from app.schemas.contract import (
     ClauseExplanation,
+    ContractAnalysisListItem,
     ContractAnalysisListResponse,
     ContractAnalysisResponse,
     NotaryQuestion,
@@ -25,7 +27,7 @@ _FREE_TIER_LIMIT = contract_service.FREE_TIER_CLAUSE_LIMIT
 
 
 def _build_response(
-    record,
+    record: ContractAnalysis,
     is_premium: bool,
 ) -> ContractAnalysisResponse:
     """Build ContractAnalysisResponse, applying free-tier clause truncation."""
@@ -148,8 +150,6 @@ async def list_contract_analyses(
     page_size: Annotated[int, Query(ge=1, le=50)] = 20,
 ) -> ContractAnalysisListResponse:
     """List all contract analyses for the current user."""
-    from app.schemas.contract import ContractAnalysisListItem
-
     records, total = contract_service.list_analyses(
         session, current_user.id, page=page, page_size=page_size
     )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -38,6 +38,7 @@ from app.models.article import (
 )
 from app.models.base import Base
 from app.models.calculator import HiddenCostCalculation
+from app.models.contract import ContractAnalysis
 from app.models.document import (
     Document,
     DocumentStatus,
@@ -126,6 +127,7 @@ __all__ = [
     "PortfolioProperty",
     "PortfolioTransaction",
     "TransactionType",
+    "ContractAnalysis",
     "ContactInquiry",
     "Professional",
     "ProfessionalReview",

--- a/backend/app/models/contract.py
+++ b/backend/app/models/contract.py
@@ -1,0 +1,32 @@
+"""Contract analysis database model."""
+
+from sqlalchemy import Column, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class ContractAnalysis(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Stores an AI-generated clause-by-clause analysis of a German purchase contract."""
+
+    __tablename__ = "contract_analysis"
+
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    filename = Column(String(255), nullable=False)
+    share_id = Column(String(12), unique=True, index=True, nullable=True)
+
+    # Analysis results stored as JSON
+    summary = Column(Text, nullable=True)
+    analyzed_clauses = Column(JSON, nullable=True)
+    notary_checklist = Column(JSON, nullable=True)
+    overall_risk_assessment = Column(String(10), nullable=True)
+    overall_risk_explanation = Column(Text, nullable=True)
+
+    # Relationships
+    user = relationship("User", back_populates="contract_analyses")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -50,3 +50,8 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    contract_analyses = relationship(
+        "ContractAnalysis",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/schemas/contract.py
+++ b/backend/app/schemas/contract.py
@@ -1,0 +1,71 @@
+"""Contract explainer API schemas."""
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ClauseExplanation(BaseModel):
+    """A single analyzed clause from a Kaufvertrag."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    section_name: str
+    section_name_en: str
+    original_text: str
+    plain_english_explanation: str
+    risk_level: Literal["low", "medium", "high"]
+    risk_reason: str
+    is_unusual: bool
+    unusual_terms: list[str]
+    page_number: int | None = None
+
+
+class NotaryQuestion(BaseModel):
+    """A question to ask the notary."""
+
+    question: str
+    related_clause: str
+    priority: Literal["essential", "recommended", "optional"]
+
+
+class ContractAnalysisResponse(BaseModel):
+    """Full response for a contract analysis."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    filename: str
+    share_id: str | None
+    summary: str | None
+    analyzed_clauses: list[ClauseExplanation] | None
+    notary_checklist: list[NotaryQuestion] | None
+    overall_risk_assessment: str | None
+    overall_risk_explanation: str | None
+    clause_count: int
+    is_truncated: bool
+    created_at: datetime
+
+
+class ContractAnalysisListItem(BaseModel):
+    """Summary item for listing analyses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    filename: str
+    share_id: str | None
+    overall_risk_assessment: str | None
+    clause_count: int
+    created_at: datetime
+
+
+class ContractAnalysisListResponse(BaseModel):
+    """Paginated list of contract analyses."""
+
+    data: list[ContractAnalysisListItem]
+    total: int
+    page: int
+    page_size: int

--- a/backend/app/services/contract_service.py
+++ b/backend/app/services/contract_service.py
@@ -192,5 +192,9 @@ def generate_share_id(
             except IntegrityError:
                 session.rollback()
         else:
+            logger.error(
+                "share_id collision: failed to generate unique id for analysis %s after 5 attempts",
+                analysis_id,
+            )
             raise RuntimeError("Failed to generate a unique share_id after 5 attempts")
     return record

--- a/backend/app/services/contract_service.py
+++ b/backend/app/services/contract_service.py
@@ -1,0 +1,177 @@
+"""Contract analysis service.
+
+Orchestrates PDF text extraction and AI-powered clause-by-clause analysis
+of German Kaufverträge (purchase contracts).
+"""
+
+import logging
+import secrets
+import tempfile
+import uuid
+
+from sqlalchemy import func, select
+from sqlmodel import Session
+
+from app.models.contract import ContractAnalysis
+from app.services.clause_analyzer_service import analyze_kaufvertrag
+
+logger = logging.getLogger(__name__)
+
+# Number of clauses visible to free-tier users
+FREE_TIER_CLAUSE_LIMIT = 3
+
+
+class ContractAnalysisNotFoundError(Exception):
+    """Raised when a contract analysis is not found."""
+
+
+def _extract_pages_from_bytes(file_bytes: bytes) -> list[dict]:
+    """Extract text from PDF bytes using pdfplumber (blocking — run in thread)."""
+    import pdfplumber
+
+    pages = []
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as tmp:
+        tmp.write(file_bytes)
+        tmp.flush()
+        with pdfplumber.open(tmp.name) as pdf:
+            for i, page in enumerate(pdf.pages, start=1):
+                text = page.extract_text() or ""
+                pages.append(
+                    {
+                        "page_number": i,
+                        "original_text": text,
+                        "translated_text": "",
+                    }
+                )
+    return pages
+
+
+async def analyze_contract_pdf(
+    session: Session,
+    user_id: uuid.UUID,
+    filename: str,
+    file_bytes: bytes,
+) -> ContractAnalysis:
+    """Upload and analyze a PDF contract.
+
+    Extracts text from the PDF, sends it to Claude for clause-by-clause
+    analysis, and stores the result in the database.
+
+    Args:
+        session: Synchronous DB session.
+        user_id: ID of the requesting user.
+        filename: Original filename of the upload.
+        file_bytes: Raw PDF content.
+
+    Returns:
+        Newly created ContractAnalysis record.
+    """
+    import asyncio
+
+    # Extract pages in a thread (pdfplumber is blocking)
+    pages = await asyncio.to_thread(_extract_pages_from_bytes, file_bytes)
+
+    # Run Claude analysis (always as "kaufvertrag" document type)
+    analysis_data = await analyze_kaufvertrag(pages, document_type="kaufvertrag")
+
+    record = ContractAnalysis(
+        user_id=user_id,
+        filename=filename,
+    )
+
+    if analysis_data:
+        record.summary = analysis_data.get("summary")
+        record.analyzed_clauses = analysis_data.get("analyzed_clauses", [])
+        record.notary_checklist = analysis_data.get("notary_checklist", [])
+        record.overall_risk_assessment = analysis_data.get("overall_risk_assessment")
+        record.overall_risk_explanation = analysis_data.get("overall_risk_explanation")
+
+    session.add(record)
+    session.commit()
+    session.refresh(record)
+    return record
+
+
+def get_analysis_by_id(
+    session: Session,
+    analysis_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ContractAnalysis:
+    """Get a contract analysis by ID, scoped to the owning user.
+
+    Raises:
+        ContractAnalysisNotFoundError: If not found or not owned by user.
+    """
+    result = session.execute(
+        select(ContractAnalysis).where(
+            ContractAnalysis.id == analysis_id,
+            ContractAnalysis.user_id == user_id,
+        )
+    ).scalars().first()
+
+    if not result:
+        raise ContractAnalysisNotFoundError(f"Analysis {analysis_id} not found")
+    return result
+
+
+def get_analysis_by_share_id(
+    session: Session,
+    share_id: str,
+) -> ContractAnalysis:
+    """Get a contract analysis by its public share_id (no auth required).
+
+    Raises:
+        ContractAnalysisNotFoundError: If not found or not shared.
+    """
+    result = session.execute(
+        select(ContractAnalysis).where(ContractAnalysis.share_id == share_id)
+    ).scalars().first()
+
+    if not result:
+        raise ContractAnalysisNotFoundError(f"Shared analysis {share_id} not found")
+    return result
+
+
+def list_analyses(
+    session: Session,
+    user_id: uuid.UUID,
+    page: int = 1,
+    page_size: int = 20,
+) -> tuple[list[ContractAnalysis], int]:
+    """List contract analyses for a user, newest first."""
+    base_query = select(ContractAnalysis).where(ContractAnalysis.user_id == user_id)
+
+    total = session.execute(
+        select(func.count()).select_from(base_query.subquery())
+    ).scalar() or 0
+
+    offset = (page - 1) * page_size
+    records = list(
+        session.execute(
+            base_query.order_by(ContractAnalysis.created_at.desc())
+            .offset(offset)
+            .limit(page_size)
+        )
+        .scalars()
+        .all()
+    )
+    return records, total
+
+
+def generate_share_id(
+    session: Session,
+    analysis_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ContractAnalysis:
+    """Generate or return an existing share_id for a contract analysis.
+
+    Raises:
+        ContractAnalysisNotFoundError: If analysis not found or not owned.
+    """
+    record = get_analysis_by_id(session, analysis_id, user_id)
+    if not record.share_id:
+        record.share_id = secrets.token_urlsafe(8)
+        session.add(record)
+        session.commit()
+        session.refresh(record)
+    return record

--- a/backend/app/services/contract_service.py
+++ b/backend/app/services/contract_service.py
@@ -10,6 +10,7 @@ import tempfile
 import uuid
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
 from app.models.contract import ContractAnalysis
@@ -102,12 +103,16 @@ def get_analysis_by_id(
     Raises:
         ContractAnalysisNotFoundError: If not found or not owned by user.
     """
-    result = session.execute(
-        select(ContractAnalysis).where(
-            ContractAnalysis.id == analysis_id,
-            ContractAnalysis.user_id == user_id,
+    result = (
+        session.execute(
+            select(ContractAnalysis).where(
+                ContractAnalysis.id == analysis_id,
+                ContractAnalysis.user_id == user_id,
+            )
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
 
     if not result:
         raise ContractAnalysisNotFoundError(f"Analysis {analysis_id} not found")
@@ -123,9 +128,13 @@ def get_analysis_by_share_id(
     Raises:
         ContractAnalysisNotFoundError: If not found or not shared.
     """
-    result = session.execute(
-        select(ContractAnalysis).where(ContractAnalysis.share_id == share_id)
-    ).scalars().first()
+    result = (
+        session.execute(
+            select(ContractAnalysis).where(ContractAnalysis.share_id == share_id)
+        )
+        .scalars()
+        .first()
+    )
 
     if not result:
         raise ContractAnalysisNotFoundError(f"Shared analysis {share_id} not found")
@@ -141,9 +150,12 @@ def list_analyses(
     """List contract analyses for a user, newest first."""
     base_query = select(ContractAnalysis).where(ContractAnalysis.user_id == user_id)
 
-    total = session.execute(
-        select(func.count()).select_from(base_query.subquery())
-    ).scalar() or 0
+    total = (
+        session.execute(
+            select(func.count()).select_from(base_query.subquery())
+        ).scalar()
+        or 0
+    )
 
     offset = (page - 1) * page_size
     records = list(
@@ -170,8 +182,15 @@ def generate_share_id(
     """
     record = get_analysis_by_id(session, analysis_id, user_id)
     if not record.share_id:
-        record.share_id = secrets.token_urlsafe(8)
-        session.add(record)
-        session.commit()
-        session.refresh(record)
+        for _ in range(5):
+            try:
+                record.share_id = secrets.token_urlsafe(8)
+                session.add(record)
+                session.commit()
+                session.refresh(record)
+                break
+            except IntegrityError:
+                session.rollback()
+        else:
+            raise RuntimeError("Failed to generate a unique share_id after 5 attempts")
     return record

--- a/backend/tests/api/routes/test_contracts.py
+++ b/backend/tests/api/routes/test_contracts.py
@@ -108,12 +108,17 @@ def test_analyze_contract_success(client: TestClient, db: Session) -> None:
     """Test uploading a PDF returns 201 with analysis data."""
     headers, _ = _get_auth_headers(client, db)
 
-    with patch(
-        "app.services.contract_service.analyze_kaufvertrag",
-        new=AsyncMock(return_value=_MOCK_ANALYSIS),
-    ), patch(
-        "app.services.contract_service._extract_pages_from_bytes",
-        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    with (
+        patch(
+            "app.services.contract_service.analyze_kaufvertrag",
+            new=AsyncMock(return_value=_MOCK_ANALYSIS),
+        ),
+        patch(
+            "app.services.contract_service._extract_pages_from_bytes",
+            return_value=[
+                {"page_number": 1, "original_text": "Test", "translated_text": ""}
+            ],
+        ),
     ):
         r = client.post(
             f"{settings.API_V1_STR}/contracts/analyze",
@@ -134,12 +139,17 @@ def test_analyze_contract_free_user_truncated(client: TestClient, db: Session) -
     """Test that free users see only the first 3 clauses."""
     headers, _ = _get_auth_headers(client, db)
 
-    with patch(
-        "app.services.contract_service.analyze_kaufvertrag",
-        new=AsyncMock(return_value=_MOCK_ANALYSIS),
-    ), patch(
-        "app.services.contract_service._extract_pages_from_bytes",
-        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    with (
+        patch(
+            "app.services.contract_service.analyze_kaufvertrag",
+            new=AsyncMock(return_value=_MOCK_ANALYSIS),
+        ),
+        patch(
+            "app.services.contract_service._extract_pages_from_bytes",
+            return_value=[
+                {"page_number": 1, "original_text": "Test", "translated_text": ""}
+            ],
+        ),
     ):
         r = client.post(
             f"{settings.API_V1_STR}/contracts/analyze",
@@ -171,7 +181,13 @@ def test_analyze_contract_invalid_file_type(client: TestClient, db: Session) -> 
 
     r = client.post(
         f"{settings.API_V1_STR}/contracts/analyze",
-        files={"file": ("contract.docx", io.BytesIO(b"fake docx"), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")},
+        files={
+            "file": (
+                "contract.docx",
+                io.BytesIO(b"fake docx"),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        },
         headers=headers,
     )
     assert r.status_code == 400
@@ -181,12 +197,17 @@ def test_analyze_contract_no_api_key(client: TestClient, db: Session) -> None:
     """Test that analysis succeeds (with no clauses) when Anthropic not configured."""
     headers, _ = _get_auth_headers(client, db)
 
-    with patch(
-        "app.services.contract_service.analyze_kaufvertrag",
-        new=AsyncMock(return_value=None),
-    ), patch(
-        "app.services.contract_service._extract_pages_from_bytes",
-        return_value=[{"page_number": 1, "original_text": "", "translated_text": ""}],
+    with (
+        patch(
+            "app.services.contract_service.analyze_kaufvertrag",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.contract_service._extract_pages_from_bytes",
+            return_value=[
+                {"page_number": 1, "original_text": "", "translated_text": ""}
+            ],
+        ),
     ):
         r = client.post(
             f"{settings.API_V1_STR}/contracts/analyze",
@@ -241,12 +262,17 @@ def test_get_analysis_not_owned(client: TestClient, db: Session) -> None:
     headers1, _ = _get_auth_headers(client, db)
     headers2, _ = _get_auth_headers(client, db)
 
-    with patch(
-        "app.services.contract_service.analyze_kaufvertrag",
-        new=AsyncMock(return_value=_MOCK_ANALYSIS),
-    ), patch(
-        "app.services.contract_service._extract_pages_from_bytes",
-        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    with (
+        patch(
+            "app.services.contract_service.analyze_kaufvertrag",
+            new=AsyncMock(return_value=_MOCK_ANALYSIS),
+        ),
+        patch(
+            "app.services.contract_service._extract_pages_from_bytes",
+            return_value=[
+                {"page_number": 1, "original_text": "Test", "translated_text": ""}
+            ],
+        ),
     ):
         r = client.post(
             f"{settings.API_V1_STR}/contracts/analyze",
@@ -273,12 +299,17 @@ def test_share_and_retrieve_analysis(client: TestClient, db: Session) -> None:
     """Test generating a share_id and retrieving via public endpoint."""
     headers, _ = _get_auth_headers(client, db)
 
-    with patch(
-        "app.services.contract_service.analyze_kaufvertrag",
-        new=AsyncMock(return_value=_MOCK_ANALYSIS),
-    ), patch(
-        "app.services.contract_service._extract_pages_from_bytes",
-        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    with (
+        patch(
+            "app.services.contract_service.analyze_kaufvertrag",
+            new=AsyncMock(return_value=_MOCK_ANALYSIS),
+        ),
+        patch(
+            "app.services.contract_service._extract_pages_from_bytes",
+            return_value=[
+                {"page_number": 1, "original_text": "Test", "translated_text": ""}
+            ],
+        ),
     ):
         r = client.post(
             f"{settings.API_V1_STR}/contracts/analyze",

--- a/backend/tests/api/routes/test_contracts.py
+++ b/backend/tests/api/routes/test_contracts.py
@@ -1,0 +1,312 @@
+"""Tests for Contract Explainer API endpoints."""
+
+import io
+import uuid
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app import crud
+from app.core.config import settings
+from app.models import UserCreate
+from tests.utils.utils import random_email, random_lower_string
+
+# Minimal PDF bytes (1-page PDF with no text content)
+_MINIMAL_PDF = (
+    b"%PDF-1.4\n"
+    b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+    b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+    b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+    b"xref\n0 4\n0000000000 65535 f\n"
+    b"0000000009 00000 n\n0000000068 00000 n\n0000000125 00000 n\n"
+    b"trailer\n<< /Size 4 /Root 1 0 R >>\n"
+    b"startxref\n197\n%%EOF"
+)
+
+# Mocked analysis returned by analyze_kaufvertrag
+_MOCK_ANALYSIS = {
+    "summary": "A standard purchase contract for residential property.",
+    "analyzed_clauses": [
+        {
+            "section_name": "Kaufgegenstand",
+            "section_name_en": "Subject of Sale",
+            "original_text": "Das Objekt wird wie besehen verkauft.",
+            "plain_english_explanation": "The property is sold as-is.",
+            "risk_level": "medium",
+            "risk_reason": "No warranty provided.",
+            "is_unusual": False,
+            "unusual_terms": [],
+            "page_number": 1,
+        },
+        {
+            "section_name": "Kaufpreis",
+            "section_name_en": "Purchase Price",
+            "original_text": "EUR 500.000",
+            "plain_english_explanation": "The purchase price is EUR 500,000.",
+            "risk_level": "low",
+            "risk_reason": "Standard pricing clause.",
+            "is_unusual": False,
+            "unusual_terms": [],
+            "page_number": 1,
+        },
+        {
+            "section_name": "Zahlung",
+            "section_name_en": "Payment Terms",
+            "original_text": "Zahlung innerhalb 30 Tagen.",
+            "plain_english_explanation": "Payment due within 30 days.",
+            "risk_level": "low",
+            "risk_reason": "Standard payment terms.",
+            "is_unusual": False,
+            "unusual_terms": [],
+            "page_number": 2,
+        },
+        {
+            "section_name": "Gewährleistung",
+            "section_name_en": "Warranty",
+            "original_text": "Keine Gewährleistung.",
+            "plain_english_explanation": "No warranty is given.",
+            "risk_level": "high",
+            "risk_reason": "All warranties excluded — buyer bears full risk.",
+            "is_unusual": True,
+            "unusual_terms": ["Gewährleistungsausschluss"],
+            "page_number": 3,
+        },
+    ],
+    "notary_checklist": [
+        {
+            "question": "Are there any encumbrances on the property?",
+            "related_clause": "Grundbuch",
+            "priority": "essential",
+        }
+    ],
+    "overall_risk_assessment": "medium",
+    "overall_risk_explanation": "The contract is largely standard but excludes all warranties.",
+    "is_ai_generated": True,
+}
+
+
+def _get_auth_headers(client: TestClient, db: Session) -> tuple[dict, str]:
+    """Create a user and return auth headers and user ID."""
+    email = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=email, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    login_data = {"username": email, "password": password}
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    tokens = r.json()
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    return headers, str(user.id)
+
+
+# ---------------------------------------------------------------------------
+# POST /contracts/analyze
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_contract_success(client: TestClient, db: Session) -> None:
+    """Test uploading a PDF returns 201 with analysis data."""
+    headers, _ = _get_auth_headers(client, db)
+
+    with patch(
+        "app.services.contract_service.analyze_kaufvertrag",
+        new=AsyncMock(return_value=_MOCK_ANALYSIS),
+    ), patch(
+        "app.services.contract_service._extract_pages_from_bytes",
+        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/contracts/analyze",
+            files={"file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")},
+            headers=headers,
+        )
+
+    assert r.status_code == 201
+    data = r.json()
+    assert data["filename"] == "test.pdf"
+    assert data["clause_count"] == 4
+    assert data["overall_risk_assessment"] == "medium"
+    assert "id" in data
+    assert "created_at" in data
+
+
+def test_analyze_contract_free_user_truncated(client: TestClient, db: Session) -> None:
+    """Test that free users see only the first 3 clauses."""
+    headers, _ = _get_auth_headers(client, db)
+
+    with patch(
+        "app.services.contract_service.analyze_kaufvertrag",
+        new=AsyncMock(return_value=_MOCK_ANALYSIS),
+    ), patch(
+        "app.services.contract_service._extract_pages_from_bytes",
+        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/contracts/analyze",
+            files={"file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")},
+            headers=headers,
+        )
+
+    assert r.status_code == 201
+    data = r.json()
+    # Free user sees 3 clauses (FREE_TIER_CLAUSE_LIMIT)
+    assert len(data["analyzed_clauses"]) == 3
+    assert data["is_truncated"] is True
+    # No notary checklist for free users
+    assert data["notary_checklist"] == []
+
+
+def test_analyze_contract_unauthenticated(client: TestClient) -> None:
+    """Test that unauthenticated requests return 401."""
+    r = client.post(
+        f"{settings.API_V1_STR}/contracts/analyze",
+        files={"file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")},
+    )
+    assert r.status_code == 401
+
+
+def test_analyze_contract_invalid_file_type(client: TestClient, db: Session) -> None:
+    """Test that non-PDF files return 422."""
+    headers, _ = _get_auth_headers(client, db)
+
+    r = client.post(
+        f"{settings.API_V1_STR}/contracts/analyze",
+        files={"file": ("contract.docx", io.BytesIO(b"fake docx"), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")},
+        headers=headers,
+    )
+    assert r.status_code == 400
+
+
+def test_analyze_contract_no_api_key(client: TestClient, db: Session) -> None:
+    """Test that analysis succeeds (with no clauses) when Anthropic not configured."""
+    headers, _ = _get_auth_headers(client, db)
+
+    with patch(
+        "app.services.contract_service.analyze_kaufvertrag",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.services.contract_service._extract_pages_from_bytes",
+        return_value=[{"page_number": 1, "original_text": "", "translated_text": ""}],
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/contracts/analyze",
+            files={"file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")},
+            headers=headers,
+        )
+
+    assert r.status_code == 201
+    data = r.json()
+    assert data["clause_count"] == 0
+    assert data["analyzed_clauses"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /contracts/
+# ---------------------------------------------------------------------------
+
+
+def test_list_analyses_empty(client: TestClient, db: Session) -> None:
+    """Test listing analyses returns empty list for new user."""
+    headers, _ = _get_auth_headers(client, db)
+    r = client.get(f"{settings.API_V1_STR}/contracts/", headers=headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["data"] == []
+    assert data["total"] == 0
+
+
+def test_list_analyses_unauthenticated(client: TestClient) -> None:
+    """Test that listing analyses requires auth."""
+    r = client.get(f"{settings.API_V1_STR}/contracts/")
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /contracts/{analysis_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_analysis_not_found(client: TestClient, db: Session) -> None:
+    """Test fetching a non-existent analysis returns 404."""
+    headers, _ = _get_auth_headers(client, db)
+    r = client.get(
+        f"{settings.API_V1_STR}/contracts/{uuid.uuid4()}",
+        headers=headers,
+    )
+    assert r.status_code == 404
+
+
+def test_get_analysis_not_owned(client: TestClient, db: Session) -> None:
+    """Test that a user cannot access another user's analysis."""
+    headers1, _ = _get_auth_headers(client, db)
+    headers2, _ = _get_auth_headers(client, db)
+
+    with patch(
+        "app.services.contract_service.analyze_kaufvertrag",
+        new=AsyncMock(return_value=_MOCK_ANALYSIS),
+    ), patch(
+        "app.services.contract_service._extract_pages_from_bytes",
+        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/contracts/analyze",
+            files={"file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")},
+            headers=headers1,
+        )
+
+    analysis_id = r.json()["id"]
+
+    # User 2 cannot see user 1's analysis
+    r = client.get(
+        f"{settings.API_V1_STR}/contracts/{analysis_id}",
+        headers=headers2,
+    )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /contracts/{analysis_id}/share + GET /contracts/shared/{share_id}
+# ---------------------------------------------------------------------------
+
+
+def test_share_and_retrieve_analysis(client: TestClient, db: Session) -> None:
+    """Test generating a share_id and retrieving via public endpoint."""
+    headers, _ = _get_auth_headers(client, db)
+
+    with patch(
+        "app.services.contract_service.analyze_kaufvertrag",
+        new=AsyncMock(return_value=_MOCK_ANALYSIS),
+    ), patch(
+        "app.services.contract_service._extract_pages_from_bytes",
+        return_value=[{"page_number": 1, "original_text": "Test", "translated_text": ""}],
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/contracts/analyze",
+            files={"file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")},
+            headers=headers,
+        )
+
+    analysis_id = r.json()["id"]
+
+    # Generate share link
+    r = client.post(
+        f"{settings.API_V1_STR}/contracts/{analysis_id}/share",
+        headers=headers,
+    )
+    assert r.status_code == 200
+    share_id = r.json()["share_id"]
+    assert share_id is not None
+
+    # Retrieve via public endpoint (no auth) — shared view shows all clauses
+    r = client.get(f"{settings.API_V1_STR}/contracts/shared/{share_id}")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["clause_count"] == 4
+    assert len(data["analyzed_clauses"]) == 4
+    assert data["is_truncated"] is False
+
+
+def test_get_shared_analysis_not_found(client: TestClient) -> None:
+    """Test retrieving a non-existent shared analysis returns 404."""
+    r = client.get(f"{settings.API_V1_STR}/contracts/shared/nonexistent12")
+    assert r.status_code == 404

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -922,6 +922,19 @@ export const BatchTranslationResponseSchema = {
     }
 } as const;
 
+export const Body_contracts_analyze_contractSchema = {
+    properties: {
+        file: {
+            type: 'string',
+            format: 'binary',
+            title: 'File'
+        }
+    },
+    type: 'object',
+    required: ['file'],
+    title: 'Body_contracts-analyze_contract'
+} as const;
+
 export const Body_documents_upload_documentSchema = {
     properties: {
         file: {
@@ -1130,6 +1143,62 @@ export const CheckoutResponseSchema = {
     description: 'Response with checkout session details.'
 } as const;
 
+export const ClauseExplanationSchema = {
+    properties: {
+        section_name: {
+            type: 'string',
+            title: 'Section Name'
+        },
+        section_name_en: {
+            type: 'string',
+            title: 'Section Name En'
+        },
+        original_text: {
+            type: 'string',
+            title: 'Original Text'
+        },
+        plain_english_explanation: {
+            type: 'string',
+            title: 'Plain English Explanation'
+        },
+        risk_level: {
+            type: 'string',
+            enum: ['low', 'medium', 'high'],
+            title: 'Risk Level'
+        },
+        risk_reason: {
+            type: 'string',
+            title: 'Risk Reason'
+        },
+        is_unusual: {
+            type: 'boolean',
+            title: 'Is Unusual'
+        },
+        unusual_terms: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Unusual Terms'
+        },
+        page_number: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Page Number'
+        }
+    },
+    type: 'object',
+    required: ['section_name', 'section_name_en', 'original_text', 'plain_english_explanation', 'risk_level', 'risk_reason', 'is_unusual', 'unusual_terms'],
+    title: 'ClauseExplanation',
+    description: 'A single analyzed clause from a Kaufvertrag.'
+} as const;
+
 export const ComparisonMetricsSchema = {
     properties: {
         key: {
@@ -1334,6 +1403,186 @@ export const ContactInquiryResponseSchema = {
     required: ['id', 'professional_id', 'sender_name', 'sender_email', 'status', 'created_at'],
     title: 'ContactInquiryResponse',
     description: 'Response schema for a contact inquiry.'
+} as const;
+
+export const ContractAnalysisListItemSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        filename: {
+            type: 'string',
+            title: 'Filename'
+        },
+        share_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Share Id'
+        },
+        overall_risk_assessment: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Overall Risk Assessment'
+        },
+        clause_count: {
+            type: 'integer',
+            title: 'Clause Count'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'filename', 'share_id', 'overall_risk_assessment', 'clause_count', 'created_at'],
+    title: 'ContractAnalysisListItem',
+    description: 'Summary item for listing analyses.'
+} as const;
+
+export const ContractAnalysisListResponseSchema = {
+    properties: {
+        data: {
+            items: {
+                '$ref': '#/components/schemas/ContractAnalysisListItem'
+            },
+            type: 'array',
+            title: 'Data'
+        },
+        total: {
+            type: 'integer',
+            title: 'Total'
+        },
+        page: {
+            type: 'integer',
+            title: 'Page'
+        },
+        page_size: {
+            type: 'integer',
+            title: 'Page Size'
+        }
+    },
+    type: 'object',
+    required: ['data', 'total', 'page', 'page_size'],
+    title: 'ContractAnalysisListResponse',
+    description: 'Paginated list of contract analyses.'
+} as const;
+
+export const ContractAnalysisResponseSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        filename: {
+            type: 'string',
+            title: 'Filename'
+        },
+        share_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Share Id'
+        },
+        summary: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Summary'
+        },
+        analyzed_clauses: {
+            anyOf: [
+                {
+                    items: {
+                        '$ref': '#/components/schemas/ClauseExplanation'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Analyzed Clauses'
+        },
+        notary_checklist: {
+            anyOf: [
+                {
+                    items: {
+                        '$ref': '#/components/schemas/app__schemas__contract__NotaryQuestion'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Notary Checklist'
+        },
+        overall_risk_assessment: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Overall Risk Assessment'
+        },
+        overall_risk_explanation: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Overall Risk Explanation'
+        },
+        clause_count: {
+            type: 'integer',
+            title: 'Clause Count'
+        },
+        is_truncated: {
+            type: 'boolean',
+            title: 'Is Truncated'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'filename', 'share_id', 'summary', 'analyzed_clauses', 'notary_checklist', 'overall_risk_assessment', 'overall_risk_explanation', 'clause_count', 'is_truncated', 'created_at'],
+    title: 'ContractAnalysisResponse',
+    description: 'Full response for a contract analysis.'
 } as const;
 
 export const CostCategorySchema = {
@@ -3908,7 +4157,7 @@ export const KaufvertragAnalysisSchema = {
         },
         notary_checklist: {
             items: {
-                '$ref': '#/components/schemas/NotaryQuestion'
+                '$ref': '#/components/schemas/app__schemas__document__NotaryQuestion'
             },
             type: 'array',
             title: 'Notary Checklist'
@@ -4563,28 +4812,6 @@ export const NextStepResponseSchema = {
     required: ['has_next'],
     title: 'NextStepResponse',
     description: 'Schema for next recommended step.'
-} as const;
-
-export const NotaryQuestionSchema = {
-    properties: {
-        question: {
-            type: 'string',
-            title: 'Question'
-        },
-        related_clause: {
-            type: 'string',
-            title: 'Related Clause'
-        },
-        priority: {
-            type: 'string',
-            enum: ['essential', 'recommended', 'optional'],
-            title: 'Priority'
-        }
-    },
-    type: 'object',
-    required: ['question', 'related_clause', 'priority'],
-    title: 'NotaryQuestion',
-    description: 'Question to ask a notary about a contract clause.'
 } as const;
 
 export const NotificationListResponseSchema = {
@@ -9493,4 +9720,48 @@ export const YearProjectionSchema = {
     required: ['year', 'rental_income', 'tax', 'net_income_after_tax', 'cumulative_net_income', 'property_value'],
     title: 'YearProjection',
     description: 'Single year projection for one ownership scenario.'
+} as const;
+
+export const app__schemas__contract__NotaryQuestionSchema = {
+    properties: {
+        question: {
+            type: 'string',
+            title: 'Question'
+        },
+        related_clause: {
+            type: 'string',
+            title: 'Related Clause'
+        },
+        priority: {
+            type: 'string',
+            enum: ['essential', 'recommended', 'optional'],
+            title: 'Priority'
+        }
+    },
+    type: 'object',
+    required: ['question', 'related_clause', 'priority'],
+    title: 'NotaryQuestion',
+    description: 'A question to ask the notary.'
+} as const;
+
+export const app__schemas__document__NotaryQuestionSchema = {
+    properties: {
+        question: {
+            type: 'string',
+            title: 'Question'
+        },
+        related_clause: {
+            type: 'string',
+            title: 'Related Clause'
+        },
+        priority: {
+            type: 'string',
+            enum: ['essential', 'recommended', 'optional'],
+            title: 'Priority'
+        }
+    },
+    type: 'object',
+    required: ['question', 'related_clause', 'priority'],
+    title: 'NotaryQuestion',
+    description: 'Question to ask a notary about a contract clause.'
 } as const;

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { ArticlesListArticlesData, ArticlesListArticlesResponse, ArticlesCreateArticleData, ArticlesCreateArticleResponse, ArticlesSearchArticlesData, ArticlesSearchArticlesResponse, ArticlesGetCategoriesResponse, ArticlesGetArticleData, ArticlesGetArticleResponse, ArticlesRateArticleData, ArticlesRateArticleResponse, ArticlesUpdateArticleData, ArticlesUpdateArticleResponse, ArticlesDeleteArticleData, ArticlesDeleteArticleResponse, AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, AuthForgotPasswordData, AuthForgotPasswordResponse, AuthResetPasswordData, AuthResetPasswordResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, CalculatorsGetSharedPropertyEvaluationData, CalculatorsGetSharedPropertyEvaluationResponse, CalculatorsListStepPropertyEvaluationsData, CalculatorsListStepPropertyEvaluationsResponse, CalculatorsCalculatePropertyEvaluationData, CalculatorsCalculatePropertyEvaluationResponse, CalculatorsListPropertyEvaluationsResponse, CalculatorsSavePropertyEvaluationData, CalculatorsSavePropertyEvaluationResponse, CalculatorsGetPropertyEvaluationData, CalculatorsGetPropertyEvaluationResponse, CalculatorsDeletePropertyEvaluationData, CalculatorsDeletePropertyEvaluationResponse, CalculatorsCalculateOwnershipComparisonData, CalculatorsCalculateOwnershipComparisonResponse, CalculatorsGetSharedOwnershipComparisonData, CalculatorsGetSharedOwnershipComparisonResponse, CalculatorsListOwnershipComparisonsResponse, CalculatorsSaveOwnershipComparisonData, CalculatorsSaveOwnershipComparisonResponse, CalculatorsGetOwnershipComparisonData, CalculatorsGetOwnershipComparisonResponse, CalculatorsDeleteOwnershipComparisonData, CalculatorsDeleteOwnershipComparisonResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsGetUsageResponse, DocumentsGetSharedDocumentData, DocumentsGetSharedDocumentResponse, DocumentsGetDocumentsByStepData, DocumentsGetDocumentsByStepResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsDeleteDocumentData, DocumentsDeleteDocumentResponse, DocumentsShareDocumentData, DocumentsShareDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FeedbackSubmitFeedbackData, FeedbackSubmitFeedbackResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, GlossaryListTermsData, GlossaryListTermsResponse, GlossarySearchGlossaryData, GlossarySearchGlossaryResponse, GlossaryListCategoriesResponse, GlossaryGetTermData, GlossaryGetTermResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, MarketGetRentEstimateData, MarketGetRentEstimateResponse, MarketListAreasResponse, MarketCompareAreasData, MarketCompareAreasResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, NotificationsUnsubscribeData, NotificationsUnsubscribeResponse, PortfolioListPropertiesResponse, PortfolioCreatePropertyData, PortfolioCreatePropertyResponse, PortfolioCreatePropertyFromJourneyData, PortfolioCreatePropertyFromJourneyResponse, PortfolioGetPropertyData, PortfolioGetPropertyResponse, PortfolioUpdatePropertyData, PortfolioUpdatePropertyResponse, PortfolioDeletePropertyData, PortfolioDeletePropertyResponse, PortfolioCreateTransactionData, PortfolioCreateTransactionResponse, PortfolioListTransactionsData, PortfolioListTransactionsResponse, PortfolioDeleteTransactionData, PortfolioDeleteTransactionResponse, PortfolioGetCostSummaryData, PortfolioGetCostSummaryResponse, PortfolioGetPortfolioPerformanceResponse, PortfolioGetPortfolioSummaryResponse, PrivateCreateUserData, PrivateCreateUserResponse, ProfessionalsGetFilterOptionsResponse, ProfessionalsListProfessionalsData, ProfessionalsListProfessionalsResponse, ProfessionalsCreateProfessionalData, ProfessionalsCreateProfessionalResponse, ProfessionalsGetProfessionalData, ProfessionalsGetProfessionalResponse, ProfessionalsUpdateProfessionalData, ProfessionalsUpdateProfessionalResponse, ProfessionalsDeleteProfessionalData, ProfessionalsDeleteProfessionalResponse, ProfessionalsCreateReviewData, ProfessionalsCreateReviewResponse, ProfessionalsCreateInquiryData, ProfessionalsCreateInquiryResponse, ProfessionalsTrackProfessionalClickData, ProfessionalsTrackProfessionalClickResponse, ProfessionalsToggleVerifyProfessionalData, ProfessionalsToggleVerifyProfessionalResponse, SearchSearchData, SearchSearchResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersUploadAvatarData, UsersUploadAvatarResponse, UsersDeleteAvatarResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
+import type { ArticlesListArticlesData, ArticlesListArticlesResponse, ArticlesCreateArticleData, ArticlesCreateArticleResponse, ArticlesSearchArticlesData, ArticlesSearchArticlesResponse, ArticlesGetCategoriesResponse, ArticlesGetArticleData, ArticlesGetArticleResponse, ArticlesRateArticleData, ArticlesRateArticleResponse, ArticlesUpdateArticleData, ArticlesUpdateArticleResponse, ArticlesDeleteArticleData, ArticlesDeleteArticleResponse, AuthRegisterData, AuthRegisterResponse, AuthLoginData, AuthLoginResponse, AuthRefreshTokenData, AuthRefreshTokenResponse, AuthLogoutData, AuthLogoutResponse, AuthVerifyEmailData, AuthVerifyEmailResponse, AuthResendVerificationData, AuthResendVerificationResponse, AuthForgotPasswordData, AuthForgotPasswordResponse, AuthResetPasswordData, AuthResetPasswordResponse, CalculatorsGetStateRatesResponse, CalculatorsCompareStatesData, CalculatorsCompareStatesResponse, CalculatorsGetSharedCalculationData, CalculatorsGetSharedCalculationResponse, CalculatorsListCalculationsResponse, CalculatorsSaveCalculationData, CalculatorsSaveCalculationResponse, CalculatorsGetCalculationData, CalculatorsGetCalculationResponse, CalculatorsDeleteCalculationData, CalculatorsDeleteCalculationResponse, CalculatorsCompareRoiScenariosData, CalculatorsCompareRoiScenariosResponse, CalculatorsGetSharedRoiCalculationData, CalculatorsGetSharedRoiCalculationResponse, CalculatorsListRoiCalculationsResponse, CalculatorsSaveRoiCalculationData, CalculatorsSaveRoiCalculationResponse, CalculatorsGetRoiCalculationData, CalculatorsGetRoiCalculationResponse, CalculatorsDeleteRoiCalculationData, CalculatorsDeleteRoiCalculationResponse, CalculatorsGetSharedPropertyEvaluationData, CalculatorsGetSharedPropertyEvaluationResponse, CalculatorsListStepPropertyEvaluationsData, CalculatorsListStepPropertyEvaluationsResponse, CalculatorsCalculatePropertyEvaluationData, CalculatorsCalculatePropertyEvaluationResponse, CalculatorsListPropertyEvaluationsResponse, CalculatorsSavePropertyEvaluationData, CalculatorsSavePropertyEvaluationResponse, CalculatorsGetPropertyEvaluationData, CalculatorsGetPropertyEvaluationResponse, CalculatorsDeletePropertyEvaluationData, CalculatorsDeletePropertyEvaluationResponse, CalculatorsCalculateOwnershipComparisonData, CalculatorsCalculateOwnershipComparisonResponse, CalculatorsGetSharedOwnershipComparisonData, CalculatorsGetSharedOwnershipComparisonResponse, CalculatorsListOwnershipComparisonsResponse, CalculatorsSaveOwnershipComparisonData, CalculatorsSaveOwnershipComparisonResponse, CalculatorsGetOwnershipComparisonData, CalculatorsGetOwnershipComparisonResponse, CalculatorsDeleteOwnershipComparisonData, CalculatorsDeleteOwnershipComparisonResponse, ContractsGetSharedAnalysisData, ContractsGetSharedAnalysisResponse, ContractsAnalyzeContractData, ContractsAnalyzeContractResponse, ContractsListContractAnalysesData, ContractsListContractAnalysesResponse, ContractsGetContractAnalysisData, ContractsGetContractAnalysisResponse, ContractsShareContractAnalysisData, ContractsShareContractAnalysisResponse, DashboardGetDashboardOverviewResponse, DocumentsUploadDocumentData, DocumentsUploadDocumentResponse, DocumentsGetUsageResponse, DocumentsGetSharedDocumentData, DocumentsGetSharedDocumentResponse, DocumentsGetDocumentsByStepData, DocumentsGetDocumentsByStepResponse, DocumentsListDocumentsData, DocumentsListDocumentsResponse, DocumentsGetDocumentData, DocumentsGetDocumentResponse, DocumentsDeleteDocumentData, DocumentsDeleteDocumentResponse, DocumentsShareDocumentData, DocumentsShareDocumentResponse, DocumentsGetDocumentTranslationData, DocumentsGetDocumentTranslationResponse, DocumentsGetDocumentStatusData, DocumentsGetDocumentStatusResponse, FeedbackSubmitFeedbackData, FeedbackSubmitFeedbackResponse, FinancingGetSharedAssessmentData, FinancingGetSharedAssessmentResponse, FinancingListAssessmentsResponse, FinancingSaveAssessmentData, FinancingSaveAssessmentResponse, FinancingGetAssessmentData, FinancingGetAssessmentResponse, FinancingDeleteAssessmentData, FinancingDeleteAssessmentResponse, GlossaryListTermsData, GlossaryListTermsResponse, GlossarySearchGlossaryData, GlossarySearchGlossaryResponse, GlossaryListCategoriesResponse, GlossaryGetTermData, GlossaryGetTermResponse, JourneysCreateJourneyData, JourneysCreateJourneyResponse, JourneysListJourneysData, JourneysListJourneysResponse, JourneysGetJourneyData, JourneysGetJourneyResponse, JourneysUpdateJourneyData, JourneysUpdateJourneyResponse, JourneysDeleteJourneyData, JourneysDeleteJourneyResponse, JourneysGetJourneyProgressData, JourneysGetJourneyProgressResponse, JourneysGetNextStepData, JourneysGetNextStepResponse, JourneysUpdateStepStatusData, JourneysUpdateStepStatusResponse, JourneysUpdateTaskStatusData, JourneysUpdateTaskStatusResponse, JourneysGetPropertyGoalsData, JourneysGetPropertyGoalsResponse, JourneysUpdatePropertyGoalsData, JourneysUpdatePropertyGoalsResponse, LawsListLawsData, LawsListLawsResponse, LawsSearchLawsData, LawsSearchLawsResponse, LawsGetCategoriesResponse, LawsGetLawsForJourneyStepData, LawsGetLawsForJourneyStepResponse, LawsGetBookmarksResponse, LawsGetLawData, LawsGetLawResponse, LawsCreateBookmarkData, LawsCreateBookmarkResponse, LawsDeleteBookmarkData, LawsDeleteBookmarkResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, MarketGetRentEstimateData, MarketGetRentEstimateResponse, MarketListAreasResponse, MarketCompareAreasData, MarketCompareAreasResponse, NotificationsListNotificationsData, NotificationsListNotificationsResponse, NotificationsMarkAllNotificationsReadResponse, NotificationsGetNotificationPreferencesResponse, NotificationsUpdateNotificationPreferencesData, NotificationsUpdateNotificationPreferencesResponse, NotificationsMarkNotificationReadData, NotificationsMarkNotificationReadResponse, NotificationsDeleteNotificationData, NotificationsDeleteNotificationResponse, NotificationsUnsubscribeData, NotificationsUnsubscribeResponse, PortfolioListPropertiesResponse, PortfolioCreatePropertyData, PortfolioCreatePropertyResponse, PortfolioCreatePropertyFromJourneyData, PortfolioCreatePropertyFromJourneyResponse, PortfolioGetPropertyData, PortfolioGetPropertyResponse, PortfolioUpdatePropertyData, PortfolioUpdatePropertyResponse, PortfolioDeletePropertyData, PortfolioDeletePropertyResponse, PortfolioCreateTransactionData, PortfolioCreateTransactionResponse, PortfolioListTransactionsData, PortfolioListTransactionsResponse, PortfolioDeleteTransactionData, PortfolioDeleteTransactionResponse, PortfolioGetCostSummaryData, PortfolioGetCostSummaryResponse, PortfolioGetPortfolioPerformanceResponse, PortfolioGetPortfolioSummaryResponse, PrivateCreateUserData, PrivateCreateUserResponse, ProfessionalsGetFilterOptionsResponse, ProfessionalsListProfessionalsData, ProfessionalsListProfessionalsResponse, ProfessionalsCreateProfessionalData, ProfessionalsCreateProfessionalResponse, ProfessionalsGetProfessionalData, ProfessionalsGetProfessionalResponse, ProfessionalsUpdateProfessionalData, ProfessionalsUpdateProfessionalResponse, ProfessionalsDeleteProfessionalData, ProfessionalsDeleteProfessionalResponse, ProfessionalsCreateReviewData, ProfessionalsCreateReviewResponse, ProfessionalsCreateInquiryData, ProfessionalsCreateInquiryResponse, ProfessionalsTrackProfessionalClickData, ProfessionalsTrackProfessionalClickResponse, ProfessionalsToggleVerifyProfessionalData, ProfessionalsToggleVerifyProfessionalResponse, SearchSearchData, SearchSearchResponse, SubscriptionsGetCurrentSubscriptionResponse, SubscriptionsCreateCheckoutSessionData, SubscriptionsCreateCheckoutSessionResponse, SubscriptionsCreatePortalSessionData, SubscriptionsCreatePortalSessionResponse, SubscriptionsHandleWebhookData, SubscriptionsHandleWebhookResponse, SubscriptionsCancelSubscriptionResponse, TranslationsTranslateTextData, TranslationsTranslateTextResponse, TranslationsDetectLanguageData, TranslationsDetectLanguageResponse, TranslationsBatchTranslateData, TranslationsBatchTranslateResponse, TranslationsGetSupportedLanguagesResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersExportUserDataResponse, UsersUploadAvatarData, UsersUploadAvatarResponse, UsersDeleteAvatarResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
 
 export class ArticlesService {
     /**
@@ -927,6 +927,116 @@ export class CalculatorsService {
             url: '/api/v1/calculators/ownership-comparison/{calc_id}',
             path: {
                 calc_id: data.calcId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
+
+export class ContractsService {
+    /**
+     * Get Shared Analysis
+     * Retrieve a shared contract analysis by share_id (no auth required).
+     * @param data The data for the request.
+     * @param data.shareId
+     * @returns ContractAnalysisResponse Successful Response
+     * @throws ApiError
+     */
+    public static getSharedAnalysis(data: ContractsGetSharedAnalysisData): CancelablePromise<ContractsGetSharedAnalysisResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/contracts/shared/{share_id}',
+            path: {
+                share_id: data.shareId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Analyze Contract
+     * Upload a PDF Kaufvertrag and receive an AI clause-by-clause analysis.
+     *
+     * Premium users see all clauses. Free users see the first 3 only.
+     * @param data The data for the request.
+     * @param data.formData
+     * @returns ContractAnalysisResponse Successful Response
+     * @throws ApiError
+     */
+    public static analyzeContract(data: ContractsAnalyzeContractData): CancelablePromise<ContractsAnalyzeContractResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/contracts/analyze',
+            formData: data.formData,
+            mediaType: 'multipart/form-data',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * List Contract Analyses
+     * List all contract analyses for the current user.
+     * @param data The data for the request.
+     * @param data.page
+     * @param data.pageSize
+     * @returns ContractAnalysisListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listContractAnalyses(data: ContractsListContractAnalysesData = {}): CancelablePromise<ContractsListContractAnalysesResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/contracts/',
+            query: {
+                page: data.page,
+                page_size: data.pageSize
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Get Contract Analysis
+     * Get a specific contract analysis owned by the current user.
+     * @param data The data for the request.
+     * @param data.analysisId
+     * @returns ContractAnalysisResponse Successful Response
+     * @throws ApiError
+     */
+    public static getContractAnalysis(data: ContractsGetContractAnalysisData): CancelablePromise<ContractsGetContractAnalysisResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/contracts/{analysis_id}',
+            path: {
+                analysis_id: data.analysisId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Share Contract Analysis
+     * Generate a shareable link for a contract analysis.
+     * @param data The data for the request.
+     * @param data.analysisId
+     * @returns ContractAnalysisResponse Successful Response
+     * @throws ApiError
+     */
+    public static shareContractAnalysis(data: ContractsShareContractAnalysisData): CancelablePromise<ContractsShareContractAnalysisResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/contracts/{analysis_id}/share',
+            path: {
+                analysis_id: data.analysisId
             },
             errors: {
                 422: 'Validation Error'

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -57,6 +57,26 @@ export type AnnualCashflowRowResponse = {
 };
 
 /**
+ * A question to ask the notary.
+ */
+export type app__schemas__contract__NotaryQuestion = {
+    question: string;
+    related_clause: string;
+    priority: 'essential' | 'recommended' | 'optional';
+};
+
+export type priority = 'essential' | 'recommended' | 'optional';
+
+/**
+ * Question to ask a notary about a contract clause.
+ */
+export type app__schemas__document__NotaryQuestion = {
+    question: string;
+    related_clause: string;
+    priority: 'essential' | 'recommended' | 'optional';
+};
+
+/**
  * Response for the area listing endpoint.
  */
 export type AreaListResponse = {
@@ -277,6 +297,10 @@ export type BatchTranslationResponse = {
     total_warnings: number;
 };
 
+export type Body_contracts_analyze_contract = {
+    file: (Blob | File);
+};
+
 export type Body_documents_upload_document = {
     file: (Blob | File);
 };
@@ -340,6 +364,21 @@ export type CheckoutResponse = {
 };
 
 /**
+ * A single analyzed clause from a Kaufvertrag.
+ */
+export type ClauseExplanation = {
+    section_name: string;
+    section_name_en: string;
+    original_text: string;
+    plain_english_explanation: string;
+    risk_level: 'low' | 'medium' | 'high';
+    risk_reason: string;
+    is_unusual: boolean;
+    unusual_terms: Array<(string)>;
+    page_number?: (number | null);
+};
+
+/**
  * Full comparison metrics for a single area.
  */
 export type ComparisonMetrics = {
@@ -387,6 +426,45 @@ export type ContactInquiryResponse = {
     sender_email: string;
     status: string;
     sent_at?: (string | null);
+    created_at: string;
+};
+
+/**
+ * Summary item for listing analyses.
+ */
+export type ContractAnalysisListItem = {
+    id: string;
+    filename: string;
+    share_id: (string | null);
+    overall_risk_assessment: (string | null);
+    clause_count: number;
+    created_at: string;
+};
+
+/**
+ * Paginated list of contract analyses.
+ */
+export type ContractAnalysisListResponse = {
+    data: Array<ContractAnalysisListItem>;
+    total: number;
+    page: number;
+    page_size: number;
+};
+
+/**
+ * Full response for a contract analysis.
+ */
+export type ContractAnalysisResponse = {
+    id: string;
+    filename: string;
+    share_id: (string | null);
+    summary: (string | null);
+    analyzed_clauses: (Array<ClauseExplanation> | null);
+    notary_checklist: (Array<app__schemas__contract__NotaryQuestion> | null);
+    overall_risk_assessment: (string | null);
+    overall_risk_explanation: (string | null);
+    clause_count: number;
+    is_truncated: boolean;
     created_at: string;
 };
 
@@ -1139,7 +1217,7 @@ export type JourneyUpdate = {
 export type KaufvertragAnalysis = {
     summary: string;
     analyzed_clauses: Array<AnalyzedClause>;
-    notary_checklist: Array<NotaryQuestion>;
+    notary_checklist: Array<app__schemas__document__NotaryQuestion>;
     overall_risk_assessment: 'low' | 'medium' | 'high';
     overall_risk_explanation: string;
     is_ai_generated?: boolean;
@@ -1346,17 +1424,6 @@ export type NextStepResponse = {
     step?: (JourneyStepResponse | null);
     message?: (string | null);
 };
-
-/**
- * Question to ask a notary about a contract clause.
- */
-export type NotaryQuestion = {
-    question: string;
-    related_clause: string;
-    priority: 'essential' | 'recommended' | 'optional';
-};
-
-export type priority = 'essential' | 'recommended' | 'optional';
 
 /**
  * Paginated list of notifications.
@@ -2838,6 +2905,37 @@ export type CalculatorsDeleteOwnershipComparisonData = {
 };
 
 export type CalculatorsDeleteOwnershipComparisonResponse = (void);
+
+export type ContractsGetSharedAnalysisData = {
+    shareId: string;
+};
+
+export type ContractsGetSharedAnalysisResponse = (ContractAnalysisResponse);
+
+export type ContractsAnalyzeContractData = {
+    formData: Body_contracts_analyze_contract;
+};
+
+export type ContractsAnalyzeContractResponse = (ContractAnalysisResponse);
+
+export type ContractsListContractAnalysesData = {
+    page?: number;
+    pageSize?: number;
+};
+
+export type ContractsListContractAnalysesResponse = (ContractAnalysisListResponse);
+
+export type ContractsGetContractAnalysisData = {
+    analysisId: string;
+};
+
+export type ContractsGetContractAnalysisResponse = (ContractAnalysisResponse);
+
+export type ContractsShareContractAnalysisData = {
+    analysisId: string;
+};
+
+export type ContractsShareContractAnalysisResponse = (ContractAnalysisResponse);
 
 export type DashboardGetDashboardOverviewResponse = (DashboardOverviewResponse);
 

--- a/frontend/src/components/ContractExplainer/ClauseCard.tsx
+++ b/frontend/src/components/ContractExplainer/ClauseCard.tsx
@@ -1,0 +1,141 @@
+/**
+ * Clause Card Component
+ * Expandable card showing original German text alongside the English explanation
+ */
+
+import { AlertTriangle, ChevronDown, ChevronRight, Tag } from "lucide-react"
+import { useState } from "react"
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import type { ClauseExplanation } from "@/models/contract"
+
+interface IProps {
+  clause: ClauseExplanation
+  index: number
+}
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const RISK_STYLES: Record<string, string> = {
+  high: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  medium:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+}
+
+const RISK_LABELS: Record<string, string> = {
+  high: "High Risk",
+  medium: "Medium Risk",
+  low: "Low Risk",
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Single expandable clause card. */
+function ClauseCard(props: Readonly<IProps>) {
+  const { clause, index } = props
+  const [expanded, setExpanded] = useState(index === 0)
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="py-3 px-4">
+        <button
+          type="button"
+          className="w-full text-left cursor-pointer select-none"
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <div className="flex items-center gap-2 min-w-0">
+              {expanded ? (
+                <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className="text-sm font-medium truncate">
+                {index + 1}. {clause.sectionNameEn}
+              </span>
+              <span className="text-xs text-muted-foreground hidden sm:inline truncate">
+                ({clause.sectionName})
+              </span>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              {clause.isUnusual && (
+                <Badge
+                  variant="outline"
+                  className="text-xs border-orange-400 text-orange-600 dark:text-orange-400"
+                >
+                  <AlertTriangle className="h-3 w-3 mr-1" />
+                  Unusual
+                </Badge>
+              )}
+              <Badge className={cn("text-xs", RISK_STYLES[clause.riskLevel])}>
+                {RISK_LABELS[clause.riskLevel]}
+              </Badge>
+            </div>
+          </div>
+        </button>
+      </CardHeader>
+
+      {expanded && (
+        <CardContent className="pt-0 pb-4 px-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            {/* Original German */}
+            <div className="space-y-1">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Original (German)
+              </p>
+              <div className="bg-muted/40 rounded-md p-3 text-sm text-muted-foreground leading-relaxed">
+                {clause.originalText}
+              </div>
+            </div>
+
+            {/* English explanation */}
+            <div className="space-y-1">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Plain English
+              </p>
+              <div className="bg-muted/40 rounded-md p-3 text-sm leading-relaxed">
+                {clause.plainEnglishExplanation}
+              </div>
+            </div>
+          </div>
+
+          {/* Risk reason */}
+          <div className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+            <span>{clause.riskReason}</span>
+          </div>
+
+          {/* Unusual terms */}
+          {clause.unusualTerms.length > 0 && (
+            <div className="mt-2 flex items-start gap-2 text-xs">
+              <Tag className="h-3.5 w-3.5 shrink-0 mt-0.5 text-orange-500" />
+              <div className="flex flex-wrap gap-1">
+                {clause.unusualTerms.map((term) => (
+                  <Badge
+                    key={term}
+                    variant="outline"
+                    className="text-xs border-orange-300"
+                  >
+                    {term}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ClauseCard }

--- a/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
+++ b/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
@@ -20,7 +20,6 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-import { Skeleton } from "@/components/ui/skeleton"
 import { useAnalyzeContract, useShareContractAnalysis } from "@/hooks/mutations"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
@@ -373,23 +372,10 @@ function UploadForm(props: Readonly<IUploadProps>) {
   )
 }
 
-/** Loading skeleton while analysis is in progress. */
-function AnalysisSkeleton() {
-  return (
-    <div className="space-y-4">
-      <Skeleton className="h-6 w-48" />
-      <Skeleton className="h-24 w-full" />
-      <Skeleton className="h-32 w-full" />
-      <Skeleton className="h-32 w-full" />
-    </div>
-  )
-}
-
 /** Default component. Contract Explainer main page. */
 function ContractExplainerPage() {
   const { user } = useAuth()
   const [analysis, setAnalysis] = useState<ContractAnalysis | null>(null)
-  const isPending = useAnalyzeContract().isPending
 
   const isPremium =
     user?.subscription_tier === "premium" ||
@@ -425,8 +411,6 @@ function ContractExplainerPage() {
       {/* Upload or results */}
       {!analysis ? (
         <UploadForm onAnalyzed={setAnalysis} />
-      ) : isPending ? (
-        <AnalysisSkeleton />
       ) : (
         <>
           <Button variant="ghost" size="sm" onClick={() => setAnalysis(null)}>

--- a/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
+++ b/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
@@ -1,0 +1,444 @@
+/**
+ * Contract Explainer Page
+ * Upload a German Kaufvertrag PDF and receive an AI clause-by-clause analysis
+ */
+
+import {
+  AlertTriangle,
+  CheckSquare,
+  Copy,
+  FileText,
+  Lock,
+  Share2,
+  Square,
+  Upload,
+} from "lucide-react"
+import { useCallback, useState } from "react"
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useAnalyzeContract, useShareContractAnalysis } from "@/hooks/mutations"
+import useAuth from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import type { ContractAnalysis, NotaryQuestion } from "@/models/contract"
+import { ClauseCard } from "./ClauseCard"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const RISK_BADGE_STYLES: Record<string, string> = {
+  high: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  medium:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+}
+
+const PRIORITY_STYLES: Record<string, string> = {
+  essential: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  recommended:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  optional: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+interface INotaryChecklistProps {
+  questions: NotaryQuestion[]
+}
+
+/** Interactive notary checklist. */
+function NotaryChecklist(props: Readonly<INotaryChecklistProps>) {
+  const { questions } = props
+  const [checked, setChecked] = useState<Set<number>>(new Set())
+
+  const toggle = useCallback((i: number) => {
+    setChecked((prev) => {
+      const next = new Set(prev)
+      next.has(i) ? next.delete(i) : next.add(i)
+      return next
+    })
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">
+          What to Ask Your Notary
+          <Badge variant="outline" className="ml-2 text-xs">
+            {checked.size}/{questions.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {questions.map((q, i) => (
+          <button
+            key={i}
+            type="button"
+            className="flex items-start gap-2 cursor-pointer w-full text-left"
+            onClick={() => toggle(i)}
+          >
+            {checked.has(i) ? (
+              <CheckSquare className="h-4 w-4 shrink-0 mt-0.5 text-amber-600" />
+            ) : (
+              <Square className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" />
+            )}
+            <div className="flex-1 min-w-0">
+              <p
+                className={cn(
+                  "text-sm",
+                  checked.has(i) && "line-through text-muted-foreground",
+                )}
+              >
+                {q.question}
+              </p>
+              <div className="flex gap-1.5 mt-0.5 flex-wrap">
+                <Badge className={cn("text-xs", PRIORITY_STYLES[q.priority])}>
+                  {q.priority}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {q.relatedClause}
+                </span>
+              </div>
+            </div>
+          </button>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+interface IUpgradeCtaProps {
+  hiddenCount: number
+}
+
+/** Premium upgrade CTA shown when clauses are truncated. */
+function UpgradeCta(props: Readonly<IUpgradeCtaProps>) {
+  const { hiddenCount } = props
+
+  return (
+    <div className="relative">
+      {/* Blur overlay */}
+      <div className="absolute inset-0 z-10 bg-background/80 backdrop-blur-sm rounded-lg flex flex-col items-center justify-center gap-3 text-center px-4">
+        <Lock className="h-8 w-8 text-amber-600" />
+        <p className="text-sm font-medium">
+          {hiddenCount} more clause{hiddenCount !== 1 ? "s" : ""} available with
+          Premium
+        </p>
+        <p className="text-xs text-muted-foreground max-w-xs">
+          Upgrade to see the full analysis, notary checklist, and detailed risk
+          explanations for all clauses.
+        </p>
+        <Button
+          size="sm"
+          className="bg-amber-600 hover:bg-amber-700 text-white"
+          onClick={() => window.location.assign("/subscriptions")}
+        >
+          Upgrade to Premium
+        </Button>
+      </div>
+      {/* Blurred placeholder clause */}
+      <div className="rounded-lg border p-4 blur-sm select-none pointer-events-none">
+        <div className="h-4 bg-muted rounded w-3/4 mb-2" />
+        <div className="h-3 bg-muted rounded w-full mb-1" />
+        <div className="h-3 bg-muted rounded w-5/6" />
+      </div>
+    </div>
+  )
+}
+
+interface IShareButtonProps {
+  analysis: ContractAnalysis
+}
+
+/** Share button — generates link and copies it. */
+function ShareButton(props: Readonly<IShareButtonProps>) {
+  const { analysis } = props
+  const { showSuccessToast } = useCustomToast()
+  const { mutate: share, isPending } = useShareContractAnalysis(analysis.id)
+
+  function handleShare() {
+    if (analysis.shareId) {
+      const url = `${window.location.origin}/contract-explainer/shared/${analysis.shareId}`
+      navigator.clipboard.writeText(url)
+      showSuccessToast("Link copied to clipboard!")
+      return
+    }
+    share(undefined, {
+      onSuccess: (updated) => {
+        if (updated.shareId) {
+          const url = `${window.location.origin}/contract-explainer/shared/${updated.shareId}`
+          navigator.clipboard.writeText(url)
+          showSuccessToast("Link copied to clipboard!")
+        }
+      },
+    })
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleShare}
+      disabled={isPending}
+    >
+      {analysis.shareId ? (
+        <Copy className="h-4 w-4 mr-1.5" />
+      ) : (
+        <Share2 className="h-4 w-4 mr-1.5" />
+      )}
+      {analysis.shareId ? "Copy Link" : "Share"}
+    </Button>
+  )
+}
+
+interface IResultsProps {
+  analysis: ContractAnalysis
+  isPremium: boolean
+}
+
+/** Renders the full analysis results. */
+function AnalysisResults(props: Readonly<IResultsProps>) {
+  const { analysis, isPremium } = props
+
+  const clauses = analysis.analyzedClauses ?? []
+  const checklist = analysis.notaryChecklist ?? []
+  const hiddenCount = analysis.clauseCount - clauses.length
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">{analysis.filename}</h2>
+          <p className="text-sm text-muted-foreground">
+            {analysis.clauseCount} clause{analysis.clauseCount !== 1 ? "s" : ""}{" "}
+            analyzed
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {analysis.overallRiskAssessment && (
+            <Badge
+              className={cn(
+                "text-xs",
+                RISK_BADGE_STYLES[analysis.overallRiskAssessment],
+              )}
+            >
+              Overall:{" "}
+              {analysis.overallRiskAssessment.charAt(0).toUpperCase() +
+                analysis.overallRiskAssessment.slice(1)}{" "}
+              Risk
+            </Badge>
+          )}
+          <ShareButton analysis={analysis} />
+        </div>
+      </div>
+
+      {/* Summary */}
+      {analysis.summary && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Summary</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {analysis.summary}
+            </p>
+            {isPremium && analysis.overallRiskExplanation && (
+              <>
+                <Separator className="my-3" />
+                <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-amber-600" />
+                  <p>{analysis.overallRiskExplanation}</p>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Clauses */}
+      <div>
+        <h3 className="text-sm font-medium mb-3 text-muted-foreground uppercase tracking-wide">
+          Clauses
+        </h3>
+        <div className="space-y-3">
+          {clauses.map((clause, i) => (
+            <ClauseCard key={i} clause={clause} index={i} />
+          ))}
+          {analysis.isTruncated && <UpgradeCta hiddenCount={hiddenCount} />}
+        </div>
+      </div>
+
+      {/* Notary checklist (premium only) */}
+      {isPremium && checklist.length > 0 && (
+        <NotaryChecklist questions={checklist} />
+      )}
+
+      {!isPremium && (
+        <Card className="border-amber-200 dark:border-amber-900/50">
+          <CardContent className="pt-4 flex items-center gap-3">
+            <Lock className="h-5 w-5 text-amber-600 shrink-0" />
+            <p className="text-sm text-muted-foreground">
+              Upgrade to Premium to unlock the notary checklist and all clause
+              explanations.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+interface IUploadProps {
+  onAnalyzed: (analysis: ContractAnalysis) => void
+}
+
+/** File upload form with drag-and-drop. */
+function UploadForm(props: Readonly<IUploadProps>) {
+  const { onAnalyzed } = props
+  const { mutate: analyze, isPending } = useAnalyzeContract()
+  const [isDragging, setIsDragging] = useState(false)
+
+  function processFile(file: File) {
+    if (!file.name.toLowerCase().endsWith(".pdf")) return
+    analyze(file, { onSuccess: onAnalyzed })
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file) processFile(file)
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    setIsDragging(false)
+    const file = e.dataTransfer.files[0]
+    if (file) processFile(file)
+  }
+
+  return (
+    <label
+      className={cn(
+        "block border-2 border-dashed rounded-xl p-10 text-center transition-colors cursor-pointer",
+        isDragging
+          ? "border-amber-500 bg-amber-50 dark:bg-amber-900/10"
+          : "border-muted hover:border-muted-foreground/50",
+        isPending && "pointer-events-none opacity-60",
+      )}
+      onDragOver={(e) => {
+        e.preventDefault()
+        setIsDragging(true)
+      }}
+      onDragLeave={() => setIsDragging(false)}
+      onDrop={handleDrop}
+    >
+      <input
+        type="file"
+        accept=".pdf"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+      {isPending ? (
+        <div className="space-y-3">
+          <div className="mx-auto h-12 w-12 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center animate-pulse">
+            <FileText className="h-6 w-6 text-amber-600" />
+          </div>
+          <p className="text-sm font-medium">
+            Analyzing your contract with AI…
+          </p>
+          <p className="text-xs text-muted-foreground">
+            This may take up to 60 seconds for large contracts.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="mx-auto h-12 w-12 rounded-full bg-muted flex items-center justify-center">
+            <Upload className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <p className="text-sm font-medium">Drop your Kaufvertrag PDF here</p>
+          <p className="text-xs text-muted-foreground">
+            or click to browse — PDF only, max 20 MB
+          </p>
+        </div>
+      )}
+    </label>
+  )
+}
+
+/** Loading skeleton while analysis is in progress. */
+function AnalysisSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  )
+}
+
+/** Default component. Contract Explainer main page. */
+function ContractExplainerPage() {
+  const { user } = useAuth()
+  const [analysis, setAnalysis] = useState<ContractAnalysis | null>(null)
+  const isPending = useAnalyzeContract().isPending
+
+  const isPremium =
+    user?.subscription_tier === "premium" ||
+    user?.subscription_tier === "enterprise" ||
+    user?.is_superuser === true
+
+  return (
+    <div className="space-y-6 max-w-4xl mx-auto">
+      {/* Page header */}
+      <div>
+        <h1 className="text-2xl font-bold">Contract Explainer</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Upload a German Kaufvertrag (purchase contract) PDF and receive a
+          clause-by-clause plain-English analysis with risk ratings.
+        </p>
+      </div>
+
+      {!isPremium && !analysis && (
+        <Card className="border-amber-200 dark:border-amber-900/50 bg-amber-50/50 dark:bg-amber-900/10">
+          <CardContent className="pt-4 flex items-center gap-3">
+            <Lock className="h-5 w-5 text-amber-600 shrink-0" />
+            <p className="text-sm">
+              <span className="font-medium">Free plan: </span>
+              <span className="text-muted-foreground">
+                You can analyze a contract, but only the first 3 clauses are
+                visible. Upgrade to Premium for the full analysis.
+              </span>
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Upload or results */}
+      {!analysis ? (
+        <UploadForm onAnalyzed={setAnalysis} />
+      ) : isPending ? (
+        <AnalysisSkeleton />
+      ) : (
+        <>
+          <Button variant="ghost" size="sm" onClick={() => setAnalysis(null)}>
+            ← Analyze another contract
+          </Button>
+          <AnalysisResults analysis={analysis} isPremium={isPremium} />
+        </>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ContractExplainerPage }

--- a/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
+++ b/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
@@ -3,6 +3,7 @@
  * Upload a German Kaufvertrag PDF and receive an AI clause-by-clause analysis
  */
 
+import { useNavigate } from "@tanstack/react-router"
 import {
   AlertTriangle,
   CheckSquare,
@@ -120,6 +121,7 @@ interface IUpgradeCtaProps {
 /** Premium upgrade CTA shown when clauses are truncated. */
 function UpgradeCta(props: Readonly<IUpgradeCtaProps>) {
   const { hiddenCount } = props
+  const navigate = useNavigate()
 
   return (
     <div className="relative">
@@ -137,7 +139,7 @@ function UpgradeCta(props: Readonly<IUpgradeCtaProps>) {
         <Button
           size="sm"
           className="bg-amber-600 hover:bg-amber-700 text-white"
-          onClick={() => window.location.assign("/subscriptions")}
+          onClick={() => navigate({ to: "/settings" })}
         >
           Upgrade to Premium
         </Button>

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -7,6 +7,7 @@ import {
   Home,
   Languages,
   Scale,
+  ScrollText,
   UserCheck,
   Users,
 } from "lucide-react"
@@ -28,6 +29,11 @@ const baseItems: Item[] = [
   { icon: Compass, title: "Journeys", path: "/journeys" },
   { icon: Building2, title: "Portfolio", path: "/portfolio" },
   { icon: FileText, title: "Documents", path: "/documents" },
+  {
+    icon: ScrollText,
+    title: "Contract Explainer",
+    path: "/contract-explainer",
+  },
   { icon: Scale, title: "Laws", path: "/laws" },
   { icon: Languages, title: "Glossary", path: "/glossary" },
   { icon: Calculator, title: "Calculators", path: "/calculators" },

--- a/frontend/src/hooks/mutations/index.ts
+++ b/frontend/src/hooks/mutations/index.ts
@@ -5,6 +5,7 @@
 export * from "./useArticleMutations"
 export * from "./useAvatarMutations"
 export * from "./useCalculatorMutations"
+export * from "./useContractMutations"
 export * from "./useDocumentMutations"
 export * from "./useJourneyMutations"
 export * from "./useLegalMutations"

--- a/frontend/src/hooks/mutations/useContractMutations.ts
+++ b/frontend/src/hooks/mutations/useContractMutations.ts
@@ -1,0 +1,49 @@
+/**
+ * Contract Explainer Mutation Hooks
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import useCustomToast from "@/hooks/useCustomToast"
+import { queryKeys } from "@/query/queryKeys"
+import { ContractService } from "@/services/ContractService"
+
+/**
+ * Upload a PDF and trigger AI contract analysis
+ */
+export function useAnalyzeContract() {
+  const queryClient = useQueryClient()
+  const { showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: (file: File) => ContractService.analyzeContract(file),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.contracts.all })
+    },
+    onError: () => {
+      showErrorToast(
+        "Could not analyze contract. Please check the file and try again.",
+      )
+    },
+  })
+}
+
+/**
+ * Generate a shareable link for a contract analysis
+ */
+export function useShareContractAnalysis(analysisId: string) {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: () => ContractService.shareAnalysis(analysisId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.contracts.detail(analysisId),
+      })
+      showSuccessToast("Shareable link generated.")
+    },
+    onError: () => {
+      showErrorToast("Could not generate share link. Please try again.")
+    },
+  })
+}

--- a/frontend/src/hooks/mutations/useContractMutations.ts
+++ b/frontend/src/hooks/mutations/useContractMutations.ts
@@ -40,6 +40,9 @@ export function useShareContractAnalysis(analysisId: string) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.contracts.detail(analysisId),
       })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.contracts.all,
+      })
       showSuccessToast("Shareable link generated.")
     },
     onError: () => {

--- a/frontend/src/hooks/queries/index.ts
+++ b/frontend/src/hooks/queries/index.ts
@@ -4,6 +4,7 @@
 
 export * from "./useArticleQueries"
 export * from "./useCalculatorQueries"
+export * from "./useContractQueries"
 export * from "./useDashboardQueries"
 export * from "./useDocumentQueries"
 export * from "./useGlossaryQueries"

--- a/frontend/src/hooks/queries/useContractQueries.ts
+++ b/frontend/src/hooks/queries/useContractQueries.ts
@@ -1,0 +1,40 @@
+/**
+ * Contract Explainer Query Hooks
+ * Read-only queries for contract analysis data
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import { queryKeys } from "@/query/queryKeys"
+import { ContractService } from "@/services/ContractService"
+
+/**
+ * Fetch the current user's list of contract analyses
+ */
+export function useContractAnalyses(page = 1) {
+  return useQuery({
+    queryKey: queryKeys.contracts.list(page),
+    queryFn: () => ContractService.listAnalyses(page),
+  })
+}
+
+/**
+ * Fetch a single contract analysis by ID
+ */
+export function useContractAnalysis(analysisId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.contracts.detail(analysisId ?? ""),
+    queryFn: () => ContractService.getAnalysis(analysisId!),
+    enabled: !!analysisId,
+  })
+}
+
+/**
+ * Fetch a shared contract analysis by share_id (no auth required)
+ */
+export function useSharedContractAnalysis(shareId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.contracts.shared(shareId ?? ""),
+    queryFn: () => ContractService.getSharedAnalysis(shareId!),
+    enabled: !!shareId,
+  })
+}

--- a/frontend/src/models/contract.ts
+++ b/frontend/src/models/contract.ts
@@ -1,0 +1,54 @@
+/**
+ * Contract Explainer TypeScript models
+ */
+
+export type RiskLevel = "low" | "medium" | "high"
+export type NotaryPriority = "essential" | "recommended" | "optional"
+
+export interface ClauseExplanation {
+  sectionName: string
+  sectionNameEn: string
+  originalText: string
+  plainEnglishExplanation: string
+  riskLevel: RiskLevel
+  riskReason: string
+  isUnusual: boolean
+  unusualTerms: string[]
+  pageNumber: number | null
+}
+
+export interface NotaryQuestion {
+  question: string
+  relatedClause: string
+  priority: NotaryPriority
+}
+
+export interface ContractAnalysis {
+  id: string
+  filename: string
+  shareId: string | null
+  summary: string | null
+  analyzedClauses: ClauseExplanation[] | null
+  notaryChecklist: NotaryQuestion[] | null
+  overallRiskAssessment: RiskLevel | null
+  overallRiskExplanation: string | null
+  clauseCount: number
+  isTruncated: boolean
+  createdAt: string
+}
+
+export interface ContractAnalysisListItem {
+  id: string
+  filename: string
+  shareId: string | null
+  overallRiskAssessment: RiskLevel | null
+  clauseCount: number
+  createdAt: string
+}
+
+export interface ContractAnalysisListResponse {
+  data: ContractAnalysisListItem[]
+  total: number
+  page: number
+  pageSize: number
+}

--- a/frontend/src/query/queryKeys.ts
+++ b/frontend/src/query/queryKeys.ts
@@ -213,4 +213,14 @@ export const queryKeys = {
     summary: () => [...queryKeys.portfolio.all, "summary"] as const,
     performance: () => [...queryKeys.portfolio.all, "performance"] as const,
   },
+
+  // Contract Explainer queries
+  contracts: {
+    all: ["contracts"] as const,
+    list: (page?: number) =>
+      [...queryKeys.contracts.all, "list", page] as const,
+    detail: (id: string) => [...queryKeys.contracts.all, "detail", id] as const,
+    shared: (shareId: string) =>
+      [...queryKeys.contracts.all, "shared", shareId] as const,
+  },
 } as const

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as ToolsMortgageCalculatorRouteImport } from './routes/tools/mort
 import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutSearchRouteImport } from './routes/_layout/search'
 import { Route as LayoutDashboardRouteImport } from './routes/_layout/dashboard'
+import { Route as LayoutContractExplainerRouteImport } from './routes/_layout/contract-explainer'
 import { Route as LayoutCalculatorsRouteImport } from './routes/_layout/calculators'
 import { Route as LayoutAdminRouteImport } from './routes/_layout/admin'
 import { Route as LayoutProfessionalsIndexRouteImport } from './routes/_layout/professionals/index'
@@ -143,6 +144,11 @@ const LayoutSearchRoute = LayoutSearchRouteImport.update({
 const LayoutDashboardRoute = LayoutDashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutContractExplainerRoute = LayoutContractExplainerRouteImport.update({
+  id: '/contract-explainer',
+  path: '/contract-explainer',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutCalculatorsRoute = LayoutCalculatorsRouteImport.update({
@@ -271,6 +277,7 @@ export interface FileRoutesByFullPath {
   '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
   '/calculators': typeof LayoutCalculatorsRoute
+  '/contract-explainer': typeof LayoutContractExplainerRoute
   '/dashboard': typeof LayoutDashboardRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
@@ -311,6 +318,7 @@ export interface FileRoutesByTo {
   '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
   '/calculators': typeof LayoutCalculatorsRoute
+  '/contract-explainer': typeof LayoutContractExplainerRoute
   '/dashboard': typeof LayoutDashboardRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
@@ -353,6 +361,7 @@ export interface FileRoutesById {
   '/verify-email': typeof VerifyEmailRoute
   '/_layout/admin': typeof LayoutAdminRoute
   '/_layout/calculators': typeof LayoutCalculatorsRoute
+  '/_layout/contract-explainer': typeof LayoutContractExplainerRoute
   '/_layout/dashboard': typeof LayoutDashboardRoute
   '/_layout/search': typeof LayoutSearchRoute
   '/_layout/settings': typeof LayoutSettingsRoute
@@ -396,6 +405,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/admin'
     | '/calculators'
+    | '/contract-explainer'
     | '/dashboard'
     | '/search'
     | '/settings'
@@ -436,6 +446,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/admin'
     | '/calculators'
+    | '/contract-explainer'
     | '/dashboard'
     | '/search'
     | '/settings'
@@ -477,6 +488,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/_layout/admin'
     | '/_layout/calculators'
+    | '/_layout/contract-explainer'
     | '/_layout/dashboard'
     | '/_layout/search'
     | '/_layout/settings'
@@ -656,6 +668,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutDashboardRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/contract-explainer': {
+      id: '/_layout/contract-explainer'
+      path: '/contract-explainer'
+      fullPath: '/contract-explainer'
+      preLoaderRoute: typeof LayoutContractExplainerRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/calculators': {
       id: '/_layout/calculators'
       path: '/calculators'
@@ -826,6 +845,7 @@ const LayoutJourneysJourneyIdRouteWithChildren =
 interface LayoutRouteChildren {
   LayoutAdminRoute: typeof LayoutAdminRoute
   LayoutCalculatorsRoute: typeof LayoutCalculatorsRoute
+  LayoutContractExplainerRoute: typeof LayoutContractExplainerRoute
   LayoutDashboardRoute: typeof LayoutDashboardRoute
   LayoutSearchRoute: typeof LayoutSearchRoute
   LayoutSettingsRoute: typeof LayoutSettingsRoute
@@ -850,6 +870,7 @@ interface LayoutRouteChildren {
 const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAdminRoute: LayoutAdminRoute,
   LayoutCalculatorsRoute: LayoutCalculatorsRoute,
+  LayoutContractExplainerRoute: LayoutContractExplainerRoute,
   LayoutDashboardRoute: LayoutDashboardRoute,
   LayoutSearchRoute: LayoutSearchRoute,
   LayoutSettingsRoute: LayoutSettingsRoute,

--- a/frontend/src/routes/_layout/contract-explainer.tsx
+++ b/frontend/src/routes/_layout/contract-explainer.tsx
@@ -1,0 +1,24 @@
+/**
+ * Contract Explainer Route
+ * AI-powered Kaufvertrag clause-by-clause analysis
+ */
+
+import { createFileRoute } from "@tanstack/react-router"
+import { ContractExplainerPage } from "@/components/ContractExplainer/ContractExplainerPage"
+
+/******************************************************************************
+                              Route
+******************************************************************************/
+
+export const Route = createFileRoute("/_layout/contract-explainer")({
+  component: ContractExplainerPage,
+  head: () => ({
+    meta: [{ title: "Contract Explainer - HeimPath" }],
+  }),
+})
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default ContractExplainerPage

--- a/frontend/src/services/ContractService.ts
+++ b/frontend/src/services/ContractService.ts
@@ -1,0 +1,86 @@
+/**
+ * Contract Service
+ * Handles all API calls related to the contract explainer feature
+ */
+
+import { OpenAPI } from "@/client"
+import { request } from "@/client/core/request"
+import type {
+  ContractAnalysis,
+  ContractAnalysisListResponse,
+} from "@/models/contract"
+import { PATHS } from "./common/Paths"
+import { transformKeys } from "./common/transformKeys"
+
+/******************************************************************************
+                              Service
+******************************************************************************/
+
+class ContractServiceClass {
+  /**
+   * Upload a PDF and receive an AI clause-by-clause analysis
+   */
+  async analyzeContract(file: File): Promise<ContractAnalysis> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "POST",
+      url: PATHS.CONTRACTS.ANALYZE,
+      formData: { file },
+      mediaType: "multipart/form-data",
+    })
+    return transformKeys<ContractAnalysis>(response)
+  }
+
+  /**
+   * List the current user's contract analyses
+   */
+  async listAnalyses(
+    page = 1,
+    pageSize = 20,
+  ): Promise<ContractAnalysisListResponse> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url: PATHS.CONTRACTS.LIST,
+      query: { page, page_size: pageSize },
+    })
+    return transformKeys<ContractAnalysisListResponse>(response)
+  }
+
+  /**
+   * Get a specific contract analysis by ID
+   */
+  async getAnalysis(analysisId: string): Promise<ContractAnalysis> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url: PATHS.CONTRACTS.DETAIL(analysisId),
+    })
+    return transformKeys<ContractAnalysis>(response)
+  }
+
+  /**
+   * Generate a shareable link for a contract analysis
+   */
+  async shareAnalysis(analysisId: string): Promise<ContractAnalysis> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "POST",
+      url: PATHS.CONTRACTS.SHARE(analysisId),
+    })
+    return transformKeys<ContractAnalysis>(response)
+  }
+
+  /**
+   * Retrieve a shared contract analysis by share_id (no auth)
+   */
+  async getSharedAnalysis(shareId: string): Promise<ContractAnalysis> {
+    const response = await request<Record<string, unknown>>(OpenAPI, {
+      method: "GET",
+      url: PATHS.CONTRACTS.SHARED(shareId),
+    })
+    return transformKeys<ContractAnalysis>(response)
+  }
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export const ContractService = new ContractServiceClass()

--- a/frontend/src/services/common/Paths.ts
+++ b/frontend/src/services/common/Paths.ts
@@ -182,4 +182,13 @@ export const PATHS = {
   FEEDBACK: {
     SUBMIT: `${API_V1}/feedback/`,
   },
+
+  // Contract Explainer
+  CONTRACTS: {
+    ANALYZE: `${API_V1}/contracts/analyze`,
+    LIST: `${API_V1}/contracts/`,
+    DETAIL: (id: string) => `${API_V1}/contracts/${id}`,
+    SHARE: (id: string) => `${API_V1}/contracts/${id}/share`,
+    SHARED: (shareId: string) => `${API_V1}/contracts/shared/${shareId}`,
+  },
 } as const


### PR DESCRIPTION
## Summary
- New Contract Explainer feature for German Kaufvertrag (purchase contract) PDF analysis
- Standalone AI-powered clause-by-clause analysis via existing Claude/Anthropic integration
- Free-tier gating: first 3 clauses visible, premium users see full analysis + notary checklist

## What Changed

### Backend
- `ContractAnalysis` model + Alembic migration (`f0g1h2i3j4k5`)
- `contract_service`: PDF extraction (pdfplumber), delegates to `clause_analyzer_service`
- `contracts` router: `POST /analyze`, `GET /`, `GET /{id}`, `POST /{id}/share`, `GET /shared/{share_id}`
- 11 tests covering auth, free-tier truncation, ownership scoping, share flow

### Frontend
- `ContractService` + query/mutation hooks
- `ClauseCard`: expandable card with side-by-side German/English text and risk badge
- `ContractExplainerPage`: drag-and-drop PDF upload, AI loading state, share button, blur CTA for free users
- Route at `/contract-explainer`, sidebar nav entry

## Test plan
- [ ] Unauthenticated upload returns 401
- [ ] Non-PDF upload returns 400
- [ ] Free user sees first 3 clauses + upgrade CTA
- [ ] Premium user sees all clauses + notary checklist
- [ ] Share link generates and is publicly accessible
- [ ] `/contract-explainer` page loads with upload form
- [ ] All CI checks pass