### PR TITLE
fix(security): remove adminer from production deployment

### DIFF
--- a/compose.override.yml
+++ b/compose.override.yml
@@ -56,7 +56,12 @@ services:
       - "5432:5432"
 
   adminer:
+    image: adminer
     restart: "no"
+    depends_on:
+      - db
+    environment:
+      - ADMINER_DESIGN=pepa-linha-dark
     ports:
       - "8080:8080"
 

--- a/compose.yml
+++ b/compose.yml
@@ -35,29 +35,6 @@ services:
       - POSTGRES_USER=${POSTGRES_USER?Variable not set}
       - POSTGRES_DB=${POSTGRES_DB?Variable not set}
 
-  adminer:
-    image: adminer
-    restart: always
-    networks:
-      - traefik-public
-      - default
-    depends_on:
-      - db
-    environment:
-      - ADMINER_DESIGN=pepa-linha-dark
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=traefik-public
-      - traefik.constraint-label=traefik-public
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-http.rule=Host(`adminer.${DOMAIN?Variable not set}`)
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-http.entrypoints=http
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-http.middlewares=https-redirect
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.rule=Host(`adminer.${DOMAIN?Variable not set}`)
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.entrypoints=https
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.tls=true
-      - traefik.http.routers.${STACK_NAME?Variable not set}-adminer-https.tls.certresolver=le
-      - traefik.http.services.${STACK_NAME?Variable not set}-adminer.loadbalancer.server.port=8080
-
   prestart:
     image: '${DOCKER_IMAGE_BACKEND?Variable not set}:${TAG-latest}'
     build:


### PR DESCRIPTION
## Summary
- Adminer (a full database management web UI) was deployed in production via `compose.yml` and exposed over HTTPS via Traefik with zero authentication — any actor with DB credentials could access all tables
- Removes the `adminer` service from `compose.yml` (production)
- Moves the full Adminer service definition to `compose.override.yml` so local developers can still access it at `http://localhost:8080`

## Test plan
- [ ] `docker compose config` (production config) contains no `adminer` service
- [ ] `curl https://adminer.{DOMAIN}` → Traefik 404 after redeployment
- [ ] Local dev: `docker compose up adminer` starts correctly at `localhost:8080`
- [ ] Backend, frontend, and database services unaffected