### PR TITLE
fix(security): add rate limiting to legacy login and restrict trusted proxy IPs

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
@@ -11,6 +11,7 @@ from app.api.deps import CurrentUser, SessionDep, get_current_active_superuser
 from app.core import security
 from app.core.config import settings
 from app.models import Message, NewPassword, Token, UserPublic, UserUpdate
+from app.services import rate_limit_service
 from app.utils import (
     generate_password_reset_token,
     generate_reset_password_email,
@@ -40,13 +41,21 @@ def login_access_token(
         auto-generated Swagger UI "Authorize" button) and will be removed in a
         future release.
     """
+    if rate_limit_service.is_locked(form_data.username):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many failed login attempts. Please try again later.",
+            headers={"Retry-After": "900"},
+        )
     user = crud.authenticate(
         session=session, email=form_data.username, password=form_data.password
     )
     if not user:
+        rate_limit_service.record_failed_attempt(form_data.username)
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     elif not user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")
+    rate_limit_service.record_successful_login(form_data.username)
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     return Token(
         access_token=security.create_access_token(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -193,5 +193,14 @@ class Settings(BaseSettings):
 
         return self
 
+    @model_validator(mode="after")
+    def _enforce_trusted_proxy_ips(self) -> Self:
+        if self.ENVIRONMENT != "local" and self.TRUSTED_PROXY_IPS == "*":
+            raise ValueError(
+                "TRUSTED_PROXY_IPS must not be '*' in staging or production. "
+                "Set it to the Azure load balancer CIDR (e.g. '10.0.0.0/8')."
+            )
+        return self
+
 
 settings = Settings()  # type: ignore

--- a/backend/tests/api/routes/test_login.py
+++ b/backend/tests/api/routes/test_login.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import fakeredis
+import pytest
 from fastapi.testclient import TestClient
 from pwdlib.hashers.bcrypt import BcryptHasher
 from sqlmodel import Session
@@ -11,6 +13,14 @@ from app.models import User, UserCreate
 from app.utils import generate_password_reset_token
 from tests.utils.user import user_authentication_headers
 from tests.utils.utils import random_email, random_lower_string
+
+
+@pytest.fixture()
+def isolated_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> fakeredis.FakeRedis:
+    """Provide isolated fakeredis for rate-limit tests in this module."""
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr("app.services.rate_limit_service._redis_client", fake)
+    return fake
 
 
 def test_get_access_token(client: TestClient) -> None:
@@ -189,3 +199,46 @@ def test_login_with_argon2_password_keeps_hash(client: TestClient, db: Session) 
 
     assert user.hashed_password == original_hash
     assert user.hashed_password.startswith("$argon2")
+
+
+def test_legacy_login_rate_limit_locks_after_5_failures(
+    client: TestClient,
+    isolated_rate_limiter: fakeredis.FakeRedis,  # noqa: ARG001
+) -> None:
+    """After 5 failed attempts the legacy endpoint returns 429."""
+    bad_data = {
+        "username": settings.FIRST_SUPERUSER,
+        "password": "wrong-password-1",
+    }
+    for _ in range(5):
+        r = client.post(f"{settings.API_V1_STR}/login/access-token", data=bad_data)
+        assert r.status_code == 400
+
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=bad_data)
+    assert r.status_code == 429
+    assert "Retry-After" in r.headers
+
+
+def test_legacy_login_rate_limit_cleared_on_success(
+    client: TestClient,
+    isolated_rate_limiter: fakeredis.FakeRedis,  # noqa: ARG001
+) -> None:
+    """A successful login clears the failure counter."""
+    bad_data = {
+        "username": settings.FIRST_SUPERUSER,
+        "password": "wrong-password-1",
+    }
+    for _ in range(3):
+        client.post(f"{settings.API_V1_STR}/login/access-token", data=bad_data)
+
+    good_data = {
+        "username": settings.FIRST_SUPERUSER,
+        "password": settings.FIRST_SUPERUSER_PASSWORD,
+    }
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=good_data)
+    assert r.status_code == 200
+
+    # Counter cleared — 5 more failures should be allowed before lock
+    for _ in range(5):
+        r = client.post(f"{settings.API_V1_STR}/login/access-token", data=bad_data)
+        assert r.status_code == 400

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -1,0 +1,63 @@
+"""Tests for Settings validation in app.core.config."""
+
+import pytest
+
+from app.core.config import Settings
+
+
+def _base_settings_kwargs() -> dict:
+    """Minimal kwargs required to instantiate Settings without reading .env."""
+    return {
+        "PROJECT_NAME": "test",
+        "POSTGRES_SERVER": "localhost",
+        "POSTGRES_USER": "test",
+        "POSTGRES_PASSWORD": "test",
+        "POSTGRES_DB": "test",
+        "FIRST_SUPERUSER": "admin@example.com",
+        "FIRST_SUPERUSER_PASSWORD": "test",
+        "SECRET_KEY": "test-secret",
+    }
+
+
+def test_trusted_proxy_ips_wildcard_rejected_in_staging() -> None:
+    """TRUSTED_PROXY_IPS='*' must raise ValueError in staging."""
+    with pytest.raises(ValueError, match="TRUSTED_PROXY_IPS"):
+        Settings(
+            **_base_settings_kwargs(),
+            ENVIRONMENT="staging",
+            TRUSTED_PROXY_IPS="*",
+            _env_file=None,
+        )
+
+
+def test_trusted_proxy_ips_wildcard_rejected_in_production() -> None:
+    """TRUSTED_PROXY_IPS='*' must raise ValueError in production."""
+    with pytest.raises(ValueError, match="TRUSTED_PROXY_IPS"):
+        Settings(
+            **_base_settings_kwargs(),
+            ENVIRONMENT="production",
+            TRUSTED_PROXY_IPS="*",
+            _env_file=None,
+        )
+
+
+def test_trusted_proxy_ips_wildcard_allowed_in_local() -> None:
+    """TRUSTED_PROXY_IPS='*' is permitted in local environment."""
+    s = Settings(
+        **_base_settings_kwargs(),
+        ENVIRONMENT="local",
+        TRUSTED_PROXY_IPS="*",
+        _env_file=None,
+    )
+    assert s.TRUSTED_PROXY_IPS == "*"
+
+
+def test_trusted_proxy_ips_cidr_allowed_in_production() -> None:
+    """A specific CIDR range is accepted in production."""
+    s = Settings(
+        **_base_settings_kwargs(),
+        ENVIRONMENT="production",
+        TRUSTED_PROXY_IPS="10.0.0.0/8",
+        _env_file=None,
+    )
+    assert s.TRUSTED_PROXY_IPS == "10.0.0.0/8"


### PR DESCRIPTION
## Summary
- **H2**: Add `is_locked` / `record_failed_attempt` / `record_successful_login` calls to the legacy `POST /login/access-token` endpoint — previously had no brute-force protection
- **H3**: Add `model_validator` to `Settings` that raises `ValueError` when `TRUSTED_PROXY_IPS='*'` in staging or production, preventing X-Forwarded-For spoofing in non-local environments

## Changes
- `backend/app/api/routes/login.py` — rate-limit the legacy login endpoint using the existing `rate_limit_service`
- `backend/app/core/config.py` — new `_enforce_trusted_proxy_ips` validator; wildcard `*` now fails at startup in non-local envs
- `backend/tests/api/routes/test_login.py` — two new tests: lock after 5 failures, counter clears on success
- `backend/tests/core/test_config.py` — four new tests covering the `TRUSTED_PROXY_IPS` validator for all environments

## Test plan
- [ ] `pytest tests/api/routes/test_login.py` — all 11 tests pass
- [ ] `pytest tests/core/test_config.py` — all 4 tests pass
- [ ] `pre-commit run --all-files` — clean
- [ ] All CI checks pass