### PR TITLE
feat(documents): add WEG-Protokolle auditor as fifth document type

### DIFF
--- a/backend/app/alembic/versions/g2h3i4j5k6l7_add_weg_protokolle_doc_type.py
+++ b/backend/app/alembic/versions/g2h3i4j5k6l7_add_weg_protokolle_doc_type.py
@@ -1,0 +1,24 @@
+"""Add weg_protokolle to documenttype enum
+
+Revision ID: g2h3i4j5k6l7
+Revises: f1g2h3i4j5k6
+Create Date: 2026-04-26 16:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "g2h3i4j5k6l7"
+down_revision = "f1g2h3i4j5k6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE documenttype ADD VALUE IF NOT EXISTS 'weg_protokolle'")
+
+
+def downgrade() -> None:
+    # PostgreSQL does not support removing enum values
+    pass

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -29,6 +29,7 @@ class DocumentType(str, PyEnum):
     TEILUNGSERKLAERUNG = "teilungserklaerung"
     HAUSGELDABRECHNUNG = "hausgeldabrechnung"
     WOHNUNGSGRUNDRISS = "wohnungsgrundriss"
+    WEG_PROTOKOLL = "weg_protokolle"
     UNKNOWN = "unknown"
 
 
@@ -51,6 +52,7 @@ _document_type_enum = PgEnum(
     "teilungserklaerung",
     "hausgeldabrechnung",
     "wohnungsgrundriss",
+    "weg_protokolle",
     "unknown",
     name="documenttype",
     create_type=False,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -135,6 +135,18 @@ DOCUMENT_TYPE_KEYWORDS: dict[DocumentType, list[str]] = {
         "skizze",
         "maßstab",
     ],
+    DocumentType.WEG_PROTOKOLL: [
+        "weg-protokoll",
+        "protokoll der eigentümerversammlung",
+        "eigentümerversammlung",
+        "wohnungseigentümer",
+        "sonderumlage",
+        "instandhaltungsrücklage",
+        "hausgeldabrechnung",
+        "verwalter",
+        "beschluss",
+        "tagesordnung",
+    ],
 }
 
 # Document types that receive structured AI analysis (excludes Kaufvertrag which
@@ -145,6 +157,7 @@ TYPED_ANALYSIS_TYPES: frozenset[str] = frozenset(
         DocumentType.TEILUNGSERKLAERUNG.value,
         DocumentType.MIETVERTRAG.value,
         DocumentType.WOHNUNGSGRUNDRISS.value,
+        DocumentType.WEG_PROTOKOLL.value,
     }
 )
 

--- a/backend/app/services/document_type_analyzer_service.py
+++ b/backend/app/services/document_type_analyzer_service.py
@@ -2,7 +2,7 @@
 
 Uses the Anthropic Claude API to analyse German real estate documents by type,
 producing structured JSON extractions for Grundbuchauszug, Teilungserklärung,
-Mietvertrag, and Wohnungsgrundriss documents.
+Mietvertrag, Wohnungsgrundriss, and WEG-Protokolle documents.
 """
 
 from __future__ import annotations
