### PR TITLE
feat(journey): make tab view the default journey steps view

### DIFF
--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -425,7 +425,7 @@ function JourneyDetail(props: IProps) {
 
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const stored = localStorage.getItem("heimpath-journey-view-mode")
-    return stored === "tab" ? "tab" : "list"
+    return stored === "list" ? "list" : "tab"
   })
 
   const handleViewModeChange = (mode: ViewMode) => {


### PR DESCRIPTION
## Summary
- Tab view is now the default view when opening the journey steps page
- Users who have previously selected list view (stored in localStorage) continue to see list view
- The only change is the fallback when no preference is stored

## Test plan
- [ ] Clear localStorage — journey page opens in tab view
- [ ] Switch to list view, reload — list view is preserved
- [ ] Switch to tab view, reload — tab view is preserved