### PR TITLE
fix(security): add redis requirepass authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
               "SMTP_PASSWORD=" \
               "EMAILS_FROM_EMAIL=info@example.com" \
               "SENTRY_DSN=" \
+              "REDIS_PASSWORD=$(openssl rand -hex 16)" \
               > .env
 
       - run:

--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,10 @@ POSTGRES_PASSWORD=changethis
 SENTRY_DSN=
 
 # Redis (token blacklist + rate limiting)
-# Defaults to redis://localhost:6379 — set to redis://redis:6379 in Docker
+# Generate password with: openssl rand -hex 32
+REDIS_PASSWORD=changethis
+# Local dev: redis://localhost:6379 (no auth required for local-only redis)
+# Docker Compose: automatically set to redis://:${REDIS_PASSWORD}@redis:6379
 REDIS_URL=redis://localhost:6379
 
 # Configure these with your own Docker registry images

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -77,6 +77,7 @@ jobs:
         echo "SMTP_PASSWORD=" >> .env
         echo "EMAILS_FROM_EMAIL=info@example.com" >> .env
         echo "SENTRY_DSN=" >> .env
+        echo "REDIS_PASSWORD=$(openssl rand -hex 16)" >> .env
     - uses: oven-sh/setup-bun@v2
     - uses: actions/setup-python@v6
       with:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -42,6 +42,7 @@ jobs:
           echo "SMTP_PASSWORD=" >> .env
           echo "EMAILS_FROM_EMAIL=info@example.com" >> .env
           echo "SENTRY_DSN=" >> .env
+          echo "REDIS_PASSWORD=$(openssl rand -hex 16)" >> .env
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,10 @@ services:
   redis:
     image: redis:7-alpine
     restart: always
+    command: redis-server --requirepass ${REDIS_PASSWORD?Variable not set}
+    environment:
+      # Used by redis-cli in healthcheck to authenticate without passing -a flag
+      - REDISCLI_AUTH=${REDIS_PASSWORD?Variable not set}
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -88,7 +92,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER?Variable not set}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
       - SENTRY_DSN=${SENTRY_DSN}
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD?Variable not set}@redis:6379
 
   backend:
     image: '${DOCKER_IMAGE_BACKEND?Variable not set}:${TAG-latest}'
@@ -123,7 +127,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER?Variable not set}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
       - SENTRY_DSN=${SENTRY_DSN}
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://:${REDIS_PASSWORD?Variable not set}@redis:6379
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/utils/health-check/"]


### PR DESCRIPTION
## Summary
- Redis was deployed without authentication, exposing the JWT blacklist and rate-limit state to any container on the Docker network
- Adds `--requirepass` to the Redis service command in `compose.yml`
- Uses `REDISCLI_AUTH` env var on the Redis container so the existing `redis-cli ping` healthcheck authenticates transparently
- Updates `REDIS_URL` for `prestart` and `backend` services to `redis://:${REDIS_PASSWORD}@redis:6379`
- Adds `REDIS_PASSWORD` to `.env.example` with generation instructions

## Test plan
- [ ] Set `REDIS_PASSWORD` in `.env`, run `docker compose up redis` — healthcheck must pass (green)
- [ ] `docker compose exec redis redis-cli ping` without `-a` flag → `(error) NOAUTH` (auth required)
- [ ] `docker compose exec redis redis-cli -a $REDIS_PASSWORD ping` → `PONG`
- [ ] Login, logout, attempt re-use of revoked token → `401 Unauthorized` (blacklist still works)
- [ ] Rate limiting still applies after repeated failed logins
- [ ] All CI backend tests pass (tests use fakeredis, unaffected by requirepass)