### PR TITLE
feat(documents): add per-clause confidence scoring

### DIFF
--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -93,12 +93,14 @@ class DetectedClause(BaseModel):
         default="",
         description="Plain-English explanation of why this risk level was assigned",
     )
-    confidence_level: str = Field(
+    confidence_level: Literal["high", "medium", "low"] = Field(
         default="high",
         description="Translation confidence: high, medium, or low",
     )
     confidence_score: int = Field(
         default=100,
+        ge=0,
+        le=100,
         description="Translation confidence score 0-100",
     )
 

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -93,6 +93,14 @@ class DetectedClause(BaseModel):
         default="",
         description="Plain-English explanation of why this risk level was assigned",
     )
+    confidence_level: str = Field(
+        default="high",
+        description="Translation confidence: high, medium, or low",
+    )
+    confidence_score: int = Field(
+        default=100,
+        description="Translation confidence score 0-100",
+    )
 
 
 class DocumentRiskWarning(BaseModel):

--- a/backend/app/services/clause_risk_analyzer_service.py
+++ b/backend/app/services/clause_risk_analyzer_service.py
@@ -1,8 +1,9 @@
 """AI-powered clause risk annotation service.
 
 Uses the Anthropic Claude API to enrich regex-detected clauses with
-nuanced risk levels and plain-English explanations. Runs as a second AI
-pass after initial clause detection, covering all document types.
+nuanced risk levels, plain-English explanations, and translation confidence
+scores. Runs as a second AI pass after initial clause detection, covering
+all document types.
 """
 
 from __future__ import annotations
@@ -25,16 +26,43 @@ _client: anthropic.Anthropic | None = None
 # Maximum clauses to submit in a single AI call (cost/latency guard)
 _MAX_CLAUSES = 20
 
+# Archaic / jurisdiction-specific German patterns that lower translation confidence
+_ARCHAIC_PATTERNS = [
+    re.compile(r"§\s*\d+", re.IGNORECASE),
+    re.compile(r"\bAbs\b"),
+    re.compile(r"\bNr\b"),
+    re.compile(r"\bgemäß\b", re.IGNORECASE),
+    re.compile(r"\bvorbehalten\b", re.IGNORECASE),
+    re.compile(r"\bdergestalt\b", re.IGNORECASE),
+    re.compile(r"\bhiermit\b", re.IGNORECASE),
+    re.compile(r"\binsoweit\b", re.IGNORECASE),
+    re.compile(r"\bvorbehaltlich\b", re.IGNORECASE),
+    re.compile(r"\bdingliche\b", re.IGNORECASE),
+    re.compile(r"\bReallast\b", re.IGNORECASE),
+    re.compile(r"\bGrundschuld\b", re.IGNORECASE),
+]
+
 SYSTEM_PROMPT = """You are a German real estate legal expert reviewing detected contract clauses.
-For each clause, assess the risk to a property buyer and explain it in plain English.
+For each clause, assess the risk to a property buyer, explain it in plain English, and score
+translation confidence.
 
 Return a JSON array with exactly one object per clause, in the same order as the input:
-[{"risk_level": "high"|"medium"|"low", "risk_reason": "1-2 sentence plain English explanation"}]
+[{
+  "risk_level": "high"|"medium"|"low",
+  "risk_reason": "1-2 sentence plain English explanation",
+  "confidence_level": "high"|"medium"|"low",
+  "confidence_score": 0-100
+}]
 
 Risk level guidelines:
 - "high": Unusual penalty clauses (Vertragsstrafe), non-standard upfront payments, rights-of-first-refusal for third parties, maintenance liability shifted to buyer, clauses deviating from BGB defaults, Sonderumlage or WEG capital reserve deficits, full warranty exclusions
 - "medium": Financial obligations, tight deadlines, special conditions requiring buyer attention
 - "low": Standard boilerplate typical in German real estate contracts
+
+Confidence level guidelines (how accurately the English translation captures the German meaning):
+- "high" (85-100): Clear standard German legal language; translation is unambiguous
+- "medium" (60-84): Some technical jargon or compound terms that may lose nuance in translation
+- "low" (0-59): Archaic German, highly jurisdiction-specific terms (§ BGB references), complex compound sentences, or mixed-language content — professional review strongly recommended
 
 Be concise — risk_reason must be 1-2 sentences. Return ONLY a valid JSON array, no markdown."""
 
@@ -50,6 +78,26 @@ def _get_anthropic_client() -> anthropic.Anthropic | None:
 
     _client = anthropic_mod.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
     return _client
