### PR TITLE
feat(contracts): add purchase price extraction and eval calculator bridge

### DIFF
--- a/backend/app/alembic/versions/h3i4j5k6l7m8_add_purchase_price_to_contract_analysis.py
+++ b/backend/app/alembic/versions/h3i4j5k6l7m8_add_purchase_price_to_contract_analysis.py
@@ -1,0 +1,29 @@
+"""Add purchase_price to contract_analysis
+
+Revision ID: h3i4j5k6l7m8
+Revises: e1h2i3j4k5l6
+Create Date: 2026-04-24 21:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision: str = "h3i4j5k6l7m8"
+down_revision: str | None = "e1h2i3j4k5l6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "contract_analysis",
+        sa.Column("purchase_price", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("contract_analysis", "purchase_price")

--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -69,6 +69,7 @@ def _build_response(
         overall_risk_explanation=record.overall_risk_explanation
         if is_premium
         else None,
+        purchase_price=record.purchase_price,
         clause_count=len(all_clauses),
         is_truncated=is_truncated,
         created_at=record.created_at,

--- a/backend/app/models/contract.py
+++ b/backend/app/models/contract.py
@@ -1,6 +1,6 @@
 """Contract analysis database model."""
 
-from sqlalchemy import Column, ForeignKey, String, Text
+from sqlalchemy import Column, Float, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import relationship
 
@@ -27,6 +27,9 @@ class ContractAnalysis(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     notary_checklist = Column(JSON, nullable=True)
     overall_risk_assessment = Column(String(10), nullable=True)
     overall_risk_explanation = Column(Text, nullable=True)
+
+    # Extracted financial data
+    purchase_price = Column(Float, nullable=True)
 
     # Relationships
     user = relationship("User", back_populates="contract_analyses")

--- a/backend/app/schemas/contract.py
+++ b/backend/app/schemas/contract.py
@@ -44,6 +44,7 @@ class ContractAnalysisResponse(BaseModel):
     notary_checklist: list[NotaryQuestion] | None
     overall_risk_assessment: str | None
     overall_risk_explanation: str | None
+    purchase_price: float | None = None
     clause_count: int
     is_truncated: bool
     created_at: datetime

--- a/backend/app/services/clause_analyzer_service.py
+++ b/backend/app/services/clause_analyzer_service.py
@@ -41,6 +41,7 @@ SYSTEM_PROMPT = """You are a German real estate legal expert helping foreign buy
    - "priority": "essential" (must ask), "recommended" (should ask), or "optional" (nice to know)
 4. **overall_risk_assessment**: "low", "medium", or "high"
 5. **overall_risk_explanation**: 1-2 sentence explanation of the overall risk level.
