### PR TITLE
fix(security): harden proxy trust, token lifetimes, and migration DDL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ STACK_NAME=heimpath
 BACKEND_CORS_ORIGINS="http://localhost,http://localhost:5173,https://localhost,https://localhost:5173"
 # Generate with: openssl rand -hex 32
 SECRET_KEY=changethis
+# Comma-separated trusted proxy IPs for X-Forwarded-* headers.
+# In production, set to the Azure Container Apps load balancer CIDR (e.g. "10.0.0.0/8").
+# Leave as "*" only if the container is protected by platform-level network ingress controls.
+TRUSTED_PROXY_IPS=*
 FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=changethis
 

--- a/backend/app/alembic/versions/c3d4e5f6a7b8_add_journey_tables.py
+++ b/backend/app/alembic/versions/c3d4e5f6a7b8_add_journey_tables.py
@@ -22,23 +22,34 @@ def upgrade() -> None:
     connection = op.get_bind()
 
     # Check and create each enum type
-    for enum_name, values in [
-        ('journeyphase', ['research', 'preparation', 'buying', 'closing']),
-        ('stepstatus', ['not_started', 'in_progress', 'completed', 'skipped']),
-        ('propertytype', ['apartment', 'house', 'land', 'commercial']),
-        ('financingtype', ['cash', 'mortgage', 'mixed']),
+    for enum_sql, check_name in [
+        (
+            "CREATE TYPE journeyphase AS ENUM "
+            "('research', 'preparation', 'buying', 'closing')",
+            "journeyphase",
+        ),
+        (
+            "CREATE TYPE stepstatus AS ENUM "
+            "('not_started', 'in_progress', 'completed', 'skipped')",
+            "stepstatus",
+        ),
+        (
+            "CREATE TYPE propertytype AS ENUM "
+            "('apartment', 'house', 'land', 'commercial')",
+            "propertytype",
+        ),
+        (
+            "CREATE TYPE financingtype AS ENUM ('cash', 'mortgage', 'mixed')",
+            "financingtype",
+        ),
     ]:
         # Check if type exists
         result = connection.execute(
             sa.text("SELECT 1 FROM pg_type WHERE typname = :name"),
-            {"name": enum_name}
+            {"name": check_name},
         )
         if not result.fetchone():
-            # Create the enum type
-            values_str = ", ".join(f"'{v}'" for v in values)
-            connection.execute(
-                sa.text(f"CREATE TYPE {enum_name} AS ENUM ({values_str})")
-            )
+            connection.execute(sa.text(enum_sql))
 
     # Define enum types that won't auto-create
     journeyphase = postgresql.ENUM(

--- a/backend/app/alembic/versions/d4e5f6a7b8c9_add_legal_knowledge_base_tables.py
+++ b/backend/app/alembic/versions/d4e5f6a7b8c9_add_legal_knowledge_base_tables.py
@@ -20,20 +20,25 @@ def upgrade() -> None:
     # Create enum types using raw SQL with existence check
     connection = op.get_bind()
 
-    for enum_name, values in [
-        ('lawcategory', ['buying_process', 'costs_and_taxes', 'rental_law', 'condominium', 'agent_regulations']),
-        ('propertyapplicability', ['all', 'apartment', 'house', 'land', 'commercial']),
+    for enum_sql, check_name in [
+        (
+            "CREATE TYPE lawcategory AS ENUM "
+            "('buying_process', 'costs_and_taxes', 'rental_law', 'condominium', 'agent_regulations')",
+            "lawcategory",
+        ),
+        (
+            "CREATE TYPE propertyapplicability AS ENUM "
+            "('all', 'apartment', 'house', 'land', 'commercial')",
+            "propertyapplicability",
+        ),
     ]:
         # Check if type exists
         result = connection.execute(
             sa.text("SELECT 1 FROM pg_type WHERE typname = :name"),
-            {"name": enum_name}
+            {"name": check_name},
         )
         if not result.fetchone():
-            values_str = ", ".join(f"'{v}'" for v in values)
-            connection.execute(
-                sa.text(f"CREATE TYPE {enum_name} AS ENUM ({values_str})")
-            )
+            connection.execute(sa.text(enum_sql))
 
     # Define enums for use in table creation
     lawcategory = postgresql.ENUM(

--- a/backend/app/alembic/versions/k1f2g3h4i5j6_add_article_tables.py
+++ b/backend/app/alembic/versions/k1f2g3h4i5j6_add_article_tables.py
@@ -20,20 +20,28 @@ def upgrade() -> None:
     # Create enum types with existence check
     connection = op.get_bind()
 
-    for enum_name, values in [
-        ('articlecategory', ['buying_process', 'costs_and_taxes', 'regulations', 'common_pitfalls']),
-        ('articlestatus', ['draft', 'published', 'archived']),
-        ('difficultylevel', ['beginner', 'intermediate', 'advanced']),
+    for enum_sql, check_name in [
+        (
+            "CREATE TYPE articlecategory AS ENUM "
+            "('buying_process', 'costs_and_taxes', 'regulations', 'common_pitfalls')",
+            "articlecategory",
+        ),
+        (
+            "CREATE TYPE articlestatus AS ENUM ('draft', 'published', 'archived')",
+            "articlestatus",
+        ),
+        (
+            "CREATE TYPE difficultylevel AS ENUM "
+            "('beginner', 'intermediate', 'advanced')",
+            "difficultylevel",
+        ),
     ]:
         result = connection.execute(
             sa.text("SELECT 1 FROM pg_type WHERE typname = :name"),
-            {"name": enum_name}
+            {"name": check_name},
         )
         if not result.fetchone():
-            values_str = ", ".join(f"'{v}'" for v in values)
-            connection.execute(
-                sa.text(f"CREATE TYPE {enum_name} AS ENUM ({values_str})")
-            )
+            connection.execute(sa.text(enum_sql))
 
     # Define enums for table creation
     articlecategory = postgresql.ENUM(

--- a/backend/app/alembic/versions/s0o1p2q3r4t5_add_professional_tables.py
+++ b/backend/app/alembic/versions/s0o1p2q3r4t5_add_professional_tables.py
@@ -22,17 +22,14 @@ def upgrade() -> None:
 
     result = connection.execute(
         sa.text("SELECT 1 FROM pg_type WHERE typname = :name"),
-        {"name": "professionaltype"}
+        {"name": "professionaltype"},
     )
     if not result.fetchone():
-        values_str = ", ".join(
-            f"'{v}'" for v in [
-                'lawyer', 'notary', 'tax_advisor',
-                'mortgage_broker', 'real_estate_agent',
-            ]
-        )
         connection.execute(
-            sa.text(f"CREATE TYPE professionaltype AS ENUM ({values_str})")
+            sa.text(
+                "CREATE TYPE professionaltype AS ENUM "
+                "('lawyer', 'notary', 'tax_advisor', 'mortgage_broker', 'real_estate_agent')"
+            )
         )
 
     # Define enum for table creation

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,13 +33,16 @@ class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
     SECRET_KEY: str = secrets.token_urlsafe(32)
     # Token expiration settings
-    ACCESS_TOKEN_EXPIRE_HOURS: int = 24
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
     REMEMBER_ME_EXPIRE_DAYS: int = 30
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     # Redis (token blacklist + rate limiting)
     REDIS_URL: str = "redis://localhost:6379"
-    # Legacy setting (kept for backward compatibility)
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
+    # Comma-separated list of trusted proxy IPs for X-Forwarded-* headers.
+    # In production, scope this to the Azure load balancer CIDR (e.g. "10.0.0.0/8").
+    # "*" trusts all sources and should only be used when the container is not
+    # directly reachable from the internet (e.g. protected by Azure Container Apps ingress).
+    TRUSTED_PROXY_IPS: str = "*"
     FRONTEND_HOST: str = "http://localhost:5173"
     ENVIRONMENT: Literal["local", "staging", "production"] = "local"
 
@@ -114,7 +117,7 @@ class Settings(BaseSettings):
     # SendGrid (preferred over SMTP when configured)
     SENDGRID_API_KEY: str | None = None
 
-    EMAIL_RESET_TOKEN_EXPIRE_HOURS: int = 48
+    EMAIL_RESET_TOKEN_EXPIRE_HOURS: int = 1
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,8 +31,13 @@ if settings.all_cors_origins:
         allow_headers=["*"],
     )
 
-# Trust proxy headers (X-Forwarded-Proto, X-Forwarded-For) from Azure Container Apps
+# Trust proxy headers (X-Forwarded-Proto, X-Forwarded-For) from Azure Container Apps.
+# trusted_hosts is controlled by TRUSTED_PROXY_IPS in config; set it to the load
+# balancer CIDR in production rather than leaving it as "*".
 if settings.ENVIRONMENT != "local":
-    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["*"])
+    app.add_middleware(
+        ProxyHeadersMiddleware,
+        trusted_hosts=settings.TRUSTED_PROXY_IPS.split(","),
+    )
 
 app.include_router(api_router, prefix=settings.API_V1_STR)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -77,7 +77,7 @@ def create_access_token(
         )
     else:
         expire = datetime.now(timezone.utc) + timedelta(
-            hours=settings.ACCESS_TOKEN_EXPIRE_HOURS
+            minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
         )
 
     to_encode: dict[str, Any] = {

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -62,9 +62,9 @@ def create_access_token(
     Args:
         subject: The user ID to embed as the ``sub`` claim.
         expires_delta: Custom lifetime. Overrides ``remember_me`` and the
-            default 24-hour window when provided.
+            default 1-hour window when provided.
         remember_me: When *True* the token lives for
-            ``settings.REMEMBER_ME_EXPIRE_DAYS`` days instead of 24 hours.
+            ``settings.REMEMBER_ME_EXPIRE_DAYS`` days instead of 1 hour.
 
     Returns:
         Encoded JWT string.

--- a/backend/tests/services/test_auth_service.py
+++ b/backend/tests/services/test_auth_service.py
@@ -71,13 +71,13 @@ class TestCreateAccessToken:
         token = create_access_token(subject=str(uuid.uuid4()))
         assert isinstance(token, str) and len(token) > 0
 
-    def test_default_expiry_24h(self) -> None:
+    def test_default_expiry_1h(self) -> None:
         token = create_access_token(subject=str(uuid.uuid4()))
         payload = decode_token(token)
         assert payload is not None
         exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         diff = exp - datetime.now(timezone.utc)
-        assert timedelta(hours=23) < diff < timedelta(hours=25)
+        assert timedelta(minutes=55) < diff < timedelta(minutes=65)
 
     def test_custom_expiry(self) -> None:
         token = create_access_token(


### PR DESCRIPTION
## Summary

- **Configurable trusted proxy IPs**: `ProxyHeadersMiddleware` now reads `TRUSTED_PROXY_IPS` env var (comma-separated). Defaults to `"*"` locally; set to the Azure Container Apps load balancer CIDR in production to prevent IP spoofing via `X-Forwarded-For`.
- **Reduced JWT access token lifetime**: `ACCESS_TOKEN_EXPIRE_MINUTES` reduced from 192 h (8 days) to 1 h. The duplicate `ACCESS_TOKEN_EXPIRE_HOURS` constant removed; `auth_service.py` updated to use `timedelta(minutes=...)`.
- **Reduced password-reset token lifetime**: `EMAIL_RESET_TOKEN_EXPIRE_HOURS` reduced from 48 h to 1 h, limiting the window for stolen reset links to be abused.
- **Static SQL strings in Alembic migrations**: Four migration files had f-string interpolation inside `sa.text()` calls. Replaced with static string literals, eliminating the theoretical DDL injection surface.

## Test plan

- [ ] Backend tests pass (`docker compose exec backend python -m pytest tests/ -q`)
- [ ] `pre-commit run --all-files` clean
- [ ] Set `TRUSTED_PROXY_IPS=10.0.0.0/8` locally and confirm middleware still resolves client IP correctly
- [ ] Login flow returns access token that expires after ~1 h
- [ ] Password-reset email link expires after ~1 h