### PR TITLE
fix(calculators): resolve sonarcloud issues in geg and tenant trap

### DIFF
--- a/frontend/src/components/Calculators/GegRetrofitCalculator.tsx
+++ b/frontend/src/components/Calculators/GegRetrofitCalculator.tsx
@@ -323,7 +323,7 @@ const AGE_MULTIPLIER: Record<BuildingYearBracket, number> = {
   pre1950: 1.4,
   "1950-1978": 1.25,
   "1979-1994": 1.1,
-  "1995-2009": 1.0,
+  "1995-2009": 1,
   "2010plus": 0.85,
 }
 
@@ -331,7 +331,7 @@ const AGE_MULTIPLIER: Record<BuildingYearBracket, number> = {
 const TYPE_MULTIPLIER: Record<BuildingType, number> = {
   einfamilienhaus: 1.1,
   mehrfamilienhaus: 0.85,
-  eigentumswohnung: 1.0,
+  eigentumswohnung: 1,
 }
 
 const BUILDING_TYPE_LABELS: Record<BuildingType, string> = {
@@ -451,6 +451,148 @@ function GegRetrofitCalculator(props: Readonly<IProps>) {
   }
 
   const hasUpgrades = results !== null && results.upgrades.length > 0
+
+  function renderResults() {
+    if (results === null) {
+      return (
+        <Card className="flex min-h-[200px] items-center justify-center">
+          <p className="text-sm text-muted-foreground">
+            Enter property size to see retrofit estimates
+          </p>
+        </Card>
+      )
+    }
+    if (!hasUpgrades) {
+      return (
+        <MetricCard
+          label={`Energy class ${inputs.energyClass} — no mandatory upgrades`}
+          value="€0"
+          description="This property meets current GEG standards. No immediate retrofit costs expected."
+          variant="success"
+        />
+      )
+    }
+    return (
+      <>
+        {/* Summary KPIs */}
+        <div className="grid grid-cols-2 gap-3">
+          <MetricCard
+            label="Total gross cost (est.)"
+            value={`${EUR.format(results.totalGrossMin)}–${EUR.format(results.totalGrossMax)}`}
+            description="Before BEG subsidies"
+            variant={energyClassVariant(inputs.energyClass)}
+          />
+          <MetricCard
+            label="BEG subsidy (est.)"
+            value={EUR.format(results.totalSubsidy)}
+            description="Federal BEG programme (BAFA/KfW)"
+            variant="success"
+          />
+          <MetricCard
+            label="Net cost after subsidy"
+            value={`${EUR.format(results.totalNetMin)}–${EUR.format(results.totalNetMax)}`}
+            description="Your estimated out-of-pocket cost"
+            variant={energyClassVariant(inputs.energyClass)}
+          />
+          <MetricCard
+            label={`Monthly cost (${AMORT_YEARS}yr amort.)`}
+            value={`${EUR.format(results.monthlyAmortMin)}–${EUR.format(results.monthlyAmortMax)}`}
+            description="Impact on monthly yield"
+            variant="default"
+          />
+        </div>
+
+        {/* Upgrade list */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Required Upgrades</CardTitle>
+          </CardHeader>
+          <CardContent className="divide-y">
+            {results.upgrades.map((u) => (
+              <div
+                key={u.name}
+                className="flex items-start justify-between gap-2 py-3 text-sm"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium">{u.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {u.mandatoryByYear
+                      ? `Mandatory by ${u.mandatoryByYear} · `
+                      : "Recommended · "}
+                    {Math.round(u.subsidyRate * 100)}% BEG subsidy · {u.source}
+                  </p>
+                </div>
+                <div className="shrink-0 text-right">
+                  <p className="font-medium">
+                    {EUR.format(u.grossMin)}–{EUR.format(u.grossMax)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    net: {EUR.format(u.netMin)}–{EUR.format(u.netMax)}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        {/* Chart */}
+        {results.chartData.length > 0 && (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">
+                Gross vs. Net Cost per Upgrade
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={200}>
+                <BarChart
+                  data={results.chartData}
+                  margin={{ top: 4, right: 8, bottom: 24, left: 8 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fontSize: 9 }}
+                    angle={-30}
+                    textAnchor="end"
+                  />
+                  <YAxis
+                    tickFormatter={(v: number) =>
+                      v >= 1000 ? `${Math.round(v / 1000)}k` : String(v)
+                    }
+                    tick={{ fontSize: 11 }}
+                  />
+                  <Tooltip
+                    formatter={(value, name) => [
+                      EUR.format(Number(value)),
+                      name === "gross" ? "Gross cost" : "Net (after subsidy)",
+                    ]}
+                  />
+                  <Legend
+                    formatter={(value) =>
+                      value === "gross" ? "Gross cost" : "Net (after subsidy)"
+                    }
+                  />
+                  <Bar
+                    dataKey="gross"
+                    fill={Colors.Chart.Amber}
+                    radius={[4, 4, 0, 0]}
+                    name="gross"
+                  />
+                  <Bar
+                    dataKey="net"
+                    fill={Colors.Chart.Blue}
+                    radius={[4, 4, 0, 0]}
+                    name="net"
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        )}
+      </>
+    )
+  }
 
   return (
     <div className={cn("space-y-6", className)}>
@@ -616,146 +758,7 @@ function GegRetrofitCalculator(props: Readonly<IProps>) {
         </Card>
 
         {/* Results */}
-        <div className="space-y-4">
-          {!results ? (
-            <Card className="flex min-h-[200px] items-center justify-center">
-              <p className="text-sm text-muted-foreground">
-                Enter property size to see retrofit estimates
-              </p>
-            </Card>
-          ) : !hasUpgrades ? (
-            <MetricCard
-              label={`Energy class ${inputs.energyClass} — no mandatory upgrades`}
-              value="€0"
-              description="This property meets current GEG standards. No immediate retrofit costs expected."
-              variant="success"
-            />
-          ) : (
-            <>
-              {/* Summary KPIs */}
-              <div className="grid grid-cols-2 gap-3">
-                <MetricCard
-                  label="Total gross cost (est.)"
-                  value={`${EUR.format(results.totalGrossMin)}–${EUR.format(results.totalGrossMax)}`}
-                  description="Before BEG subsidies"
-                  variant={energyClassVariant(inputs.energyClass)}
-                />
-                <MetricCard
-                  label="BEG subsidy (est.)"
-                  value={EUR.format(results.totalSubsidy)}
-                  description="Federal BEG programme (BAFA/KfW)"
-                  variant="success"
-                />
-                <MetricCard
-                  label="Net cost after subsidy"
-                  value={`${EUR.format(results.totalNetMin)}–${EUR.format(results.totalNetMax)}`}
-                  description="Your estimated out-of-pocket cost"
-                  variant={energyClassVariant(inputs.energyClass)}
-                />
-                <MetricCard
-                  label={`Monthly cost (${AMORT_YEARS}yr amort.)`}
-                  value={`${EUR.format(results.monthlyAmortMin)}–${EUR.format(results.monthlyAmortMax)}`}
-                  description="Impact on monthly yield"
-                  variant="default"
-                />
-              </div>
-
-              {/* Upgrade list */}
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm">Required Upgrades</CardTitle>
-                </CardHeader>
-                <CardContent className="divide-y">
-                  {results.upgrades.map((u) => (
-                    <div
-                      key={u.name}
-                      className="flex items-start justify-between gap-2 py-3 text-sm"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="font-medium">{u.name}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {u.mandatoryByYear
-                            ? `Mandatory by ${u.mandatoryByYear} · `
-                            : "Recommended · "}
-                          {Math.round(u.subsidyRate * 100)}% BEG subsidy ·{" "}
-                          {u.source}
-                        </p>
-                      </div>
-                      <div className="shrink-0 text-right">
-                        <p className="font-medium">
-                          {EUR.format(u.grossMin)}–{EUR.format(u.grossMax)}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          net: {EUR.format(u.netMin)}–{EUR.format(u.netMax)}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
-                </CardContent>
-              </Card>
-
-              {/* Chart */}
-              {results.chartData.length > 0 && (
-                <Card>
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-sm">
-                      Gross vs. Net Cost per Upgrade
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <ResponsiveContainer width="100%" height={200}>
-                      <BarChart
-                        data={results.chartData}
-                        margin={{ top: 4, right: 8, bottom: 24, left: 8 }}
-                      >
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis
-                          dataKey="name"
-                          tick={{ fontSize: 9 }}
-                          angle={-30}
-                          textAnchor="end"
-                        />
-                        <YAxis
-                          tickFormatter={(v: number) =>
-                            v >= 1000 ? `${Math.round(v / 1000)}k` : String(v)
-                          }
-                          tick={{ fontSize: 11 }}
-                        />
-                        <Tooltip
-                          formatter={(value, name) => [
-                            EUR.format(Number(value)),
-                            name === "gross"
-                              ? "Gross cost"
-                              : "Net (after subsidy)",
-                          ]}
-                        />
-                        <Legend
-                          formatter={(value) =>
-                            value === "gross"
-                              ? "Gross cost"
-                              : "Net (after subsidy)"
-                          }
-                        />
-                        <Bar
-                          dataKey="gross"
-                          fill={Colors.Chart.Amber}
-                          radius={[4, 4, 0, 0]}
-                          name="gross"
-                        />
-                        <Bar
-                          dataKey="net"
-                          fill={Colors.Chart.Blue}
-                          radius={[4, 4, 0, 0]}
-                          name="net"
-                        />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </CardContent>
-                </Card>
-              )}
-            </>
-          )}
-        </div>
+        <div className="space-y-4">{renderResults()}</div>
       </div>
 
       {/* Educational section */}

--- a/frontend/src/components/Calculators/TenantTrapCalculator.tsx
+++ b/frontend/src/components/Calculators/TenantTrapCalculator.tsx
@@ -79,6 +79,12 @@ const VERDICT_LABEL: Record<StressResults["verdict"], string> = {
   danger: "Critical — portfolio may not survive default scenario",
 }
 
+const VERDICT_BAR_COLOR: Record<StressResults["verdict"], string> = {
+  safe: Colors.Chart.Green,
+  warning: Colors.Chart.Amber,
+  danger: Colors.Chart.Red,
+}
+
 const DEFAULT_INPUTS: CalculatorInputs = {
   numUnits: "",
   avgMonthlyRent: "",
@@ -111,8 +117,8 @@ function formatMonths(months: number): string {
   if (months >= 120) return "10+ years"
   const y = Math.floor(months / 12)
   const m = Math.round(months % 12)
-  if (y === 0) return `${m} month${m !== 1 ? "s" : ""}`
-  if (m === 0) return `${y} year${y !== 1 ? "s" : ""}`
+  if (y === 0) return `${m} month${m === 1 ? "" : "s"}`
+  if (m === 0) return `${y} year${y === 1 ? "" : "s"}`
   return `${y}y ${m}m`
 }
 
@@ -173,12 +179,14 @@ function calculateTenantStress(inputs: CalculatorInputs): StressResults | null {
   const bufferCoverageRatio =
     recommendedBuffer > 0 ? cashReserves / recommendedBuffer : Infinity
 
-  const verdict: StressResults["verdict"] =
-    bufferCoverageRatio >= 1
-      ? "safe"
-      : bufferCoverageRatio >= 0.5
-        ? "warning"
-        : "danger"
+  let verdict: StressResults["verdict"]
+  if (bufferCoverageRatio >= 1) {
+    verdict = "safe"
+  } else if (bufferCoverageRatio >= 0.5) {
+    verdict = "warning"
+  } else {
+    verdict = "danger"
+  }
 
   const chartData = [
     { name: "Cash Reserves", value: Math.round(cashReserves) },
@@ -385,13 +393,7 @@ function TenantTrapCalculator(props: Readonly<IProps>) {
 
         {/* Results */}
         <div className="space-y-4">
-          {!results ? (
-            <Card className="flex min-h-[200px] items-center justify-center">
-              <p className="text-sm text-muted-foreground">
-                Enter portfolio details to run the stress test
-              </p>
-            </Card>
-          ) : (
+          {results ? (
             <>
               {/* Verdict */}
               <Alert
@@ -411,7 +413,7 @@ function TenantTrapCalculator(props: Readonly<IProps>) {
                   {results.nonPayingUnits > 0 && (
                     <span className="ml-1 font-normal">
                       — {results.nonPayingUnits} unit
-                      {results.nonPayingUnits !== 1 ? "s" : ""} non-paying at{" "}
+                      {results.nonPayingUnits === 1 ? "" : "s"} non-paying at{" "}
                       {inputs.nonPayingPct}%
                     </span>
                   )}
@@ -486,13 +488,7 @@ function TenantTrapCalculator(props: Readonly<IProps>) {
                       />
                       <Bar
                         dataKey="value"
-                        fill={
-                          results.verdict === "safe"
-                            ? Colors.Chart.Green
-                            : results.verdict === "warning"
-                              ? Colors.Chart.Amber
-                              : Colors.Chart.Red
-                        }
+                        fill={VERDICT_BAR_COLOR[results.verdict]}
                         radius={[4, 4, 0, 0]}
                       />
                       {results.recommendedBuffer > 0 && (
@@ -512,6 +508,12 @@ function TenantTrapCalculator(props: Readonly<IProps>) {
                 </CardContent>
               </Card>
             </>
+          ) : (
+            <Card className="flex min-h-[200px] items-center justify-center">
+              <p className="text-sm text-muted-foreground">
+                Enter portfolio details to run the stress test
+              </p>
+            </Card>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace negated ternary conditions (S7735) with positive equivalents
- Extract nested ternary operations (S3358) into if-else blocks / helper functions
- Fix zero-fraction number literals (S7748: `1.0` → `1`)
- Reduce cognitive complexity (S3776) by extracting bar color to `VERDICT_BAR_COLOR` constant

## Fixes
- `GegRetrofitCalculator`: `1.0` → `1` (×2); extracted results rendering to `renderResults()` inner function
- `TenantTrapCalculator`: flipped negated ternaries in `formatMonths`, extracted `verdict` to if/else, added `VERDICT_BAR_COLOR` record, flipped `!results` ternary, replaced nested bar-fill ternary with record lookup

## Test plan
- [ ] TypeScript: `bunx tsc --noEmit` passes
- [ ] Pre-commit: biome passes
- [ ] SonarCloud: 0 new issues