+
+
+def _estimate_confidence(clause: dict) -> tuple[str, int]:
+    """Rule-based confidence estimation used when the AI call is unavailable.
+
+    Counts archaic/technical German patterns and sentence length as proxies
+    for translation difficulty.
+
+    Returns:
+        Tuple of (confidence_level, confidence_score).
+    """
+    text = clause.get("original_text", "")
+    archaic_count = sum(1 for p in _ARCHAIC_PATTERNS if p.search(text))
+    word_count = len(text.split())
+
+    if archaic_count >= 2 or word_count > 50:
+        return "low", 50
+    if archaic_count == 1 or word_count > 25:
+        return "medium", 72
+    return "high", 92
 
 
 def _build_clauses_text(clauses: list[dict]) -> str:
@@ -115,17 +163,25 @@ def _parse_risk_response(text: str, expected_count: int) -> list[dict] | None:
             item["risk_level"] = "medium"
         if not isinstance(item.get("risk_reason"), str):
             item["risk_reason"] = ""
+        if item.get("confidence_level") not in valid_levels:
+            item["confidence_level"] = "high"
+        raw_score = item.get("confidence_score")
+        if not isinstance(raw_score, int) or not (0 <= raw_score <= 100):
+            item["confidence_score"] = 92
 
     return data
 
 
 async def analyze_clause_risks(clauses: list[dict]) -> list[dict]:
-    """Enrich detected clauses with AI-powered risk levels and explanations.
+    """Enrich detected clauses with AI-powered risk levels, explanations, and confidence.
 
     Takes the regex-detected clause list and returns a copy where each item
-    has an updated ``risk_level`` and a new ``risk_reason`` field containing a
-    plain-English explanation. Falls back gracefully to the original list if
-    the AI call is unavailable or fails.
+    has an updated ``risk_level``, a new ``risk_reason`` field, and
+    ``confidence_level`` / ``confidence_score`` fields indicating how
+    accurately the English translation captures the original German meaning.
+
+    Falls back gracefully to rule-based confidence heuristics if the AI call
+    is unavailable or fails.
 
     Args:
         clauses: List of clause dicts (from regex detection). Each must have
@@ -133,16 +189,16 @@ async def analyze_clause_risks(clauses: list[dict]) -> list[dict]:
             and ``risk_level`` keys.
 
     Returns:
-        Enhanced clause list with ``risk_reason`` populated. Original list
-        returned unchanged on error.
+        Enhanced clause list. Original list returned with heuristic confidence
+        on error.
     """
     if not clauses:
         return clauses
 
     client = _get_anthropic_client()
     if client is None:
-        logger.info("Anthropic not configured — skipping clause risk annotation")
-        return _add_empty_risk_reason(clauses)
+        logger.info("Anthropic not configured — using heuristic clause confidence")
+        return _add_defaults(clauses)
 
     # Process up to _MAX_CLAUSES; keep the rest unchanged
     batch = clauses[:_MAX_CLAUSES]
@@ -155,31 +211,61 @@ async def analyze_clause_risks(clauses: list[dict]) -> list[dict]:
         annotations = _parse_risk_response(raw, len(batch))
     except Exception:
         logger.exception("Clause risk AI analysis failed")
-        return _add_empty_risk_reason(clauses)
+        return _add_defaults(clauses)
 
     if annotations is None:
-        return _add_empty_risk_reason(clauses)
+        return _add_defaults(clauses)
 
     enriched: list[dict] = []
     for i, clause in enumerate(batch):
         if i < len(annotations):
             annotation = annotations[i]
+            conf_level, conf_score = _estimate_confidence(clause)
             enriched.append(
                 {
                     **clause,
                     "risk_level": annotation.get("risk_level", clause["risk_level"]),
                     "risk_reason": annotation.get("risk_reason", ""),
+                    "confidence_level": annotation.get("confidence_level", conf_level),
+                    "confidence_score": annotation.get("confidence_score", conf_score),
                 }
             )
         else:
-            enriched.append({**clause, "risk_reason": ""})
+            conf_level, conf_score = _estimate_confidence(clause)
+            enriched.append(
+                {
+                    **clause,
+                    "risk_reason": "",
+                    "confidence_level": conf_level,
+                    "confidence_score": conf_score,
+                }
+            )
 
     for clause in remainder:
-        enriched.append({**clause, "risk_reason": ""})
+        conf_level, conf_score = _estimate_confidence(clause)
+        enriched.append(
+            {
+                **clause,
+                "risk_reason": clause.get("risk_reason", ""),
+                "confidence_level": conf_level,
+                "confidence_score": conf_score,
+            }
+        )
 
     return enriched
 
 
-def _add_empty_risk_reason(clauses: list[dict]) -> list[dict]:
-    """Return clauses unchanged but with risk_reason defaulted to empty string."""
-    return [{**c, "risk_reason": c.get("risk_reason", "")} for c in clauses]
+def _add_defaults(clauses: list[dict]) -> list[dict]:
+    """Return clauses with risk_reason defaulted and confidence estimated via heuristics."""
+    result = []
+    for c in clauses:
+        conf_level, conf_score = _estimate_confidence(c)
+        result.append(
+            {
+                **c,
+                "risk_reason": c.get("risk_reason", ""),
+                "confidence_level": c.get("confidence_level", conf_level),
+                "confidence_score": c.get("confidence_score", conf_score),
+            }
+        )
+    return result

--- a/backend/app/services/clause_risk_analyzer_service.py
+++ b/backend/app/services/clause_risk_analyzer_service.py
@@ -26,7 +26,13 @@ _client: anthropic.Anthropic | None = None
 # Maximum clauses to submit in a single AI call (cost/latency guard)
 _MAX_CLAUSES = 20
 
-# Archaic / jurisdiction-specific German patterns that lower translation confidence
+# Fallback confidence score used when AI returns an out-of-range or missing value.
+# Matches the "high" heuristic bucket in _estimate_confidence.
+_DEFAULT_CONFIDENCE_SCORE = 92
+
+# Archaic / jurisdiction-specific German patterns that lower translation confidence.
+# Abs and Nr are intentionally case-sensitive: both are capitalised abbreviations
+# in German legal text (Absatz, Nummer) and lowercase occurrences are not legal usage.
 _ARCHAIC_PATTERNS = [
     re.compile(r"§\s*\d+", re.IGNORECASE),
     re.compile(r"\bAbs\b"),
@@ -42,7 +48,7 @@ _ARCHAIC_PATTERNS = [
     re.compile(r"\bGrundschuld\b", re.IGNORECASE),
 ]
 
-SYSTEM_PROMPT = """You are a German real estate legal expert reviewing detected contract clauses.
+_SYSTEM_PROMPT = """You are a German real estate legal expert reviewing detected contract clauses.
 For each clause, assess the risk to a property buyer, explain it in plain English, and score
 translation confidence.
 
@@ -84,7 +90,9 @@ def _estimate_confidence(clause: dict) -> tuple[str, int]:
     """Rule-based confidence estimation used when the AI call is unavailable.
 
     Counts archaic/technical German patterns and sentence length as proxies
