### PR TITLE
docs: replace template security policy with heimpath-specific content

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,29 +1,42 @@
 # Security Policy
 
-Security is very important for this project and its community. 🔒
+HeimPath handles sensitive user data — property finances, personal documents, and payment information. Security is taken seriously.
 
-Learn more about it below. 👇
+## Supported Versions
 
-## Versions
-
-The latest version or release is supported.
-
-You are encouraged to write tests for your application and update your versions frequently after ensuring that your tests are passing. This way you will benefit from the latest features, bug fixes, and **security fixes**.
+Only the latest production release is actively supported with security fixes.
 
 ## Reporting a Vulnerability
 
-If you think you found a vulnerability, and even if you are not sure about it, please report it right away by sending an email to: security@tiangolo.com. Please try to be as explicit as possible, describing all the steps and example code to reproduce the security issue.
+**Please do not report security vulnerabilities through public GitHub issues.**
 
-I (the author, [@tiangolo](https://twitter.com/tiangolo)) will review it thoroughly and get back to you.
+If you believe you have found a security vulnerability, report it by emailing:
 
-## Public Discussions
+**security@heimpath.com**
 
-Please restrain from publicly discussing a potential security vulnerability. 🙊
+Include as much detail as possible:
 
-It's better to discuss privately and try to find a solution first, to limit the potential impact as much as possible.
+- A description of the vulnerability and its potential impact
+- Step-by-step instructions to reproduce it
+- Any relevant code, screenshots, or logs
 
----
+We will acknowledge receipt within 48 hours and aim to provide a fix or mitigation within 14 days for critical issues.
 
-Thanks for your help!
+## Disclosure Policy
 
-The community and I thank you for that. 🙇
+Please give us a reasonable amount of time to address the issue before any public disclosure. We will credit reporters in the fix commit unless you prefer to remain anonymous.
+
+## Scope
+
+The following are in scope:
+
+- `heimpath.com` and `staging.heimpath.com`
+- The HeimPath API (`/api/v1/`)
+- Authentication and session management
+- User data access controls
+
+The following are out of scope:
+
+- Vulnerabilities in third-party dependencies (report those upstream)
+- Social engineering attacks
+- Physical security


### PR DESCRIPTION
## Summary

- Removes the `tiangolo/full-stack-fastapi-template` boilerplate content (wrong contact email `security@tiangolo.com`, references to `@tiangolo`)
- Replaces with HeimPath-specific security policy covering contact address (`security@heimpath.com`), SLAs (48h acknowledgement, 14-day critical fix), in-scope/out-of-scope definition, and responsible disclosure terms

## Test plan

- [ ] Confirm GitHub surfaces the updated policy on the Security tab
- [ ] CI passes (docs-only change)