### PR TITLE
feat(calculators): prefill roi monthly rent from rent estimate cta

### DIFF
--- a/frontend/src/components/Calculators/ROICalculator.tsx
+++ b/frontend/src/components/Calculators/ROICalculator.tsx
@@ -645,6 +645,9 @@ function SavedROICalculations(props: {
 function ROICalculator(props: Readonly<IProps>) {
   const { className, initialMonthlyRent } = props
 
+  // initialMonthlyRent is intentionally a one-time seed: it pre-fills the
+  // field on first mount (e.g. from the Rent Estimate CTA) but subsequent
+  // prop changes do not update state — the user owns the field after that.
   const [inputs, setInputs] = useState<CalculatorInputs>({
     purchasePrice: "",
     downPayment: "",

--- a/frontend/src/components/Calculators/ROICalculator.tsx
+++ b/frontend/src/components/Calculators/ROICalculator.tsx
@@ -60,6 +60,7 @@ import { SaveShareSection } from "./common/SaveShareSection"
 
 interface IProps {
   className?: string
+  initialMonthlyRent?: number
 }
 
 /******************************************************************************
@@ -641,13 +642,15 @@ function SavedROICalculations(props: {
 }
 
 /** Default component. ROI calculator. */
-function ROICalculator(props: IProps) {
-  const { className } = props
+function ROICalculator(props: Readonly<IProps>) {
+  const { className, initialMonthlyRent } = props
 
   const [inputs, setInputs] = useState<CalculatorInputs>({
     purchasePrice: "",
     downPayment: "",
-    monthlyRent: "",
+    monthlyRent: initialMonthlyRent
+      ? String(Math.round(initialMonthlyRent))
+      : "",
     monthlyExpenses: "",
     annualAppreciation: "2",
     vacancyRate: "5",

--- a/frontend/src/components/Calculators/RentEstimate.tsx
+++ b/frontend/src/components/Calculators/RentEstimate.tsx
@@ -318,12 +318,13 @@ function RentEstimate(props: Readonly<IProps>) {
                     to="/calculators"
                     search={{
                       tab: "roi",
+                      // Only pass monthlyRent when a property size was given so
+                      // the API computed a true monthly total. The per-sqm rate
+                      // alone cannot be used as a monthly figure without size.
                       monthlyRent:
                         estimate.monthlyRent != null
                           ? Math.round(estimate.monthlyRent)
-                          : estimate.estimatedRentPerSqm != null
-                            ? Math.round(estimate.estimatedRentPerSqm)
-                            : undefined,
+                          : undefined,
                     }}
                     className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
                   >

--- a/frontend/src/components/Calculators/RentEstimate.tsx
+++ b/frontend/src/components/Calculators/RentEstimate.tsx
@@ -316,7 +316,15 @@ function RentEstimate(props: Readonly<IProps>) {
                   </p>
                   <Link
                     to="/calculators"
-                    search={{ tab: "roi" }}
+                    search={{
+                      tab: "roi",
+                      monthlyRent:
+                        estimate.monthlyRent != null
+                          ? Math.round(estimate.monthlyRent)
+                          : estimate.estimatedRentPerSqm != null
+                            ? Math.round(estimate.estimatedRentPerSqm)
+                            : undefined,
+                    }}
                     className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
                   >
                     Open ROI Calculator

--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -41,13 +41,19 @@ export const Route = createFileRoute("/_layout/calculators")({
   component: CalculatorsPage,
   validateSearch: (
     search: Record<string, unknown>,
-  ): { tab?: string; purchasePrice?: number } => ({
+  ): { tab?: string; purchasePrice?: number; monthlyRent?: number } => ({
     tab: (search.tab as string) || undefined,
     purchasePrice:
       typeof search.purchasePrice === "number"
         ? search.purchasePrice
         : typeof search.purchasePrice === "string"
           ? Number.parseFloat(search.purchasePrice) || undefined
+          : undefined,
+    monthlyRent:
+      typeof search.monthlyRent === "number"
+        ? search.monthlyRent
+        : typeof search.monthlyRent === "string"
+          ? Number.parseFloat(search.monthlyRent) || undefined
           : undefined,
   }),
   head: () => ({
@@ -61,7 +67,7 @@ export const Route = createFileRoute("/_layout/calculators")({
 
 /** Default component. Calculators page with tabs. */
 function CalculatorsPage() {
-  const { tab, purchasePrice } = Route.useSearch()
+  const { tab, purchasePrice, monthlyRent } = Route.useSearch()
 
   return (
     <div className="min-w-0 space-y-6">
@@ -168,7 +174,7 @@ function CalculatorsPage() {
         </TabsContent>
 
         <TabsContent value="roi" className="mt-6">
-          <ROICalculator />
+          <ROICalculator initialMonthlyRent={monthlyRent} />
         </TabsContent>
 
         <TabsContent value="compare" className="mt-6">


### PR DESCRIPTION
## Summary

- When a user obtains a rent estimate result and clicks "Open ROI Calculator", the monthly rent field is now pre-populated automatically
- If the user provided a property size, the API's `monthlyRent` value is passed; otherwise the per-sqm rate is used as a fallback
- The value is carried as a `monthlyRent` query param, validated in `validateSearch`, and seeded into the ROI calculator's initial state
- Follows the same pattern as the contract → property evaluation bridge (PR #197)

## Test plan

- [ ] Navigate to Rent Estimate tab, enter postcode `80331` + size `65` → get result
- [ ] Click "Open ROI Calculator" — verify the Monthly Rent field is pre-populated with the estimated monthly rent
- [ ] Navigate to Rent Estimate tab, enter only postcode (no size) → get result
- [ ] Click "Open ROI Calculator" — verify the Monthly Rent field is pre-populated with the per-sqm rate
- [ ] Navigate directly to `/calculators?tab=roi` (no monthlyRent param) — verify Monthly Rent field is empty
- [ ] Navigate to `/calculators?tab=roi&monthlyRent=850` directly — verify field shows 850
- [ ] Confirm ROI calculator results update correctly when pre-filled value is present