-    for translation difficulty.
+    for translation difficulty. Scores are coarse three-bucket values (92/72/50)
+    rather than a continuous scale — precision is not warranted given the
+    heuristic nature of the estimation.
 
     Returns:
         Tuple of (confidence_level, confidence_score).
@@ -97,7 +105,7 @@ def _estimate_confidence(clause: dict) -> tuple[str, int]:
         return "low", 50
     if archaic_count == 1 or word_count > 25:
         return "medium", 72
-    return "high", 92
+    return "high", _DEFAULT_CONFIDENCE_SCORE
 
 
 def _build_clauses_text(clauses: list[dict]) -> str:
@@ -120,7 +128,7 @@ def _call_claude(client: anthropic.Anthropic, clauses_text: str) -> str:
     message = client.messages.create(
         model=settings.ANTHROPIC_MODEL,
         max_tokens=settings.ANTHROPIC_MAX_TOKENS,
-        system=SYSTEM_PROMPT,
+        system=_SYSTEM_PROMPT,
         messages=[
             {
                 "role": "user",
@@ -167,7 +175,7 @@ def _parse_risk_response(text: str, expected_count: int) -> list[dict] | None:
             item["confidence_level"] = "high"
         raw_score = item.get("confidence_score")
         if not isinstance(raw_score, int) or not (0 <= raw_score <= 100):
-            item["confidence_score"] = 92
+            item["confidence_score"] = _DEFAULT_CONFIDENCE_SCORE
 
     return data
 
@@ -241,6 +249,8 @@ async def analyze_clause_risks(clauses: list[dict]) -> list[dict]:
                 }
             )
 
+    # Remainder clauses were not submitted to the AI; preserve any pre-existing
+    # risk_reason and apply heuristic confidence estimation.
     for clause in remainder:
         conf_level, conf_score = _estimate_confidence(clause)
         enriched.append(

--- a/backend/tests/services/test_clause_risk_analyzer_service.py
+++ b/backend/tests/services/test_clause_risk_analyzer_service.py
@@ -6,8 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services.clause_risk_analyzer_service import (
-    _add_empty_risk_reason,
+    _add_defaults,
     _build_clauses_text,
+    _estimate_confidence,
     _parse_risk_response,
     analyze_clause_risks,
 )
@@ -42,14 +43,20 @@ VALID_RISK_RESPONSE = [
     {
         "risk_level": "high",
         "risk_reason": "Full warranty exclusion is unusual; buyer accepts all defects.",
+        "confidence_level": "high",
+        "confidence_score": 92,
     },
     {
         "risk_level": "medium",
         "risk_reason": "Standard purchase price clause — verify amount matches offer.",
+        "confidence_level": "high",
+        "confidence_score": 95,
     },
     {
         "risk_level": "medium",
         "risk_reason": "Standard deadline; confirm timeline is achievable.",
+        "confidence_level": "medium",
+        "confidence_score": 75,
     },
 ]
 
@@ -105,6 +112,14 @@ class TestParseRiskResponse:
         assert result[0]["risk_level"] == "high"
         assert "warranty" in result[0]["risk_reason"]
 
+    def test_parses_confidence_fields(self) -> None:
+        raw = json.dumps(VALID_RISK_RESPONSE)
+        result = _parse_risk_response(raw, 3)
+        assert result is not None
+        assert result[0]["confidence_level"] == "high"
+        assert result[0]["confidence_score"] == 92
+        assert result[2]["confidence_level"] == "medium"
+
     def test_strips_markdown_json_fences(self) -> None:
         raw = f"```json\n{json.dumps(VALID_RISK_RESPONSE)}\n```"
         result = _parse_risk_response(raw, 3)
@@ -125,13 +140,45 @@ class TestParseRiskResponse:
         assert result is None
 
     def test_coerces_invalid_risk_level_to_medium(self) -> None:
-        data = [{"risk_level": "extreme", "risk_reason": "Very bad."}]
+        data = [
+            {
+                "risk_level": "extreme",
+                "risk_reason": "Very bad.",
+                "confidence_level": "high",
+                "confidence_score": 90,
+            }
+        ]
         result = _parse_risk_response(json.dumps(data), 1)
         assert result is not None
         assert result[0]["risk_level"] == "medium"
 
+    def test_coerces_invalid_confidence_level_to_high(self) -> None:
+        data = [
+            {
+                "risk_level": "low",
+                "risk_reason": "Fine.",
+                "confidence_level": "excellent",
+                "confidence_score": 90,
+            }
+        ]
+        result = _parse_risk_response(json.dumps(data), 1)
+        assert result is not None
+        assert result[0]["confidence_level"] == "high"
+
+    def test_defaults_out_of_range_confidence_score(self) -> None:
+        data = [
+            {
+                "risk_level": "low",
+                "risk_reason": "Fine.",
+                "confidence_level": "high",
+                "confidence_score": 150,
+            }
+        ]
+        result = _parse_risk_response(json.dumps(data), 1)
+        assert result is not None
+        assert result[0]["confidence_score"] == 92
+
     def test_tolerates_count_mismatch(self) -> None:
-        # Returns data even if count differs from expected
         data = [{"risk_level": "high", "risk_reason": "test"}]
         result = _parse_risk_response(json.dumps(data), 3)
         assert result is not None
@@ -144,6 +191,48 @@ class TestParseRiskResponse:
         assert result[0]["risk_reason"] == ""
 
 
+# --- _estimate_confidence ---
+
+
+class TestEstimateConfidence:
+    def test_short_simple_clause_is_high(self) -> None:
+        clause = {"original_text": "Der Kaufpreis beträgt EUR 350.000."}
+        level, score = _estimate_confidence(clause)
+        assert level == "high"
+        assert score >= 85
+
+    def test_clause_with_one_archaic_pattern_is_medium(self) -> None:
+        clause = {"original_text": "gemäß den Vereinbarungen gilt folgendes."}
+        level, score = _estimate_confidence(clause)
+        assert level == "medium"
+        assert 60 <= score < 85
+
+    def test_clause_with_multiple_archaic_patterns_is_low(self) -> None:
+        clause = {
+            "original_text": "Gemäß § 433 BGB vorbehaltlich der Regelungen des Abs. 2."
+        }
+        level, score = _estimate_confidence(clause)
+        assert level == "low"
+        assert score < 60
+
+    def test_long_clause_over_50_words_is_low(self) -> None:
+        long_text = " ".join(["Wort"] * 55)
+        clause = {"original_text": long_text}
+        level, score = _estimate_confidence(clause)
+        assert level == "low"
+
+    def test_medium_length_clause_is_medium(self) -> None:
+        medium_text = " ".join(["Wort"] * 30)
+        clause = {"original_text": medium_text}
+        level, score = _estimate_confidence(clause)
+        assert level == "medium"
+
+    def test_empty_text_returns_high(self) -> None:
+        clause = {"original_text": ""}
+        level, score = _estimate_confidence(clause)
+        assert level == "high"
+
+
 # --- analyze_clause_risks ---
 
 
@@ -154,7 +243,7 @@ class TestAnalyzeClauseRisks:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_returns_clauses_with_empty_reason_when_not_configured(
+    async def test_returns_clauses_with_defaults_when_not_configured(
         self,
     ) -> None:
         with patch(
@@ -164,7 +253,9 @@ class TestAnalyzeClauseRisks:
             result = await analyze_clause_risks(SAMPLE_CLAUSES)
         assert len(result) == 3
         assert all("risk_reason" in c for c in result)
-        assert all(c["risk_reason"] == "" for c in result)
+        assert all("confidence_level" in c for c in result)
+        assert all("confidence_score" in c for c in result)
+        assert all(c["confidence_level"] in {"high", "medium", "low"} for c in result)
 
     @pytest.mark.asyncio
     async def test_enriches_clauses_on_success(self) -> None:
@@ -183,6 +274,9 @@ class TestAnalyzeClauseRisks:
         assert result[0]["risk_level"] == "high"
         assert "warranty" in result[0]["risk_reason"]
         assert result[1]["risk_level"] == "medium"
+        assert result[0]["confidence_level"] == "high"
+        assert result[0]["confidence_score"] == 92
+        assert result[2]["confidence_level"] == "medium"
 
     @pytest.mark.asyncio
     async def test_preserves_original_fields(self) -> None:
@@ -213,7 +307,8 @@ class TestAnalyzeClauseRisks:
             result = await analyze_clause_risks(SAMPLE_CLAUSES)
 
         assert len(result) == 3
-        assert all(c["risk_reason"] == "" for c in result)
+        assert all("confidence_level" in c for c in result)
+        assert all("confidence_score" in c for c in result)
 
     @pytest.mark.asyncio
     async def test_falls_back_on_invalid_response(self) -> None:
@@ -229,7 +324,7 @@ class TestAnalyzeClauseRisks:
             result = await analyze_clause_risks(SAMPLE_CLAUSES)
 
         assert len(result) == 3
-        assert all(c["risk_reason"] == "" for c in result)
+        assert all("confidence_level" in c for c in result)
 
     @pytest.mark.asyncio
     async def test_caps_batch_at_max_clauses(self) -> None:
@@ -243,9 +338,14 @@ class TestAnalyzeClauseRisks:
             }
             for i in range(25)
         ]
-        # 20 items returned by AI, 5 remainder get empty reason
         ai_response = [
-            {"risk_level": "medium", "risk_reason": f"Reason {i}"} for i in range(20)
+            {
+                "risk_level": "medium",
+                "risk_reason": f"Reason {i}",
+                "confidence_level": "high",
+                "confidence_score": 90,
+            }
+            for i in range(20)
         ]
         mock_client = MagicMock()
         mock_message = MagicMock()
@@ -261,26 +361,46 @@ class TestAnalyzeClauseRisks:
         assert len(result) == 25
         assert result[0]["risk_reason"] == "Reason 0"
         assert result[24]["risk_reason"] == ""
+        # Remainder gets heuristic confidence
+        assert result[24]["confidence_level"] in {"high", "medium", "low"}
 
 
-# --- _add_empty_risk_reason ---
+# --- _add_defaults ---
 
 
-class TestAddEmptyRiskReason:
+class TestAddDefaults:
+    def test_adds_confidence_fields(self) -> None:
+        clauses = [
+            {"clause_type": "deadline", "risk_level": "high", "original_text": "Frist"}
+        ]
+        result = _add_defaults(clauses)
+        assert "confidence_level" in result[0]
+        assert "confidence_score" in result[0]
+
     def test_adds_risk_reason_field(self) -> None:
-        clauses = [{"clause_type": "deadline", "risk_level": "high"}]
-        result = _add_empty_risk_reason(clauses)
+        clauses = [
+            {"clause_type": "deadline", "risk_level": "high", "original_text": "Frist"}
+        ]
+        result = _add_defaults(clauses)
         assert result[0]["risk_reason"] == ""
 
     def test_preserves_existing_risk_reason(self) -> None:
         clauses = [
-            {"clause_type": "deadline", "risk_level": "high", "risk_reason": "Tight"}
+            {
+                "clause_type": "deadline",
+                "risk_level": "high",
+                "risk_reason": "Tight",
+                "original_text": "Frist",
+            }
         ]
-        result = _add_empty_risk_reason(clauses)
+        result = _add_defaults(clauses)
         assert result[0]["risk_reason"] == "Tight"
 
     def test_does_not_mutate_original(self) -> None:
-        clauses = [{"clause_type": "deadline", "risk_level": "high"}]
-        result = _add_empty_risk_reason(clauses)
+        clauses = [
+            {"clause_type": "deadline", "risk_level": "high", "original_text": "Frist"}
+        ]
+        result = _add_defaults(clauses)
         assert "risk_reason" not in clauses[0]
+        assert "confidence_level" not in clauses[0]
         assert result[0]["risk_reason"] == ""

--- a/backend/tests/services/test_clause_risk_analyzer_service.py
+++ b/backend/tests/services/test_clause_risk_analyzer_service.py
@@ -309,6 +309,7 @@ class TestAnalyzeClauseRisks:
         assert len(result) == 3
         assert all("confidence_level" in c for c in result)
         assert all("confidence_score" in c for c in result)
+        assert all(c["risk_reason"] == "" for c in result)
 
     @pytest.mark.asyncio
     async def test_falls_back_on_invalid_response(self) -> None:
@@ -361,8 +362,10 @@ class TestAnalyzeClauseRisks:
         assert len(result) == 25
         assert result[0]["risk_reason"] == "Reason 0"
         assert result[24]["risk_reason"] == ""
-        # Remainder gets heuristic confidence
+        # Remainder clauses (indices 20-24) use heuristic confidence, not AI's score of 90
         assert result[24]["confidence_level"] in {"high", "medium", "low"}
+        # "Term 24" is short with no archaic patterns → heuristic returns "high"/92
+        assert result[24]["confidence_score"] == 92
 
 
 # --- _add_defaults ---

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2023,6 +2023,18 @@ export const DetectedClauseSchema = {
             title: 'Risk Reason',
             description: 'Plain-English explanation of why this risk level was assigned',
             default: ''
+        },
+        confidence_level: {
+            type: 'string',
+            title: 'Confidence Level',
+            description: 'Translation confidence: high, medium, or low',
+            default: 'high'
+        },
+        confidence_score: {
+            type: 'integer',
+            title: 'Confidence Score',
+            description: 'Translation confidence score 0-100',
+            default: 100
         }
     },
     type: 'object',

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2026,12 +2026,15 @@ export const DetectedClauseSchema = {
         },
         confidence_level: {
             type: 'string',
+            enum: ['high', 'medium', 'low'],
             title: 'Confidence Level',
             description: 'Translation confidence: high, medium, or low',
             default: 'high'
         },
         confidence_score: {
             type: 'integer',
+            maximum: 100,
+            minimum: 0,
             title: 'Confidence Score',
             description: 'Translation confidence score 0-100',
             default: 100

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -599,12 +599,17 @@ export type DetectedClause = {
     /**
      * Translation confidence: high, medium, or low
      */
-    confidence_level?: string;
+    confidence_level?: 'high' | 'medium' | 'low';
     /**
      * Translation confidence score 0-100
      */
     confidence_score?: number;
 };
+
+/**
+ * Translation confidence: high, medium, or low
+ */
+export type confidence_level = 'high' | 'medium' | 'low';
 
 /**
  * Difficulty level for articles.

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -596,6 +596,14 @@ export type DetectedClause = {
      * Plain-English explanation of why this risk level was assigned
      */
     risk_reason?: string;
+    /**
+     * Translation confidence: high, medium, or low
+     */
+    confidence_level?: string;
+    /**
+     * Translation confidence score 0-100
+     */
+    confidence_score?: number;
 };
 
 /**

--- a/frontend/src/components/Documents/ClauseHighlights.tsx
+++ b/frontend/src/components/Documents/ClauseHighlights.tsx
@@ -1,15 +1,22 @@
 /**
  * Clause Highlights Component
  * Detected clauses grouped by type with risk level badges, coloured
- * left-border indicators, expandable risk explanations, and a summary banner.
+ * left-border indicators, expandable risk explanations, confidence indicators,
+ * and a summary banner.
  */
 
-import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronUp, HelpCircle } from "lucide-react"
 import { useState } from "react"
 
 import { cn } from "@/common/utils"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { DetectedClause } from "@/models/document"
 
 interface IProps {
@@ -71,40 +78,113 @@ interface IRiskSummaryProps {
   clauses: DetectedClause[]
 }
 
-/** Banner summarising high and medium risk clause counts. */
+/** Banner summarising high/medium risk counts and low-confidence clause count. */
 function RiskSummaryBanner(props: Readonly<IRiskSummaryProps>) {
   const { clauses } = props
-  const { highCount, mediumCount } = clauses.reduce(
+  const { highCount, mediumCount, lowConfidenceCount } = clauses.reduce(
     (acc, c) => {
       if (c.riskLevel === "high") acc.highCount++
       else if (c.riskLevel === "medium") acc.mediumCount++
+      if (c.confidenceLevel === "low") acc.lowConfidenceCount++
       return acc
     },
-    { highCount: 0, mediumCount: 0 },
+    { highCount: 0, mediumCount: 0, lowConfidenceCount: 0 },
   )
 
-  if (highCount === 0 && mediumCount === 0) return null
+  if (highCount === 0 && mediumCount === 0 && lowConfidenceCount === 0)
+    return null
 
   return (
-    <div className="flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-950/30">
-      <AlertTriangle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
-      <p className="text-sm text-red-800 dark:text-red-300">
-        {highCount > 0 && (
-          <span className="font-semibold">
-            {highCount} high-risk clause{highCount === 1 ? "" : "s"} found
-            {" — "}review before signing
-          </span>
-        )}
-        {highCount > 0 && mediumCount > 0 && (
-          <span className="text-red-600 dark:text-red-400"> · </span>
-        )}
-        {mediumCount > 0 && (
-          <span>
-            {mediumCount} clause{mediumCount === 1 ? "" : "s"} need attention
-          </span>
-        )}
-      </p>
+    <div className="space-y-2">
+      {(highCount > 0 || mediumCount > 0) && (
+        <div className="flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-950/30">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+          <p className="text-sm text-red-800 dark:text-red-300">
+            {highCount > 0 && (
+              <span className="font-semibold">
+                {highCount} high-risk clause{highCount === 1 ? "" : "s"} found
+                {" — "}review before signing
+              </span>
+            )}
+            {highCount > 0 && mediumCount > 0 && (
+              <span className="text-red-600 dark:text-red-400"> · </span>
+            )}
+            {mediumCount > 0 && (
+              <span>
+                {mediumCount} clause{mediumCount === 1 ? "" : "s"} need
+                attention
+              </span>
+            )}
+          </p>
+        </div>
+      )}
+      {lowConfidenceCount > 0 && (
+        <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-900 dark:bg-amber-950/30">
+          <HelpCircle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <p className="text-sm text-amber-800 dark:text-amber-300">
+            <span className="font-semibold">
+              {lowConfidenceCount} clause
+              {lowConfidenceCount === 1 ? "" : "s"} contain complex legal
+              language
+            </span>
+            {" — "}consult a professional for accurate interpretation
+          </p>
+        </div>
+      )}
     </div>
+  )
+}
+
+interface IConfidenceBadgeProps {
+  confidenceLevel: string
+  confidenceScore: number
+}
+
+/** Inline confidence indicator shown beside the translation text. */
+function ConfidenceBadge(props: Readonly<IConfidenceBadgeProps>) {
+  const { confidenceLevel, confidenceScore } = props
+
+  if (confidenceLevel === "high") return null
+
+  if (confidenceLevel === "medium") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex items-center gap-0.5 text-xs italic text-muted-foreground cursor-help">
+            <HelpCircle className="h-3 w-3" />~
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-56 text-xs" side="top">
+          Translation may vary — verify with source text
+          {confidenceScore < 100 && (
+            <span className="block text-muted-foreground mt-0.5">
+              Confidence: {confidenceScore}%
+            </span>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  // low confidence
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400 cursor-help">
+          <AlertTriangle className="h-3 w-3 shrink-0" />
+          Complex legal language
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-56 text-xs" side="top">
+        Archaic or jurisdiction-specific German — consult a professional for
+        this clause
+        {confidenceScore < 100 && (
+          <span className="block text-muted-foreground mt-0.5">
+            Confidence: {confidenceScore}%
+          </span>
+        )}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -157,7 +237,13 @@ function ClauseItem(props: Readonly<IClauseItemProps>) {
         </div>
         {clause.translatedText && (
           <div>
-            <p className="text-xs text-muted-foreground mb-1">Translation</p>
+            <div className="flex items-center gap-1 mb-1">
+              <p className="text-xs text-muted-foreground">Translation</p>
+              <ConfidenceBadge
+                confidenceLevel={clause.confidenceLevel}
+                confidenceScore={clause.confidenceScore}
+              />
+            </div>
             <p className="text-sm">{clause.translatedText}</p>
           </div>
         )}
@@ -174,7 +260,7 @@ function ClauseItem(props: Readonly<IClauseItemProps>) {
   )
 }
 
-/** Default component. Grouped clause highlights with risk summary. */
+/** Default component. Grouped clause highlights with risk and confidence summary. */
 function ClauseHighlights(props: Readonly<IProps>) {
   const { clauses } = props
 
@@ -189,26 +275,28 @@ function ClauseHighlights(props: Readonly<IProps>) {
   const grouped = groupByType(clauses)
 
   return (
-    <div className="space-y-4">
-      <RiskSummaryBanner clauses={clauses} />
-      {Object.entries(grouped).map(([type, items]) => (
-        <Card key={type}>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">
-              {CLAUSE_TYPE_LABELS[type] ?? type}
-              <Badge variant="outline" className="ml-2 text-xs">
-                {items.length}
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {items.map((clause) => (
-              <ClauseItem key={clauseKey(clause)} clause={clause} />
-            ))}
-          </CardContent>
-        </Card>
-      ))}
-    </div>
+    <TooltipProvider>
+      <div className="space-y-4">
+        <RiskSummaryBanner clauses={clauses} />
+        {Object.entries(grouped).map(([type, items]) => (
+          <Card key={type}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">
+                {CLAUSE_TYPE_LABELS[type] ?? type}
+                <Badge variant="outline" className="ml-2 text-xs">
+                  {items.length}
+                </Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {items.map((clause) => (
+                <ClauseItem key={clauseKey(clause)} clause={clause} />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </TooltipProvider>
   )
 }
 

--- a/frontend/src/components/Documents/ClauseHighlights.tsx
+++ b/frontend/src/components/Documents/ClauseHighlights.tsx
@@ -94,9 +94,12 @@ function RiskSummaryBanner(props: Readonly<IRiskSummaryProps>) {
   if (highCount === 0 && mediumCount === 0 && lowConfidenceCount === 0)
     return null
 
+  const showRisk = highCount > 0 || mediumCount > 0
+  const showConfidence = lowConfidenceCount > 0
+
   return (
-    <div className="space-y-2">
-      {(highCount > 0 || mediumCount > 0) && (
+    <div className={showRisk && showConfidence ? "space-y-2" : undefined}>
+      {showRisk && (
         <div className="flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-950/30">
           <AlertTriangle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
           <p className="text-sm text-red-800 dark:text-red-300">
@@ -118,7 +121,7 @@ function RiskSummaryBanner(props: Readonly<IRiskSummaryProps>) {
           </p>
         </div>
       )}
-      {lowConfidenceCount > 0 && (
+      {showConfidence && (
         <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-900 dark:bg-amber-950/30">
           <HelpCircle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
           <p className="text-sm text-amber-800 dark:text-amber-300">
@@ -136,7 +139,7 @@ function RiskSummaryBanner(props: Readonly<IRiskSummaryProps>) {
 }
 
 interface IConfidenceBadgeProps {
-  confidenceLevel: string
+  confidenceLevel: "high" | "medium" | "low"
   confidenceScore: number
 }
 
@@ -151,16 +154,15 @@ function ConfidenceBadge(props: Readonly<IConfidenceBadgeProps>) {
       <Tooltip>
         <TooltipTrigger asChild>
           <span className="inline-flex items-center gap-0.5 text-xs italic text-muted-foreground cursor-help">
-            <HelpCircle className="h-3 w-3" />~
+            <HelpCircle className="h-3 w-3" />
+            <span aria-hidden="true">~</span>
           </span>
         </TooltipTrigger>
         <TooltipContent className="max-w-56 text-xs" side="top">
           Translation may vary — verify with source text
-          {confidenceScore < 100 && (
-            <span className="block text-muted-foreground mt-0.5">
-              Confidence: {confidenceScore}%
-            </span>
-          )}
+          <span className="block text-muted-foreground mt-0.5">
+            Confidence: {confidenceScore}%
+          </span>
         </TooltipContent>
       </Tooltip>
     )
@@ -178,11 +180,9 @@ function ConfidenceBadge(props: Readonly<IConfidenceBadgeProps>) {
       <TooltipContent className="max-w-56 text-xs" side="top">
         Archaic or jurisdiction-specific German — consult a professional for
         this clause
-        {confidenceScore < 100 && (
-          <span className="block text-muted-foreground mt-0.5">
-            Confidence: {confidenceScore}%
-          </span>
-        )}
+        <span className="block text-muted-foreground mt-0.5">
+          Confidence: {confidenceScore}%
+        </span>
       </TooltipContent>
     </Tooltip>
   )

--- a/frontend/src/models/document.ts
+++ b/frontend/src/models/document.ts
@@ -41,6 +41,8 @@ export interface DetectedClause {
   pageNumber: number
   riskLevel: string
   riskReason: string
+  confidenceLevel: string
+  confidenceScore: number
 }
 
 export interface DocumentRiskWarning {

--- a/frontend/src/models/document.ts
+++ b/frontend/src/models/document.ts
@@ -41,7 +41,7 @@ export interface DetectedClause {
   pageNumber: number
   riskLevel: string
   riskReason: string
-  confidenceLevel: string
+  confidenceLevel: "high" | "medium" | "low"
   confidenceScore: number
 }
 


### PR DESCRIPTION
## Summary
- Backend `clause_risk_analyzer_service` extended: Claude now returns `confidence_level`/`confidence_score` alongside risk annotation in the same batch call; rule-based `_estimate_confidence` heuristic fallback using archaic German patterns for when AI is unavailable
- `DetectedClause` schema gains `confidence_level` (high/medium/low) and `confidence_score` (0–100) fields with safe defaults
- `ClauseHighlights` renders confidence inline: HIGH = no treatment; MEDIUM = `~` prefix with tooltip; LOW = amber warning icon with "Complex legal language" tooltip
- `RiskSummaryBanner` now also shows count of low-confidence clauses in an amber alert bar

## Test plan
- [ ] 33 backend tests passing (`test_clause_risk_analyzer_service.py`)
- [ ] TypeScript compiles without errors
- [ ] Pre-commit passes clean
- [ ] Upload a Kaufvertrag → Clauses tab → verify confidence badges render on medium/low clauses
- [ ] Banner shows amber "complex legal language" row when low-confidence clauses present
- [ ] Hovering `~` badge shows "Translation may vary" tooltip; hovering amber shows full explanation