+6. **purchase_price_euros**: The purchase price as a plain number in euros (digits only, no currency symbols, no thousands separators). Extract this from the Kaufpreis section. Return null if not clearly stated.
 
 Return ONLY valid JSON. No markdown, no explanation outside the JSON."""
 

--- a/backend/app/services/contract_service.py
+++ b/backend/app/services/contract_service.py
@@ -86,6 +86,10 @@ async def analyze_contract_pdf(
         record.notary_checklist = analysis_data.get("notary_checklist", [])
         record.overall_risk_assessment = analysis_data.get("overall_risk_assessment")
         record.overall_risk_explanation = analysis_data.get("overall_risk_explanation")
+        raw_price = analysis_data.get("purchase_price_euros")
+        record.purchase_price = (
+            float(raw_price) if isinstance(raw_price, (int, float)) else None
+        )
 
     session.add(record)
     session.commit()

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1565,6 +1565,17 @@ export const ContractAnalysisResponseSchema = {
             ],
             title: 'Overall Risk Explanation'
         },
+        purchase_price: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Purchase Price'
+        },
         clause_count: {
             type: 'integer',
             title: 'Clause Count'

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -463,6 +463,7 @@ export type ContractAnalysisResponse = {
     notary_checklist: (Array<app__schemas__contract__NotaryQuestion> | null);
     overall_risk_assessment: (string | null);
     overall_risk_explanation: (string | null);
+    purchase_price?: (number | null);
     clause_count: number;
     is_truncated: boolean;
     created_at: string;

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/PropertyEvaluationCalculator.tsx
@@ -276,6 +276,7 @@ function PropertyEvaluationCalculator(
     journeyStepId,
     initialState,
     initialBudget,
+    initialPurchasePrice,
     propertyUse,
     className,
   } = props
@@ -283,7 +284,11 @@ function PropertyEvaluationCalculator(
   const isOwnerOccupier = propertyUse === "live_in"
 
   const [state, setState] = useState<PropertyEvaluationState>(() =>
-    loadFromStorage(journeyId, initialState, initialBudget),
+    loadFromStorage(
+      journeyId,
+      initialState,
+      initialPurchasePrice ?? initialBudget,
+    ),
   )
   const [saveName, setSaveName] = useState("")
   const [shareUrl, setShareUrl] = useState("")

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/types.ts
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/types.ts
@@ -18,6 +18,7 @@ export interface PropertyEvaluationCalculatorProps {
   journeyStepId?: string
   initialState?: string // German state code for transfer tax
   initialBudget?: number
+  initialPurchasePrice?: number
   propertyUse?: "live_in" | "rent_out"
   className?: string
 }

--- a/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
+++ b/frontend/src/components/ContractExplainer/ContractExplainerPage.tsx
@@ -3,9 +3,10 @@
  * Upload a German Kaufvertrag PDF and receive an AI clause-by-clause analysis
  */
 
-import { useNavigate } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import {
   AlertTriangle,
+  Calculator,
   CheckSquare,
   Copy,
   FileText,
@@ -259,6 +260,37 @@ function AnalysisResults(props: Readonly<IResultsProps>) {
                 </div>
               </>
             )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Evaluate this property CTA */}
+      {analysis.purchasePrice != null && analysis.purchasePrice > 0 && (
+        <Card className="border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30">
+          <CardContent className="flex flex-col items-center gap-3 py-4 text-center sm:flex-row sm:text-left">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/50">
+              <Calculator className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+                Purchase price detected: €
+                {analysis.purchasePrice.toLocaleString("de-DE")}
+              </p>
+              <p className="text-xs text-blue-700 dark:text-blue-300">
+                Analyse this property's investment return instantly.
+              </p>
+            </div>
+            <Button asChild size="sm" className="shrink-0">
+              <Link
+                to="/calculators"
+                search={{
+                  tab: "property-evaluation",
+                  purchasePrice: analysis.purchasePrice,
+                }}
+              >
+                Evaluate this property
+              </Link>
+            </Button>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/models/contract.ts
+++ b/frontend/src/models/contract.ts
@@ -32,6 +32,7 @@ export interface ContractAnalysis {
   notaryChecklist: NotaryQuestion[] | null
   overallRiskAssessment: RiskLevel | null
   overallRiskExplanation: string | null
+  purchasePrice: number | null
   clauseCount: number
   isTruncated: boolean
   createdAt: string

--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -35,8 +35,16 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export const Route = createFileRoute("/_layout/calculators")({
   component: CalculatorsPage,
-  validateSearch: (search: Record<string, unknown>): { tab?: string } => ({
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: string; purchasePrice?: number } => ({
     tab: (search.tab as string) || undefined,
+    purchasePrice:
+      typeof search.purchasePrice === "number"
+        ? search.purchasePrice
+        : typeof search.purchasePrice === "string"
+          ? Number.parseFloat(search.purchasePrice) || undefined
+          : undefined,
   }),
   head: () => ({
     meta: [{ title: "Calculators - HeimPath" }],
@@ -49,7 +57,7 @@ export const Route = createFileRoute("/_layout/calculators")({
 
 /** Default component. Calculators page with tabs. */
 function CalculatorsPage() {
-  const { tab } = Route.useSearch()
+  const { tab, purchasePrice } = Route.useSearch()
 
   return (
     <div className="min-w-0 space-y-6">
@@ -152,7 +160,7 @@ function CalculatorsPage() {
         </TabsContent>
 
         <TabsContent value="property-evaluation" className="mt-6">
-          <PropertyEvaluationCalculator />
+          <PropertyEvaluationCalculator initialPurchasePrice={purchasePrice} />
         </TabsContent>
 
         <TabsContent value="ownership" className="mt-6">


### PR DESCRIPTION
## Summary
- AI clause analysis now extracts the purchase price from the Kaufpreis section of the Kaufvertrag
- New `purchase_price` field added to `ContractAnalysis` model + Alembic migration
- Contract Explainer results page shows a blue "Evaluate this property" CTA when a purchase price is found
- Clicking the CTA navigates to `/calculators?tab=property-evaluation&purchasePrice=<price>`
- Property Evaluation Calculator pre-populates the purchase price field from the URL param
- The bridge reduces friction between legal review and financial decision making

## Files changed
- Backend: model, schema, route, clause analyzer, contract service
- Migration: `h3i4j5k6l7m8_add_purchase_price_to_contract_analysis.py`
- Frontend: contract model, ContractExplainerPage, PropertyEvaluationCalculator, calculators route

## Test plan
- [ ] Upload a Kaufvertrag PDF — analysis extracts purchase price if present
- [ ] "Evaluate this property" CTA appears when price is found, hidden when not
- [ ] Clicking CTA navigates to calculators with correct query params
- [ ] Calculator pre-populates purchase price from URL
- [ ] No CTA shown when purchase price is null or 0
- [ ] Existing calculator functionality unaffected