@@ -27,6 +27,7 @@ SUPPORTED_TYPES = {
     "teilungserklaerung",
     "mietvertrag",
     "wohnungsgrundriss",
+    "weg_protokolle",
 }
 
 _SYSTEM_PROMPTS: dict[str, str] = {
@@ -77,6 +78,30 @@ Return ONLY valid JSON. No markdown, no explanation outside the JSON.""",
 - "is_ai_generated": true
 
 Return ONLY valid JSON. No markdown, no explanation outside the JSON.""",
+    "weg_protokolle": """You are a German WEG (Wohnungseigentumsgesetz) expert helping foreign property investors audit WEG meeting minutes (Protokolle). Identify hidden financial risks, structural concerns, and legal disputes. Return a JSON object with:
+
+- "risk_flags": [ { "flag": str, "description": str, "risk_level": "low"|"medium"|"high", "source_quote_de": str|null, "source_quote_en": str|null } ]
+  Include ALL occurrences of:
+  * Sonderumlage votes (any amount, past or proposed) — always "high"
+  * Ongoing or threatened legal proceedings (Rechtsstreit, Klage) — "high"
+  * Structural work on Dach, Fassade, Aufzug, Fenster, Heizung — "medium"/"high" by cost
+  * Votes restricting rental (Vermietungsverbot) or renovation rights — "medium"
+  * Energy upgrade obligations (GEG, Sanierungspflicht) — "medium"/"high"
+
+- "reserve_assessment": { "reserve_balance_eur": number|null, "assessment": "adequate"|"low"|"critical"|"unknown", "details": str }
+  Extract Instandhaltungsrücklage balance. Flag "low" if below €10,000 per unit equivalent.
+
+- "upcoming_costs": [ { "description": str, "estimated_eur": number|null, "timeline": str|null, "source_quote_de": str|null, "source_quote_en": str|null } ]
+
+- "disputes": [ { "description": str, "status": str, "source_quote_de": str|null, "source_quote_en": str|null } ]
+
+- "meeting_dates": [ str ]  ISO date strings of all meeting dates found.
+
+- "low_confidence_warning": bool  true if text appears OCR-extracted from a scanned/handwritten document (garbled characters, very sparse pages, OCR artifacts like â€œ or Ã¤).
+
+- "is_ai_generated": true
+
+Return ONLY valid JSON. No markdown, no explanation outside the JSON.""",
 }
 
 _REQUIRED_KEYS: dict[str, set[str]] = {
@@ -93,6 +118,7 @@ _REQUIRED_KEYS: dict[str, set[str]] = {
     },
     "mietvertrag": {"monthly_rent_eur", "is_unlimited", "risk_flags"},
     "wohnungsgrundriss": {"rooms"},
+    "weg_protokolle": {"risk_flags", "reserve_assessment", "low_confidence_warning"},
 }
 
 

--- a/backend/tests/services/test_weg_protokolle_analyzer.py
+++ b/backend/tests/services/test_weg_protokolle_analyzer.py
@@ -96,7 +96,11 @@ class TestParseWegResponse:
     def test_missing_required_keys_returns_none(self) -> None:
         # Missing risk_flags key
         incomplete = {
-            "reserve_assessment": {"reserve_balance_eur": None, "assessment": "unknown", "details": ""},
+            "reserve_assessment": {
+                "reserve_balance_eur": None,
+                "assessment": "unknown",
+                "details": "",
+            },
             "low_confidence_warning": False,
         }
         required = {"risk_flags", "reserve_assessment", "low_confidence_warning"}
@@ -143,6 +147,8 @@ class TestAnalyzeWegProtokolle:
 
     @pytest.mark.asyncio
     async def test_sonderumlage_detected_as_high_risk(self) -> None:
+        # Verifies that risk_level="high" from Claude's JSON is preserved
+        # through the parsing layer and returned in the result.
         mock_client = MagicMock()
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=json.dumps(WEG_ANALYSIS))]
@@ -164,13 +170,18 @@ class TestAnalyzeWegProtokolle:
 
     @pytest.mark.asyncio
     async def test_clean_protokoll_has_no_risk_flags(self) -> None:
