### PR TITLE
feat(journey): show 'view journey' label on completed journey cards

### DIFF
--- a/frontend/src/components/Journey/JourneyCard.tsx
+++ b/frontend/src/components/Journey/JourneyCard.tsx
@@ -136,7 +136,7 @@ function JourneyCard(props: IProps) {
       <CardFooter className="mt-auto pt-0">
         <Button asChild className="w-full gap-2">
           <Link to="/journeys/$journeyId" params={{ journeyId: journey.id }}>
-            Continue Journey
+            {journey.completed_at ? "View Journey" : "Continue Journey"}
             <ArrowRight className="h-4 w-4" />
           </Link>
         </Button>


### PR DESCRIPTION
## Summary
- Journey cards now display "View Journey" instead of "Continue Journey" when the journey is complete (`completed_at` is set)
- Incomplete journeys continue to show "Continue Journey"

## Test plan
- [ ] Open journeys list — incomplete journeys show "Continue Journey"
- [ ] Complete all steps in a journey — card should switch to "View Journey"
- [ ] Clicking "View Journey" navigates correctly to the journey detail page