### PR TITLE
fix(journey): navigate to first incomplete step's phase on completion CTA

### DIFF
--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -280,6 +280,29 @@ function StepListView(props: {
         const phaseLabel =
           JOURNEY_PHASES.find((p) => p.key === group.phase)?.label ??
           group.phase
+
+        // Find the phase containing the first incomplete step that comes after
+        // the current phase (by step_number). This ensures the CTA navigates to
+        // the section with the user's actual next step, rather than the canonical
+        // successor — which can differ for rent_out journeys where some phases
+        // have lower step_numbers than earlier canonical phases.
+        const currentPhaseOrder = JOURNEY_PHASES.findIndex(
+          (p) => p.key === group.phase,
+        )
+        const phasesAfterCurrent = new Set(
+          JOURNEY_PHASES.slice(currentPhaseOrder + 1).map((p) => p.key),
+        )
+        const nextPhaseByStepOrder = steps
+          .filter(
+            (s) =>
+              phasesAfterCurrent.has(s.phase) &&
+              s.status !== "completed" &&
+              s.status !== "skipped",
+          )
+          .sort((a, b) => a.step_number - b.step_number)[0]?.phase as
+          | JourneyPhase
+          | undefined
+
         return (
           <div
             key={group.phase}
@@ -316,6 +339,7 @@ function StepListView(props: {
                 currentPhase={group.phase}
                 activePhaseKeys={navPhases.map((p) => p.key)}
                 onContinue={handleContinueToPhase}
+                nextPhaseKey={nextPhaseByStepOrder}
               />
             )}
           </div>

--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -274,9 +274,6 @@ function StepListView(props: {
         const isComplete = group.steps.every(
           (s) => s.status === "completed" || s.status === "skipped",
         )
-        const nextGroup = phaseGroups[groupIndex + 1]
-        const nextPhaseStarted =
-          nextGroup?.steps.some((s) => s.status !== "not_started") ?? false
         const phaseLabel =
           JOURNEY_PHASES.find((p) => p.key === group.phase)?.label ??
           group.phase
@@ -302,6 +299,17 @@ function StepListView(props: {
           .sort((a, b) => a.step_number - b.step_number)[0]?.phase as
           | JourneyPhase
           | undefined
+
+        // Don't show the CTA if the next phase (by step order) has already started.
+        // Falls back to canonical next phase group if no step-order next is found.
+        const nextPhaseStartedGroup = nextPhaseByStepOrder
+          ? (phaseGroups.find((g) => g.phase === nextPhaseByStepOrder) ??
+            phaseGroups[groupIndex + 1])
+          : phaseGroups[groupIndex + 1]
+        const nextPhaseStarted =
+          nextPhaseStartedGroup?.steps.some(
+            (s) => s.status !== "not_started",
+          ) ?? false
 
         return (
           <div

--- a/frontend/src/components/Journey/PhaseCompletionCta.tsx
+++ b/frontend/src/components/Journey/PhaseCompletionCta.tsx
@@ -16,6 +16,14 @@ interface IProps {
   /** Keys of phases that have steps in this journey (determines next-phase target). */
   activePhaseKeys: string[]
   onContinue: (nextPhase: JourneyPhase) => void
+  /**
+   * Override the canonical next phase. When provided, this phase is used as
+   * the navigation target instead of the canonical JOURNEY_PHASES successor.
+   * Use this to navigate to the phase containing the first incomplete step
+   * (by step_number), which may differ from the canonical order for journeys
+   * where steps span phases non-sequentially (e.g. rent_out investors).
+   */
+  nextPhaseKey?: JourneyPhase
 }
 
 /******************************************************************************
@@ -24,7 +32,7 @@ interface IProps {
 
 /** Default component. Phase completion CTA card. */
 function PhaseCompletionCta(props: Readonly<IProps>) {
-  const { currentPhase, activePhaseKeys, onContinue } = props
+  const { currentPhase, activePhaseKeys, onContinue, nextPhaseKey } = props
 
   // Only consider phases that actually have steps in this journey, preserving
   // canonical JOURNEY_PHASES order.
@@ -33,9 +41,19 @@ function PhaseCompletionCta(props: Readonly<IProps>) {
   )
 
   const phaseIndex = visiblePhases.findIndex((p) => p.key === currentPhase)
-  const isLastPhase =
+  const canonicalIsLast =
     phaseIndex === -1 || phaseIndex === visiblePhases.length - 1
-  const nextPhase = isLastPhase ? null : visiblePhases[phaseIndex + 1]
+  const canonicalNext = canonicalIsLast ? null : visiblePhases[phaseIndex + 1]
+
+  // Use the explicit override if provided, otherwise fall back to the canonical
+  // successor. The override ensures users navigate to the section that actually
+  // contains their next incomplete step, rather than the canonical next phase
+  // (which can differ when steps span phases non-sequentially).
+  const nextPhase = nextPhaseKey
+    ? (visiblePhases.find((p) => p.key === nextPhaseKey) ?? canonicalNext)
+    : canonicalNext
+  const isLastPhase = nextPhase === null
+
   const currentLabel = visiblePhases[phaseIndex]?.label ?? currentPhase
 
   if (isLastPhase) {

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -63,12 +63,36 @@ function StepTabView(props: IProps) {
   const effectivePhaseIndex = visiblePhases.findIndex(
     (p) => p.key === effectivePhase,
   )
-  const nextPhaseKey = visiblePhases[effectivePhaseIndex + 1]?.key as
+  const canonicalNextPhaseKey = visiblePhases[effectivePhaseIndex + 1]?.key as
     | JourneyPhase
     | undefined
-  const nextPhaseStarted = nextPhaseKey
-    ? stepsByPhase[nextPhaseKey].some((s) => s.status !== "not_started")
+  const nextPhaseStarted = canonicalNextPhaseKey
+    ? stepsByPhase[canonicalNextPhaseKey].some(
+        (s) => s.status !== "not_started",
+      )
     : false
+
+  // Find the phase containing the first incomplete step that comes after
+  // the current phase (by step_number). This ensures the CTA navigates to
+  // the section with the user's actual next step, rather than the canonical
+  // successor — which can differ for rent_out journeys where some phases
+  // have lower step_numbers than earlier canonical phases.
+  const currentPhaseOrder = JOURNEY_PHASES.findIndex(
+    (p) => p.key === effectivePhase,
+  )
+  const phasesAfterCurrent = new Set(
+    JOURNEY_PHASES.slice(currentPhaseOrder + 1).map((p) => p.key),
+  )
+  const nextPhaseByStepOrder = steps
+    .filter(
+      (s) =>
+        phasesAfterCurrent.has(s.phase) &&
+        s.status !== "completed" &&
+        s.status !== "skipped",
+    )
+    .sort((a, b) => a.step_number - b.step_number)[0]?.phase as
+    | JourneyPhase
+    | undefined
 
   const handleContinueToPhase = (nextPhase: JourneyPhase) => {
     setSelectedPhase(nextPhase)
@@ -105,6 +129,7 @@ function StepTabView(props: IProps) {
           currentPhase={effectivePhase}
           activePhaseKeys={visiblePhases.map((p) => p.key)}
           onContinue={handleContinueToPhase}
+          nextPhaseKey={nextPhaseByStepOrder}
         />
       )}
     </div>

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -60,18 +60,6 @@ function StepTabView(props: IProps) {
     phaseSteps.length > 0 &&
     phaseSteps.every((s) => s.status === "completed" || s.status === "skipped")
 
-  const effectivePhaseIndex = visiblePhases.findIndex(
-    (p) => p.key === effectivePhase,
-  )
-  const canonicalNextPhaseKey = visiblePhases[effectivePhaseIndex + 1]?.key as
-    | JourneyPhase
-    | undefined
-  const nextPhaseStarted = canonicalNextPhaseKey
-    ? stepsByPhase[canonicalNextPhaseKey].some(
-        (s) => s.status !== "not_started",
-      )
-    : false
-
   // Find the phase containing the first incomplete step that comes after
   // the current phase (by step_number). This ensures the CTA navigates to
   // the section with the user's actual next step, rather than the canonical
@@ -93,6 +81,11 @@ function StepTabView(props: IProps) {
     .sort((a, b) => a.step_number - b.step_number)[0]?.phase as
     | JourneyPhase
     | undefined
+
+  // Don't show the CTA if the next phase (by step order) has already started.
+  const nextPhaseStarted = nextPhaseByStepOrder
+    ? stepsByPhase[nextPhaseByStepOrder].some((s) => s.status !== "not_started")
+    : false
 
   const handleContinueToPhase = (nextPhase: JourneyPhase) => {
     setSelectedPhase(nextPhase)


### PR DESCRIPTION
## Summary

- For rent_out users, the phase completion CTA after closing showed "Continue to Ownership" (canonical next phase), but the user's first incomplete step by step_number was in `rental_setup`. Clicking navigated to the wrong section.
- Added a `nextPhaseKey` prop to `PhaseCompletionCta` to allow callers to override the canonical next phase with the actual next phase (determined by the first incomplete step's phase, ordered by step_number).
- `StepListView` and `StepTabView` now compute and pass the correct next phase, fixing navigation for rent_out journeys where step_numbers and canonical phase order diverge.

## Test plan

- [ ] Complete closing phase as a rent_out user — CTA now shows correct label (e.g. "Continue to Rental Setup") and navigates to the correct section
- [ ] Complete closing phase as a live_in user — CTA still shows "Continue to Ownership" and navigates correctly
- [ ] Works in both list view and tab view