+        # Verifies that an empty risk_flags list from Claude's JSON is
+        # correctly propagated through the parsing layer.
         mock_client = MagicMock()
         mock_message = MagicMock()
         mock_message.content = [MagicMock(text=json.dumps(WEG_ANALYSIS_CLEAN))]
         mock_client.messages.create.return_value = mock_message
 
         clean_pages = [
-            {"page_number": 1, "original_text": "Protokoll ohne besondere Vorkommnisse."}
+            {
+                "page_number": 1,
+                "original_text": "Protokoll ohne besondere Vorkommnisse.",
+            }
         ]
 
         with patch(

--- a/backend/tests/services/test_weg_protokolle_analyzer.py
+++ b/backend/tests/services/test_weg_protokolle_analyzer.py
@@ -1,0 +1,195 @@
+"""Tests for WEG-Protokolle analysis via the document type analyzer service."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.document_type_analyzer_service import (
+    _parse_response,
+    analyze_document_type,
+)
+
+# --- Sample data ---
+
+WEG_PAGES = [
+    {
+        "page_number": 1,
+        "original_text": (
+            "Protokoll der Eigentümerversammlung\n"
+            "Datum: 15. März 2024\n"
+            "Tagesordnungspunkt 3: Sonderumlage\n"
+            "Die Versammlung beschloss eine Sonderumlage in Höhe von 5.000 EUR "
+            "pro Wohneinheit für die Dachsanierung."
+        ),
+    },
+    {
+        "page_number": 2,
+        "original_text": (
+            "Instandhaltungsrücklage: aktueller Bestand 45.000 EUR\n"
+            "Verwalter: Immobilienverwaltung Muster GmbH\n"
+            "Beschluss: Erneuerung der Heizungsanlage im nächsten Jahr."
+        ),
+    },
+    {"page_number": 3, "original_text": ""},
+]
+
+WEG_ANALYSIS = {
+    "risk_flags": [
+        {
+            "flag": "Sonderumlage beschlossen",
+            "description": "A special levy of €5,000 per unit was voted for roof repair.",
+            "risk_level": "high",
+            "source_quote_de": "Sonderumlage in Höhe von 5.000 EUR pro Wohneinheit",
+            "source_quote_en": "Special levy of €5,000 per residential unit",
+        }
+    ],
+    "reserve_assessment": {
+        "reserve_balance_eur": 45000,
+        "assessment": "low",
+        "details": "Reserve of €45,000 across 10 units equals €4,500 per unit, below the €10,000 threshold.",
+    },
+    "upcoming_costs": [
+        {
+            "description": "Renewal of heating system",
+            "estimated_eur": None,
+            "timeline": "next year",
+            "source_quote_de": "Erneuerung der Heizungsanlage im nächsten Jahr",
+            "source_quote_en": "Renewal of the heating system next year",
+        }
+    ],
+    "disputes": [],
+    "meeting_dates": ["2024-03-15"],
+    "low_confidence_warning": False,
+    "is_ai_generated": True,
+}
+
+WEG_ANALYSIS_CLEAN = {
+    "risk_flags": [],
+    "reserve_assessment": {
+        "reserve_balance_eur": 120000,
+        "assessment": "adequate",
+        "details": "Reserve is well-funded.",
+    },
+    "upcoming_costs": [],
+    "disputes": [],
+    "meeting_dates": ["2024-01-10"],
+    "low_confidence_warning": False,
+    "is_ai_generated": True,
+}
+
+
+# --- _parse_response for weg_protokolle ---
+
+
+class TestParseWegResponse:
+    def test_valid_weg_response_parsed(self) -> None:
+        raw = json.dumps(WEG_ANALYSIS)
+        required = {"risk_flags", "reserve_assessment", "low_confidence_warning"}
+        result = _parse_response(raw, required)
+        assert result is not None
+        assert "risk_flags" in result
+        assert "reserve_assessment" in result
+        assert "low_confidence_warning" in result
+        assert result["is_ai_generated"] is True
+
+    def test_missing_required_keys_returns_none(self) -> None:
+        # Missing risk_flags key
+        incomplete = {
+            "reserve_assessment": {"reserve_balance_eur": None, "assessment": "unknown", "details": ""},
+            "low_confidence_warning": False,
+        }
+        required = {"risk_flags", "reserve_assessment", "low_confidence_warning"}
+        result = _parse_response(json.dumps(incomplete), required)
+        assert result is None
+
+
+# --- analyze_document_type for weg_protokolle ---
+
+
+class TestAnalyzeWegProtokolle:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_unsupported_type(self) -> None:
+        result = await analyze_document_type(WEG_PAGES, "expose")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_anthropic_not_configured(self) -> None:
+        with patch(
+            "app.services.document_type_analyzer_service._get_anthropic_client",
+            return_value=None,
+        ):
+            result = await analyze_document_type(WEG_PAGES, "weg_protokolle")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_analysis_on_success(self) -> None:
+        mock_client = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=json.dumps(WEG_ANALYSIS))]
+        mock_client.messages.create.return_value = mock_message
+
+        with patch(
+            "app.services.document_type_analyzer_service._get_anthropic_client",
+            return_value=mock_client,
+        ):
+            result = await analyze_document_type(WEG_PAGES, "weg_protokolle")
+
+        assert result is not None
+        assert "risk_flags" in result
+        assert "reserve_assessment" in result
+        assert "low_confidence_warning" in result
+        assert result["is_ai_generated"] is True
+
+    @pytest.mark.asyncio
+    async def test_sonderumlage_detected_as_high_risk(self) -> None:
+        mock_client = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=json.dumps(WEG_ANALYSIS))]
+        mock_client.messages.create.return_value = mock_message
+
+        with patch(
+            "app.services.document_type_analyzer_service._get_anthropic_client",
+            return_value=mock_client,
+        ):
+            result = await analyze_document_type(WEG_PAGES, "weg_protokolle")
+
+        assert result is not None
+        assert len(result["risk_flags"]) > 0
+        sonderumlage_flags = [
+            f for f in result["risk_flags"] if "sonderumlage" in f["flag"].lower()
+        ]
+        assert len(sonderumlage_flags) > 0
+        assert sonderumlage_flags[0]["risk_level"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_clean_protokoll_has_no_risk_flags(self) -> None:
+        mock_client = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = [MagicMock(text=json.dumps(WEG_ANALYSIS_CLEAN))]
+        mock_client.messages.create.return_value = mock_message
+
+        clean_pages = [
+            {"page_number": 1, "original_text": "Protokoll ohne besondere Vorkommnisse."}
+        ]
+
+        with patch(
+            "app.services.document_type_analyzer_service._get_anthropic_client",
+            return_value=mock_client,
+        ):
+            result = await analyze_document_type(clean_pages, "weg_protokolle")
+
+        assert result is not None
+        assert result["risk_flags"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self) -> None:
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = RuntimeError("API error")
+
+        with patch(
+            "app.services.document_type_analyzer_service._get_anthropic_client",
+            return_value=mock_client,
+        ):
+            result = await analyze_document_type(WEG_PAGES, "weg_protokolle")
+            assert result is None

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2425,7 +2425,7 @@ export const DocumentTranslationResponseSchema = {
 
 export const DocumentTypeSchema = {
     type: 'string',
-    enum: ['kaufvertrag', 'mietvertrag', 'expose', 'nebenkostenabrechnung', 'grundbuchauszug', 'teilungserklaerung', 'hausgeldabrechnung', 'wohnungsgrundriss', 'unknown'],
+    enum: ['kaufvertrag', 'mietvertrag', 'expose', 'nebenkostenabrechnung', 'grundbuchauszug', 'teilungserklaerung', 'hausgeldabrechnung', 'wohnungsgrundriss', 'weg_protokolle', 'unknown'],
     title: 'DocumentType',
     description: 'Types of German real estate documents.'
 } as const;

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -720,7 +720,7 @@ export type DocumentTranslationResponse = {
 /**
  * Types of German real estate documents.
  */
-export type DocumentType = 'kaufvertrag' | 'mietvertrag' | 'expose' | 'nebenkostenabrechnung' | 'grundbuchauszug' | 'teilungserklaerung' | 'hausgeldabrechnung' | 'wohnungsgrundriss' | 'unknown';
+export type DocumentType = 'kaufvertrag' | 'mietvertrag' | 'expose' | 'nebenkostenabrechnung' | 'grundbuchauszug' | 'teilungserklaerung' | 'hausgeldabrechnung' | 'wohnungsgrundriss' | 'weg_protokolle' | 'unknown';
 
 /**
  * Document type choices.

--- a/frontend/src/components/Documents/DocumentCard.tsx
+++ b/frontend/src/components/Documents/DocumentCard.tsx
@@ -44,6 +44,7 @@ const DOCUMENT_TYPE_LABELS: Record<DocumentType, string> = {
   teilungserklaerung: "Division Declaration",
   hausgeldabrechnung: "Condo Fee Statement",
   wohnungsgrundriss: "Floor Plan",
+  weg_protokolle: "WEG Meeting Minutes",
   unknown: "Unknown",
 }
 

--- a/frontend/src/components/Documents/TypeAnalysis.tsx
+++ b/frontend/src/components/Documents/TypeAnalysis.tsx
@@ -15,6 +15,7 @@ import type {
   RiskFlag,
   TeilungserklaerungAnalysis,
   WegProtokolleAnalysis,
+  WegReserveAssessment,
   WegRiskFlag,
   WohnungsgrundrissAnalysis,
 } from "@/models/document"
@@ -33,6 +34,17 @@ const RISK_LEVEL_STYLES: Record<string, string> = {
   medium:
     "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
   low: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+}
+
+const RESERVE_ASSESSMENT_STYLES: Record<
+  WegReserveAssessment["assessment"],
+  string
+> = {
+  adequate:
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  low: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  critical: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  unknown: "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400",
 }
 
 /******************************************************************************
@@ -344,14 +356,6 @@ function GrundrissView(props: Readonly<{ data: WohnungsgrundrissAnalysis }>) {
   )
 }
 
-const RESERVE_ASSESSMENT_STYLES: Record<string, string> = {
-  adequate:
-    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-  low: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
-  critical: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-  unknown: "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400",
-}
-
 interface IWegRiskFlagProps {
   flag: WegRiskFlag
 }
@@ -465,8 +469,8 @@ function WegProtokolleView(props: Readonly<{ data: WegProtokolleAnalysis }>) {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {data.upcomingCosts.map((cost) => (
-              <div key={cost.description} className="space-y-1">
+            {data.upcomingCosts.map((cost, i) => (
+              <div key={`${i}-${cost.description}`} className="space-y-1">
                 <div className="flex items-start justify-between gap-2">
                   <p className="text-sm font-medium">{cost.description}</p>
                   <div className="text-right shrink-0">
@@ -503,8 +507,8 @@ function WegProtokolleView(props: Readonly<{ data: WegProtokolleAnalysis }>) {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {data.disputes.map((dispute) => (
-              <div key={dispute.description} className="space-y-1">
+            {data.disputes.map((dispute, i) => (
+              <div key={`${i}-${dispute.description}`} className="space-y-1">
                 <div className="flex items-start justify-between gap-2">
                   <p className="text-sm font-medium">{dispute.description}</p>
                   <Badge variant="outline" className="text-xs shrink-0">

--- a/frontend/src/components/Documents/TypeAnalysis.tsx
+++ b/frontend/src/components/Documents/TypeAnalysis.tsx
@@ -1,10 +1,10 @@
 /**
  * Type Analysis Component
  * AI-generated structured analysis for Grundbuchauszug, Teilungserklärung,
- * Mietvertrag, and Wohnungsgrundriss document types
+ * Mietvertrag, Wohnungsgrundriss, and WEG-Protokolle document types
  */
 
-import { Bot } from "lucide-react"
+import { AlertTriangle, Bot } from "lucide-react"
 import { cn } from "@/common/utils"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -14,6 +14,8 @@ import type {
   MietvertragAnalysis,
   RiskFlag,
   TeilungserklaerungAnalysis,
+  WegProtokolleAnalysis,
+  WegRiskFlag,
   WohnungsgrundrissAnalysis,
 } from "@/models/document"
 
@@ -342,6 +344,192 @@ function GrundrissView(props: Readonly<{ data: WohnungsgrundrissAnalysis }>) {
   )
 }
 
+const RESERVE_ASSESSMENT_STYLES: Record<string, string> = {
+  adequate:
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  low: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  critical: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  unknown: "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400",
+}
+
+interface IWegRiskFlagProps {
+  flag: WegRiskFlag
+}
+
+/** Single WEG risk flag with source quotes. */
+function WegRiskFlagRow(props: Readonly<IWegRiskFlagProps>) {
+  const { flag } = props
+  return (
+    <div className="space-y-1">
+      <div className="flex items-start gap-2">
+        <Badge
+          variant="outline"
+          className={cn("text-xs shrink-0", RISK_LEVEL_STYLES[flag.riskLevel])}
+        >
+          {flag.riskLevel}
+        </Badge>
+        <div>
+          <p className="text-sm font-medium">{flag.flag}</p>
+          <p className="text-xs text-muted-foreground">{flag.description}</p>
+        </div>
+      </div>
+      {flag.sourceQuoteDe && (
+        <blockquote className="ml-4 pl-3 border-l-2 border-muted text-xs text-muted-foreground italic">
+          <p>{flag.sourceQuoteDe}</p>
+          {flag.sourceQuoteEn && (
+            <p className="mt-0.5 not-italic">{flag.sourceQuoteEn}</p>
+          )}
+        </blockquote>
+      )}
+    </div>
+  )
+}
+
+/** WEG meeting minutes (Protokolle) structured audit view. */
+function WegProtokolleView(props: Readonly<{ data: WegProtokolleAnalysis }>) {
+  const { data } = props
+  const hasNoIssues =
+    !data.lowConfidenceWarning &&
+    data.riskFlags.length === 0 &&
+    data.upcomingCosts.length === 0 &&
+    data.disputes.length === 0
+
+  return (
+    <div className="space-y-4">
+      {data.lowConfidenceWarning && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-900/20">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+          <p className="text-xs text-amber-800 dark:text-amber-300">
+            Low confidence — this document may contain OCR artifacts or be from
+            a scanned/handwritten source. Verify findings manually.
+          </p>
+        </div>
+      )}
+      {hasNoIssues && (
+        <Card className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20">
+          <CardContent className="pt-4">
+            <p className="text-sm text-green-800 dark:text-green-300">
+              No significant risk flags, upcoming costs, or disputes found in
+              this Protokoll.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+      {data.riskFlags.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Risk Flags</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {data.riskFlags.map((f) => (
+              <WegRiskFlagRow key={`${f.flag}-${f.riskLevel}`} flag={f} />
+            ))}
+          </CardContent>
+        </Card>
+      )}
+      {data.reserveAssessment && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">
+              Maintenance Reserve (Instandhaltungsrücklage)
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex items-center gap-3">
+              {data.reserveAssessment.reserveBalanceEur !== null && (
+                <span className="text-sm font-medium">
+                  €{data.reserveAssessment.reserveBalanceEur.toLocaleString()}
+                </span>
+              )}
+              <Badge
+                variant="outline"
+                className={cn(
+                  "text-xs",
+                  RESERVE_ASSESSMENT_STYLES[data.reserveAssessment.assessment],
+                )}
+              >
+                {data.reserveAssessment.assessment}
+              </Badge>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {data.reserveAssessment.details}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+      {data.upcomingCosts.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">
+              Upcoming Costs
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {data.upcomingCosts.map((cost) => (
+              <div key={cost.description} className="space-y-1">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-medium">{cost.description}</p>
+                  <div className="text-right shrink-0">
+                    {cost.estimatedEur !== null && (
+                      <p className="text-sm">
+                        €{cost.estimatedEur.toLocaleString()}
+                      </p>
+                    )}
+                    {cost.timeline && (
+                      <p className="text-xs text-muted-foreground">
+                        {cost.timeline}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                {cost.sourceQuoteDe && (
+                  <blockquote className="pl-3 border-l-2 border-muted text-xs text-muted-foreground italic">
+                    <p>{cost.sourceQuoteDe}</p>
+                    {cost.sourceQuoteEn && (
+                      <p className="mt-0.5 not-italic">{cost.sourceQuoteEn}</p>
+                    )}
+                  </blockquote>
+                )}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+      {data.disputes.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">
+              Legal Disputes
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {data.disputes.map((dispute) => (
+              <div key={dispute.description} className="space-y-1">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-medium">{dispute.description}</p>
+                  <Badge variant="outline" className="text-xs shrink-0">
+                    {dispute.status}
+                  </Badge>
+                </div>
+                {dispute.sourceQuoteDe && (
+                  <blockquote className="pl-3 border-l-2 border-muted text-xs text-muted-foreground italic">
+                    <p>{dispute.sourceQuoteDe}</p>
+                    {dispute.sourceQuoteEn && (
+                      <p className="mt-0.5 not-italic">
+                        {dispute.sourceQuoteEn}
+                      </p>
+                    )}
+                  </blockquote>
+                )}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
 /** Default component. Type-specific AI analysis viewer. */
 function TypeAnalysis(props: Readonly<IProps>) {
   const { documentType, typeAnalysis } = props
@@ -374,6 +562,11 @@ function TypeAnalysis(props: Readonly<IProps>) {
       {documentType === "wohnungsgrundriss" && (
         <GrundrissView
           data={typeAnalysis as unknown as WohnungsgrundrissAnalysis}
+        />
+      )}
+      {documentType === "weg_protokolle" && (
+        <WegProtokolleView
+          data={typeAnalysis as unknown as WegProtokolleAnalysis}
         />
       )}
     </div>

--- a/frontend/src/models/document.ts
+++ b/frontend/src/models/document.ts
@@ -12,6 +12,7 @@ export type DocumentType =
   | "teilungserklaerung"
   | "hausgeldabrechnung"
   | "wohnungsgrundriss"
+  | "weg_protokolle"
   | "unknown"
 
 export type DocumentStatus = "uploaded" | "processing" | "completed" | "failed"
@@ -150,6 +151,45 @@ export interface WohnungsgrundrissAnalysis {
   floor: string | null
   features: string[]
   notes: string[]
+  isAiGenerated: boolean
+}
+
+export interface WegRiskFlag {
+  flag: string
+  description: string
+  riskLevel: "low" | "medium" | "high"
+  sourceQuoteDe: string | null
+  sourceQuoteEn: string | null
+}
+
+export interface WegReserveAssessment {
+  reserveBalanceEur: number | null
+  assessment: "adequate" | "low" | "critical" | "unknown"
+  details: string
+}
+
+export interface WegUpcomingCost {
+  description: string
+  estimatedEur: number | null
+  timeline: string | null
+  sourceQuoteDe: string | null
+  sourceQuoteEn: string | null
+}
+
+export interface WegDispute {
+  description: string
+  status: string
+  sourceQuoteDe: string | null
+  sourceQuoteEn: string | null
+}
+
+export interface WegProtokolleAnalysis {
+  riskFlags: WegRiskFlag[]
+  reserveAssessment: WegReserveAssessment | null
+  upcomingCosts: WegUpcomingCost[]
+  disputes: WegDispute[]
+  meetingDates: string[]
+  lowConfidenceWarning: boolean
   isAiGenerated: boolean
 }
 


### PR DESCRIPTION
## Summary

- Adds `weg_protokolle` as the fifth typed AI analysis document type, following the identical pipeline pattern as Grundbuchauszug, Teilungserklärung, Mietvertrag, and Wohnungsgrundriss
- Claude system prompt extracts risk flags (Sonderumlage, legal disputes, structural work), maintenance reserve assessment, upcoming costs, and disputes — each with `source_quote_de` + `source_quote_en`
- Low-confidence warning banner shown when OCR artifacts are detected
- Frontend `WegProtokolleView` renders a full audit dashboard with risk level badges, blockquote source citations, and reserve adequacy badge

## Changes

**Backend**
- `g2h3i4j5k6l7` migration: `ALTER TYPE documenttype ADD VALUE 'weg_protokolle'`
- `DocumentType.WEG_PROTOKOLL` enum value + `_document_type_enum` PgEnum update
- WEG keyword list added to `DOCUMENT_TYPE_KEYWORDS`
- `weg_protokolle` added to `TYPED_ANALYSIS_TYPES`
- WEG system prompt + required keys in `document_type_analyzer_service.py`
- 8 unit tests covering: parse validation, unsupported type, no API key, success, Sonderumlage high-risk detection, clean Protokoll, API error

**Frontend**
- `DocumentType` union extended with `"weg_protokolle"`
- `WegRiskFlag`, `WegReserveAssessment`, `WegUpcomingCost`, `WegDispute`, `WegProtokolleAnalysis` interfaces
- `WegProtokolleView` component in `TypeAnalysis.tsx`
- `"WEG Meeting Minutes"` label in `DocumentCard`

## Test plan

- [ ] `pytest tests/services/test_weg_protokolle_analyzer.py -v` — 8/8 pass
- [ ] `bunx tsc --noEmit` — no errors
- [ ] `pre-commit run --all-files` — all hooks pass
- [ ] Upload a WEG Protokoll PDF → AI Analysis tab shows risk dashboard
- [ ] Sonderumlage text → high-risk red flag with source quote visible
- [ ] Clean Protokoll → green "no issues found" card