### PR TITLE
feat(journey): add portfolio cta to all phases complete card

### DIFF
--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -3,9 +3,10 @@
  * Full journey view with all steps and progress
  */
 
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { ArrowLeft, Calendar, Home, MapPin, Trash2, Wallet } from "lucide-react"
 import { useCallback, useMemo, useRef, useState } from "react"
+import { ApiError } from "@/client"
 import {
   FINANCING_TYPES,
   GERMAN_STATES,
@@ -19,6 +20,8 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useCreatePropertyFromJourney } from "@/hooks/mutations"
+import useCustomToast from "@/hooks/useCustomToast"
 import type {
   JourneyPhase,
   JourneyProgress,
@@ -215,8 +218,15 @@ function StepListView(props: {
   activeStepNumber: number
   onTaskToggle: (stepId: string, taskId: string, isCompleted: boolean) => void
   onStepOpen?: (stepId: string) => void
+  onAddToPortfolio?: () => void
 }) {
-  const { steps, activeStepNumber, onTaskToggle, onStepOpen } = props
+  const {
+    steps,
+    activeStepNumber,
+    onTaskToggle,
+    onStepOpen,
+    onAddToPortfolio,
+  } = props
   const phaseRefs = useRef<Record<string, HTMLDivElement | null>>({})
 
   const handleContinueToPhase = useCallback((nextPhase: JourneyPhase) => {
@@ -348,6 +358,7 @@ function StepListView(props: {
                 activePhaseKeys={navPhases.map((p) => p.key)}
                 onContinue={handleContinueToPhase}
                 nextPhaseKey={nextPhaseByStepOrder}
+                onAddToPortfolio={onAddToPortfolio}
               />
             )}
           </div>
@@ -369,6 +380,10 @@ function JourneyDetail(props: IProps) {
     className,
   } = props
 
+  const navigate = useNavigate()
+  const createFromJourney = useCreatePropertyFromJourney()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const stored = localStorage.getItem("heimpath-journey-view-mode")
     return stored === "tab" ? "tab" : "list"
@@ -378,6 +393,26 @@ function JourneyDetail(props: IProps) {
     setViewMode(mode)
     localStorage.setItem("heimpath-journey-view-mode", mode)
   }
+
+  const handleAddToPortfolio = useCallback(() => {
+    if (!journey) return
+    createFromJourney.mutate(journey.id, {
+      onSuccess: (property) => {
+        showSuccessToast("Property added to your portfolio!")
+        navigate({
+          to: "/portfolio/$propertyId",
+          params: { propertyId: property.id },
+        })
+      },
+      onError: (err) => {
+        const message =
+          err instanceof ApiError && err.status === 409
+            ? "This journey is already linked to a portfolio property."
+            : "Failed to create portfolio property. Please try again."
+        showErrorToast(message)
+      },
+    })
+  }, [journey, createFromJourney, navigate, showSuccessToast, showErrorToast])
 
   // JourneyCompletionCta ("Add to Portfolio") is intentionally shown only for
   // buying/investor journeys where the ownership phase exists. Pure rental
@@ -476,6 +511,9 @@ function JourneyDetail(props: IProps) {
                 activeStepNumber={journey.current_step_number}
                 onTaskToggle={onTaskToggle}
                 onStepOpen={onStepOpen}
+                onAddToPortfolio={
+                  isOwnershipComplete ? handleAddToPortfolio : undefined
+                }
               />
             ) : (
               <StepTabView
@@ -483,6 +521,9 @@ function JourneyDetail(props: IProps) {
                 activeStepNumber={journey.current_step_number}
                 onTaskToggle={onTaskToggle}
                 onStepOpen={onStepOpen}
+                onAddToPortfolio={
+                  isOwnershipComplete ? handleAddToPortfolio : undefined
+                }
               />
             )}
           </div>

--- a/frontend/src/components/Journey/PhaseCompletionCta.tsx
+++ b/frontend/src/components/Journey/PhaseCompletionCta.tsx
@@ -4,7 +4,7 @@
  * or a "Journey Complete" message on the last phase.
  */
 
-import { ArrowRight, CheckCircle2, PartyPopper } from "lucide-react"
+import { ArrowRight, Building2, CheckCircle2, PartyPopper } from "lucide-react"
 
 import { JOURNEY_PHASES } from "@/common/constants"
 import { Button } from "@/components/ui/button"
@@ -24,6 +24,8 @@ interface IProps {
    * where steps span phases non-sequentially (e.g. rent_out investors).
    */
   nextPhaseKey?: JourneyPhase
+  /** Called when the user clicks "Add to Portfolio" on the all-phases-complete card. */
+  onAddToPortfolio?: () => void
 }
 
 /******************************************************************************
@@ -32,7 +34,13 @@ interface IProps {
 
 /** Default component. Phase completion CTA card. */
 function PhaseCompletionCta(props: Readonly<IProps>) {
-  const { currentPhase, activePhaseKeys, onContinue, nextPhaseKey } = props
+  const {
+    currentPhase,
+    activePhaseKeys,
+    onContinue,
+    nextPhaseKey,
+    onAddToPortfolio,
+  } = props
 
   // Only consider phases that actually have steps in this journey, preserving
   // canonical JOURNEY_PHASES order.
@@ -72,6 +80,12 @@ function PhaseCompletionCta(props: Readonly<IProps>) {
               journey.
             </p>
           </div>
+          {onAddToPortfolio && (
+            <Button className="shrink-0 gap-2" onClick={onAddToPortfolio}>
+              <Building2 className="h-4 w-4" />
+              Add to Portfolio
+            </Button>
+          )}
         </CardContent>
       </Card>
     )

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -16,6 +16,7 @@ interface IProps {
   activeStepNumber: number
   onTaskToggle: (stepId: string, taskId: string, isCompleted: boolean) => void
   onStepOpen?: (stepId: string) => void
+  onAddToPortfolio?: () => void
 }
 
 /******************************************************************************
@@ -23,7 +24,13 @@ interface IProps {
 ******************************************************************************/
 
 function StepTabView(props: IProps) {
-  const { steps, activeStepNumber, onTaskToggle, onStepOpen } = props
+  const {
+    steps,
+    activeStepNumber,
+    onTaskToggle,
+    onStepOpen,
+    onAddToPortfolio,
+  } = props
 
   const activeStep = steps.find((s) => s.step_number === activeStepNumber)
   const defaultPhase = activeStep?.phase ?? "research"
@@ -123,6 +130,7 @@ function StepTabView(props: IProps) {
           activePhaseKeys={visiblePhases.map((p) => p.key)}
           onContinue={handleContinueToPhase}
           nextPhaseKey={nextPhaseByStepOrder}
+          onAddToPortfolio={onAddToPortfolio}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Adds an "Add to Portfolio" button to the green "All phases complete!" card in `PhaseCompletionCta`
- The button is shown in both list view (StepListView) and tab view (StepTabView) when all phases are complete
- Threads an `onAddToPortfolio` callback from `JourneyDetail` → `StepListView`/`StepTabView` → `PhaseCompletionCta`, only provided when `isOwnershipComplete` is true (same guard as the existing top-of-page `JourneyCompletionCta`)

## Test plan
- [ ] Complete all journey phases — "All phases complete!" card shows "Add to Portfolio" button
- [ ] Clicking the button creates a portfolio property and navigates to it
- [ ] Clicking again shows "already linked" toast (409 handling)
- [ ] Works in both list view and tab view