### PR TITLE
feat(security): migrate JWT storage from localStorage to HttpOnly cookies

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -2,7 +2,7 @@ from collections.abc import AsyncGenerator, Generator
 from typing import Annotated
 
 import jwt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt.exceptions import InvalidTokenError
 from pydantic import ValidationError
@@ -41,10 +41,32 @@ async def get_async_db() -> AsyncGenerator[AsyncSession, None]:
 
 SessionDep = Annotated[Session, Depends(get_db)]
 AsyncSessionDep = Annotated[AsyncSession, Depends(get_async_db)]
+# Kept for Swagger UI compatibility (Bearer token via OAuth2 flow)
 TokenDep = Annotated[str, Depends(reusable_oauth2)]
 
 
-def get_current_user(session: SessionDep, token: TokenDep) -> User:
+def _resolve_token(
+    request: Request,
+    bearer: Annotated[str | None, Depends(reusable_oauth2_optional)] = None,
+) -> str | None:
+    """Return the best available access token: Bearer header first, then cookie.
+
+    Reading the cookie via ``request.cookies`` (not via FastAPI's ``Cookie()``
+    parameter type) prevents the cookie from being documented in the OpenAPI
+    schema, which would pollute every endpoint's generated SDK input type.
+    """
+    return bearer or request.cookies.get("access_token")
+
+
+def get_current_user(
+    session: SessionDep,
+    token: Annotated[str | None, Depends(_resolve_token)] = None,
+) -> User:
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
     try:
         payload = jwt.decode(
             token, settings.SECRET_KEY, algorithms=[security.ALGORITHM]
@@ -74,7 +96,7 @@ CurrentUser = Annotated[User, Depends(get_current_user)]
 
 def get_optional_current_user(
     session: SessionDep,
-    token: Annotated[str | None, Depends(reusable_oauth2_optional)] = None,
+    token: Annotated[str | None, Depends(_resolve_token)] = None,
 ) -> User | None:
     """Return the current user if a valid token is provided, otherwise None."""
     if not token:

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -252,11 +252,11 @@ async def login(
     )
     # JS-readable indicator so the frontend can check login state synchronously.
     # httponly=False is intentional: this cookie contains no secret, only the
-    # boolean "1" to signal to isLoggedIn() that an HttpOnly access token exists.  # NOSONAR - S3330 false positive: non-httponly is intentional for this indicator cookie
-    response.set_cookie(
+    # boolean "1" to signal to isLoggedIn() that an HttpOnly access token exists.
+    response.set_cookie(  # NOSONAR - S3330: httponly=False intentional for UI indicator
         key="logged_in",
         value="1",
-        httponly=False,  # NOSONAR
+        httponly=False,
         secure=secure,
         samesite="lax",
         max_age=access_max_age,
@@ -312,11 +312,10 @@ async def refresh_token(
     # logged_in follows the refresh token lifetime so the indicator stays valid
     # as long as silent refresh is possible (not just the current access token window).
     # httponly=False is intentional: see the login endpoint comment.
-    # NOSONAR - S3330 false positive: non-httponly is intentional for this indicator cookie
-    response.set_cookie(
+    response.set_cookie(  # NOSONAR - S3330: httponly=False intentional for UI indicator
         key="logged_in",
         value="1",
-        httponly=False,  # NOSONAR
+        httponly=False,
         secure=secure,
         samesite="lax",
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -9,7 +9,7 @@ Provides registration and login endpoints with:
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlmodel import Session, select
 
 from app.api.deps import get_db
@@ -147,6 +147,7 @@ async def register(
 @router.post("/login", response_model=AuthToken)
 async def login(
     request: LoginRequest,
+    response: Response,
     session: Session = Depends(get_db),
 ) -> AuthToken:
     """
@@ -155,6 +156,8 @@ async def login(
     Rate limiting: After 5 failed attempts, the account is locked for 15 minutes.
 
     Returns access token (24h or 30d with remember_me) and refresh token (7d).
+    Also sets HttpOnly cookies: ``access_token``, ``refresh_token``, and a
+    JS-readable ``logged_in`` indicator cookie.
     """
     # Check if account is locked due to rate limiting
     if rate_limit_service.is_locked(request.email):
@@ -218,43 +221,133 @@ async def login(
         subject=str(user.id),
         remember_me=request.remember_me,
     )
-    refresh_token = auth_service.create_refresh_token(subject=str(user.id))
+    refresh_token_value = auth_service.create_refresh_token(subject=str(user.id))
+
+    # Set HttpOnly cookies so the browser never exposes tokens to JS
+    secure = settings.ENVIRONMENT != "local"
+    access_max_age = (
+        settings.REMEMBER_ME_EXPIRE_DAYS * 24 * 60 * 60
+        if request.remember_me
+        else settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+    )
+    refresh_max_age = settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60
+
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        max_age=access_max_age,
+        path="/",
+    )
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token_value,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        max_age=refresh_max_age,
+        path="/",
+    )
+    # JS-readable indicator so the frontend can check login state synchronously
+    response.set_cookie(
+        key="logged_in",
+        value="1",
+        httponly=False,
+        secure=secure,
+        samesite="lax",
+        max_age=access_max_age,
+        path="/",
+    )
 
     return AuthToken(
         access_token=access_token,
-        refresh_token=refresh_token,
+        refresh_token=refresh_token_value,
     )
 
 
 @router.post("/refresh", response_model=AuthToken)
-async def refresh_token(request: RefreshTokenRequest) -> AuthToken:
+async def refresh_token(
+    body: RefreshTokenRequest,
+    http_request: Request,
+    response: Response,
+) -> AuthToken:
     """
     Get new access token using refresh token.
 
     The refresh token is validated and a new access token is issued.
     The same refresh token remains valid until expiration.
+
+    The refresh token may be supplied in the JSON body **or** via the HttpOnly
+    ``refresh_token`` cookie set during login.
     """
-    new_access_token = auth_service.refresh_access_token(request.refresh_token)
+    token = body.refresh_token or http_request.cookies.get("refresh_token")
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
+    new_access_token = auth_service.refresh_access_token(token)
     if new_access_token is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
         )
 
+    # Rotate the access_token cookie
+    secure = settings.ENVIRONMENT != "local"
+    response.set_cookie(
+        key="access_token",
+        value=new_access_token,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        path="/",
+    )
+    # logged_in follows the refresh token lifetime so the indicator stays valid
+    # as long as silent refresh is possible (not just the current access token window)
+    response.set_cookie(
+        key="logged_in",
+        value="1",
+        httponly=False,
+        secure=secure,
+        samesite="lax",
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        path="/",
+    )
+
     return AuthToken(
         access_token=new_access_token,
-        refresh_token=request.refresh_token,  # Return same refresh token
+        refresh_token=token,  # Return same refresh token
     )
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
-async def logout(request: LogoutRequest) -> None:
+async def logout(
+    body: LogoutRequest,
+    http_request: Request,
+    response: Response,
+) -> None:
     """
-    Logout by invalidating the refresh token.
+    Logout by invalidating the refresh token and clearing auth cookies.
 
-    The refresh token is blacklisted and cannot be used again.
+    The refresh token (from body or cookie) is blacklisted and cannot be used
+    again.  All auth cookies (``access_token``, ``refresh_token``, ``logged_in``)
+    are deleted from the browser.
     """
-    auth_service.logout(request.refresh_token)
+    token = body.refresh_token or http_request.cookies.get("refresh_token")
+    if token:
+        auth_service.logout(token)
+    # Always clear cookies regardless of token validity.
+    # secure + samesite must match the attributes used when setting the cookies
+    # so that browsers (especially Safari) actually remove them.
+    secure = settings.ENVIRONMENT != "local"
+    response.delete_cookie(key="access_token", path="/", secure=secure, samesite="lax")
+    response.delete_cookie(key="refresh_token", path="/", secure=secure, samesite="lax")
+    response.delete_cookie(key="logged_in", path="/", secure=secure, samesite="lax")
     # Always return success even if token was invalid (security best practice)
 
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -250,11 +250,13 @@ async def login(
         max_age=refresh_max_age,
         path="/",
     )
-    # JS-readable indicator so the frontend can check login state synchronously
+    # JS-readable indicator so the frontend can check login state synchronously.
+    # httponly=False is intentional: this cookie contains no secret, only the
+    # boolean "1" to signal to isLoggedIn() that an HttpOnly access token exists.  # NOSONAR - S3330 false positive: non-httponly is intentional for this indicator cookie
     response.set_cookie(
         key="logged_in",
         value="1",
-        httponly=False,
+        httponly=False,  # NOSONAR
         secure=secure,
         samesite="lax",
         max_age=access_max_age,
@@ -308,11 +310,13 @@ async def refresh_token(
         path="/",
     )
     # logged_in follows the refresh token lifetime so the indicator stays valid
-    # as long as silent refresh is possible (not just the current access token window)
+    # as long as silent refresh is possible (not just the current access token window).
+    # httponly=False is intentional: see the login endpoint comment.
+    # NOSONAR - S3330 false positive: non-httponly is intentional for this indicator cookie
     response.set_cookie(
         key="logged_in",
         value="1",
-        httponly=False,
+        httponly=False,  # NOSONAR
         secure=secure,
         samesite="lax",
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -74,10 +74,12 @@ def login_access_token(
         max_age=access_max_age,
         path="/",
     )
+    # httponly=False is intentional: non-secret indicator for isLoggedIn() in JS.
+    # NOSONAR - S3330 false positive: non-httponly is intentional for this indicator cookie
     response.set_cookie(
         key="logged_in",
         value="1",
-        httponly=False,
+        httponly=False,  # NOSONAR
         secure=secure,
         samesite="lax",
         max_age=access_max_age,

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
@@ -28,7 +28,9 @@ class PasswordRecoveryRequest(BaseModel):
 
 @router.post("/login/access-token")
 def login_access_token(
-    session: SessionDep, form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+    session: SessionDep,
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    response: Response,
 ) -> Token:
     """
     OAuth2 compatible token login, get an access token for future requests.
@@ -57,11 +59,31 @@ def login_access_token(
         raise HTTPException(status_code=400, detail="Inactive user")
     rate_limit_service.record_successful_login(form_data.username)
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    return Token(
-        access_token=security.create_access_token(
-            user.id, expires_delta=access_token_expires
-        )
+    access_token = security.create_access_token(
+        user.id, expires_delta=access_token_expires
     )
+    # Set HttpOnly cookie so the browser never exposes the token to JS
+    secure = settings.ENVIRONMENT != "local"
+    access_max_age = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        max_age=access_max_age,
+        path="/",
+    )
+    response.set_cookie(
+        key="logged_in",
+        value="1",
+        httponly=False,
+        secure=secure,
+        samesite="lax",
+        max_age=access_max_age,
+        path="/",
+    )
+    return Token(access_token=access_token)
 
 
 @router.post("/login/test-token", response_model=UserPublic)

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -75,11 +75,10 @@ def login_access_token(
         path="/",
     )
     # httponly=False is intentional: non-secret indicator for isLoggedIn() in JS.
-    # NOSONAR - S3330 false positive: non-httponly is intentional for this indicator cookie
-    response.set_cookie(
+    response.set_cookie(  # NOSONAR - S3330: httponly=False intentional for UI indicator
         key="logged_in",
         value="1",
-        httponly=False,  # NOSONAR
+        httponly=False,
         secure=secure,
         samesite="lax",
         max_age=access_max_age,

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -62,15 +62,23 @@ class AuthToken(BaseModel):
 
 
 class RefreshTokenRequest(BaseModel):
-    """Schema for token refresh request."""
+    """Schema for token refresh request.
 
-    refresh_token: str
+    ``refresh_token`` may be omitted when the client sends it as an HttpOnly
+    cookie instead of a JSON body field.
+    """
+
+    refresh_token: str | None = None
 
 
 class LogoutRequest(BaseModel):
-    """Schema for logout request."""
+    """Schema for logout request.
 
-    refresh_token: str
+    ``refresh_token`` may be omitted when the client sends it as an HttpOnly
+    cookie instead of a JSON body field.
+    """
+
+    refresh_token: str | None = None
 
 
 class VerifyEmailRequest(BaseModel):

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -187,6 +187,67 @@ def test_login_remember_me_issues_longer_token(client: TestClient) -> None:
     # A longer token is returned — the exact payload is validated in unit tests
 
 
+def test_login_sets_httponly_cookies(client: TestClient) -> None:
+    """Successful login must set access_token and refresh_token as HttpOnly cookies."""
+    email = random_email()
+    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+
+    r = client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
+    assert r.status_code == 200
+    assert "access_token" in r.cookies
+    assert "refresh_token" in r.cookies
+    assert "logged_in" in r.cookies
+    assert r.cookies["logged_in"] == "1"
+
+
+def test_cookie_auth_allows_protected_endpoint(client: TestClient) -> None:
+    """access_token cookie must be accepted by the auth dependency (no Bearer header)."""
+    email = random_email()
+    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
+    # TestClient persists cookies from previous responses automatically
+    r = client.post(f"{settings.API_V1_STR}/login/test-token")
+    assert r.status_code == 200
+    assert r.json()["email"] == email
+
+
+def test_logout_clears_cookies(client: TestClient) -> None:
+    """logout must delete access_token, refresh_token, and logged_in cookies."""
+    email = random_email()
+    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    login_r = client.post(
+        f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD}
+    )
+    assert login_r.status_code == 200
+
+    r = client.post(f"{AUTH}/logout", json={})
+    assert r.status_code == 204
+    # Cookies deleted: the jar should no longer have them
+    assert "access_token" not in client.cookies
+    assert "refresh_token" not in client.cookies
+    assert "logged_in" not in client.cookies
+
+
+def test_logout_via_cookie_token(client: TestClient) -> None:
+    """logout without body must use the refresh_token cookie to blacklist the token."""
+    email = random_email()
+    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    login_r = client.post(
+        f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD}
+    )
+    assert login_r.status_code == 200
+    refresh_cookie = client.cookies.get("refresh_token")
+    assert refresh_cookie is not None
+
+    # Logout without body — should use the cookie
+    r = client.post(f"{AUTH}/logout", json={})
+    assert r.status_code == 204
+
+    # The refresh token from the cookie must now be blacklisted
+    r2 = client.post(f"{AUTH}/refresh", json={"refresh_token": refresh_cookie})
+    assert r2.status_code == 401
+
+
 # ── refresh ───────────────────────────────────────────────────────────────────
 
 
@@ -218,6 +279,20 @@ def test_refresh_with_access_token_returns_401(client: TestClient) -> None:
     # Pass the access token where a refresh token is expected
     r = client.post(f"{AUTH}/refresh", json={"refresh_token": tokens["access_token"]})
     assert r.status_code == 401
+
+
+def test_refresh_via_cookie_token(client: TestClient) -> None:
+    """Calling /auth/refresh with no body must use the refresh_token cookie."""
+    _register_and_login(client)
+    # At this point client.cookies holds the refresh_token cookie from login
+    assert client.cookies.get("refresh_token") is not None
+
+    r = client.post(f"{AUTH}/refresh", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert "access_token" in body
+    # access_token cookie must be rotated in the response
+    assert "access_token" in r.cookies
 
 
 # ── logout ────────────────────────────────────────────────────────────────────

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,6 +36,22 @@ def client() -> Generator[TestClient, None, None]:
         yield c
 
 
+@pytest.fixture(autouse=True)
+def clear_client_cookies(request: pytest.FixtureRequest) -> None:
+    """Clear the module-scoped client's cookie jar before each test.
+
+    Login endpoints now set HttpOnly cookies.  Without this fixture, cookies
+    from one test would leak into the next, causing "unauthenticated" tests to
+    accidentally pass because the cookie jar still holds a valid access_token.
+
+    Only active when the ``client`` fixture is already used by the current test
+    so that unit/seed test modules without an HTTP client are not affected.
+    """
+    if "client" in request.fixturenames:
+        http_client: TestClient = request.getfixturevalue("client")
+        http_client.cookies.clear()
+
+
 @pytest.fixture(scope="module")
 def superuser_token_headers(client: TestClient) -> dict[str, str]:
     return get_superuser_token_headers(client)

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4813,14 +4813,23 @@ export const LoginRequestSchema = {
 export const LogoutRequestSchema = {
     properties: {
         refresh_token: {
-            type: 'string',
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Refresh Token'
         }
     },
     type: 'object',
-    required: ['refresh_token'],
     title: 'LogoutRequest',
-    description: 'Schema for logout request.'
+    description: `Schema for logout request.
+
+\`\`refresh_token\`\` may be omitted when the client sends it as an HttpOnly
+cookie instead of a JSON body field.`
 } as const;
 
 export const MarketInsightsDataSchema = {
@@ -8369,14 +8378,23 @@ export const RecurrenceIntervalSchema = {
 export const RefreshTokenRequestSchema = {
     properties: {
         refresh_token: {
-            type: 'string',
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Refresh Token'
         }
     },
     type: 'object',
-    required: ['refresh_token'],
     title: 'RefreshTokenRequest',
-    description: 'Schema for token refresh request.'
+    description: `Schema for token refresh request.
+
+\`\`refresh_token\`\` may be omitted when the client sends it as an HttpOnly
+cookie instead of a JSON body field.`
 } as const;
 
 export const RegisterRequestSchema = {

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -217,6 +217,8 @@ export class AuthService {
      * Rate limiting: After 5 failed attempts, the account is locked for 15 minutes.
      *
      * Returns access token (24h or 30d with remember_me) and refresh token (7d).
+     * Also sets HttpOnly cookies: ``access_token``, ``refresh_token``, and a
+     * JS-readable ``logged_in`` indicator cookie.
      * @param data The data for the request.
      * @param data.requestBody
      * @returns AuthToken Successful Response
@@ -240,6 +242,9 @@ export class AuthService {
      *
      * The refresh token is validated and a new access token is issued.
      * The same refresh token remains valid until expiration.
+     *
+     * The refresh token may be supplied in the JSON body **or** via the HttpOnly
+     * ``refresh_token`` cookie set during login.
      * @param data The data for the request.
      * @param data.requestBody
      * @returns AuthToken Successful Response
@@ -259,9 +264,11 @@ export class AuthService {
     
     /**
      * Logout
-     * Logout by invalidating the refresh token.
+     * Logout by invalidating the refresh token and clearing auth cookies.
      *
-     * The refresh token is blacklisted and cannot be used again.
+     * The refresh token (from body or cookie) is blacklisted and cannot be used
+     * again.  All auth cookies (``access_token``, ``refresh_token``, ``logged_in``)
+     * are deleted from the browser.
      * @param data The data for the request.
      * @param data.requestBody
      * @returns void Successful Response

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1432,9 +1432,12 @@ export type LoginRequest = {
 
 /**
  * Schema for logout request.
+ *
+ * ``refresh_token`` may be omitted when the client sends it as an HttpOnly
+ * cookie instead of a JSON body field.
  */
 export type LogoutRequest = {
-    refresh_token: string;
+    refresh_token?: (string | null);
 };
 
 /**
@@ -2115,9 +2118,12 @@ export type RecurrenceInterval = 'monthly' | 'annually';
 
 /**
  * Schema for token refresh request.
+ *
+ * ``refresh_token`` may be omitted when the client sends it as an HttpOnly
+ * cookie instead of a JSON body field.
  */
 export type RefreshTokenRequest = {
-    refresh_token: string;
+    refresh_token?: (string | null);
 };
 
 /**

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -13,8 +13,14 @@ import { queryClient } from "@/query/client"
 import { handleError } from "@/utils"
 import useCustomToast from "./useCustomToast"
 
+/**
+ * Returns true when the JS-readable `logged_in` cookie is present.
+ * This cookie is set by the server on login alongside the HttpOnly
+ * `access_token` cookie.  It lets us check auth state synchronously
+ * (e.g. in TanStack Router `beforeLoad`) without touching localStorage.
+ */
 const isLoggedIn = () => {
-  return localStorage.getItem("access_token") !== null
+  return document.cookie.split(";").some((c) => c.trim() === "logged_in=1")
 }
 
 const useAuth = (redirectTo?: string) => {
@@ -37,11 +43,10 @@ const useAuth = (redirectTo?: string) => {
   })
 
   const login = async (data: AccessToken) => {
-    const response = await LoginService.loginAccessToken({
-      formData: data,
-    })
+    await LoginService.loginAccessToken({ formData: data })
     queryClient.clear()
-    localStorage.setItem("access_token", response.access_token)
+    // Auth tokens are stored in HttpOnly cookies by the server.
+    // No localStorage write needed.
   }
 
   const loginMutation = useMutation({
@@ -56,9 +61,16 @@ const useAuth = (redirectTo?: string) => {
     onError: handleError.bind(showErrorToast),
   })
 
-  const logout = () => {
+  const logout = async () => {
+    try {
+      // Ask the server to blacklist the refresh token (from cookie) and delete
+      // auth cookies.  The server accepts an empty body and falls back to the
+      // HttpOnly refresh_token cookie automatically.
+      await AuthService.logout({ requestBody: {} })
+    } catch {
+      // Ignore errors — proceed with client-side cleanup regardless
+    }
     queryClient.clear()
-    localStorage.removeItem("access_token")
     localStorage.removeItem("heimpath-wizard-state")
     localStorage.removeItem("heimpath-wizard-step")
     localStorage.removeItem("heimpath-email-banner-dismissed-at")

--- a/frontend/src/services/common/API/client.ts
+++ b/frontend/src/services/common/API/client.ts
@@ -1,45 +1,25 @@
 /**
  * API Client wrapper
- * Provides a consistent interface for API calls with auth token handling
+ * Provides a consistent interface for API calls with auth state handling
  */
 
 import { OpenAPI } from "@/client"
 
 /**
- * Initialize the API client with the base URL and token handler
- * Called once at app startup
+ * Initialize the API client with the base URL.
+ * Auth is handled via HttpOnly cookies — no token is stored in JS memory.
+ * withCredentials is enabled so the browser sends cookies on every request.
  */
 export function initializeApiClient() {
   OpenAPI.BASE = import.meta.env.VITE_API_URL
-  OpenAPI.TOKEN = async () => {
-    return localStorage.getItem("access_token") || ""
-  }
+  OpenAPI.WITH_CREDENTIALS = true
 }
 
 /**
- * Get the current auth token
- */
-export function getAuthToken(): string | null {
-  return localStorage.getItem("access_token")
-}
-
-/**
- * Set the auth token
- */
-export function setAuthToken(token: string): void {
-  localStorage.setItem("access_token", token)
-}
-
-/**
- * Clear the auth token (logout)
- */
-export function clearAuthToken(): void {
-  localStorage.removeItem("access_token")
-}
-
-/**
- * Check if user is authenticated
+ * Check if user is authenticated using the JS-readable `logged_in` indicator
+ * cookie set by the server on login.  This is intentionally synchronous so it
+ * can be called from TanStack Router's `beforeLoad`.
  */
 export function isAuthenticated(): boolean {
-  return getAuthToken() !== null
+  return document.cookie.split(";").some((c) => c.trim() === "logged_in=1")
 }

--- a/frontend/src/services/common/API/client.ts
+++ b/frontend/src/services/common/API/client.ts
@@ -9,9 +9,14 @@ import { OpenAPI } from "@/client"
  * Initialize the API client with the base URL.
  * Auth is handled via HttpOnly cookies — no token is stored in JS memory.
  * withCredentials is enabled so the browser sends cookies on every request.
+ *
+ * In development the Vite dev server proxies /api/... to the backend, so we
+ * use an empty base (relative URLs) to keep cookies on the same origin
+ * (localhost).  In production there is no Vite proxy, so the full backend URL
+ * is used directly.
  */
 export function initializeApiClient() {
-  OpenAPI.BASE = import.meta.env.VITE_API_URL
+  OpenAPI.BASE = import.meta.env.PROD ? import.meta.env.VITE_API_URL : ""
   OpenAPI.WITH_CREDENTIALS = true
 }
 

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -4,13 +4,7 @@
 
 export { ArticleService } from "./ArticleService"
 export { CalculatorService } from "./CalculatorService"
-export {
-  clearAuthToken,
-  getAuthToken,
-  initializeApiClient,
-  isAuthenticated,
-  setAuthToken,
-} from "./common/API/client"
+export { initializeApiClient, isAuthenticated } from "./common/API/client"
 export { PATHS } from "./common/Paths"
 export { DashboardService } from "./DashboardService"
 export type { FeedbackInput } from "./FeedbackService"

--- a/frontend/tests/login.spec.ts
+++ b/frontend/tests/login.spec.ts
@@ -103,23 +103,17 @@ test("Logged-out user cannot access protected routes", async ({ page }) => {
 })
 
 test("Redirects to /login when token is wrong", async ({ page, context }) => {
+  // Navigate to any public page first so page.url() returns a real URL
+  // (not "about:blank") and we can derive the correct hostname for cookies.
+  await page.goto("/login")
+  const domain = new URL(page.url()).hostname
+
   // Set a stale `logged_in` indicator cookie so isLoggedIn() returns true,
   // but the access_token cookie contains an invalid JWT — the backend will
-  // reject it and the app should redirect to /login.
-  const url = new URL(page.url() || "http://localhost:5173")
+  // reject it and the global 401/403 handler should redirect to /login.
   await context.addCookies([
-    {
-      name: "logged_in",
-      value: "1",
-      domain: url.hostname,
-      path: "/",
-    },
-    {
-      name: "access_token",
-      value: "invalid_token",
-      domain: url.hostname,
-      path: "/",
-    },
+    { name: "logged_in", value: "1", domain, path: "/" },
+    { name: "access_token", value: "invalid_token", domain, path: "/" },
   ])
   await page.goto("/settings")
   await page.waitForURL("/login")

--- a/frontend/tests/login.spec.ts
+++ b/frontend/tests/login.spec.ts
@@ -102,11 +102,25 @@ test("Logged-out user cannot access protected routes", async ({ page }) => {
   await page.waitForURL("/login")
 })
 
-test("Redirects to /login when token is wrong", async ({ page }) => {
-  await page.goto("/settings")
-  await page.evaluate(() => {
-    localStorage.setItem("access_token", "invalid_token")
-  })
+test("Redirects to /login when token is wrong", async ({ page, context }) => {
+  // Set a stale `logged_in` indicator cookie so isLoggedIn() returns true,
+  // but the access_token cookie contains an invalid JWT — the backend will
+  // reject it and the app should redirect to /login.
+  const url = new URL(page.url() || "http://localhost:5173")
+  await context.addCookies([
+    {
+      name: "logged_in",
+      value: "1",
+      domain: url.hostname,
+      path: "/",
+    },
+    {
+      name: "access_token",
+      value: "invalid_token",
+      domain: url.hostname,
+      path: "/",
+    },
+  ])
   await page.goto("/settings")
   await page.waitForURL("/login")
   await expect(page).toHaveURL("/login")

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,17 @@ export default defineConfig({
     watch: {
       usePolling: true,
     },
+    // Proxy /api/... to the backend so cookies are set on the same origin
+    // (localhost) in both local dev and playwright CI.  Without this, the
+    // backend at a different hostname (e.g. backend:8000) would set cookies
+    // on its own domain, making them invisible to document.cookie at
+    // localhost:5173 and breaking isLoggedIn() checks.
+    proxy: {
+      "/api": {
+        target: process.env.VITE_API_URL ?? "http://localhost:8000",
+        changeOrigin: true,
+      },
+    },
   },
   plugins: [
     tanstackRouter({


### PR DESCRIPTION
## Summary
- JWT access tokens are now stored in HttpOnly cookies instead of localStorage, preventing XSS exfiltration
- A JS-readable `logged_in` indicator cookie enables synchronous auth checks in TanStack Router's `beforeLoad`
- Bearer header auth continues to work for Swagger UI / OAuth2 clients (backward-compatible)

## Changes

### Backend
- `api/routes/auth.py` — `POST /auth/login` sets `access_token` (HttpOnly) + `refresh_token` (HttpOnly) + `logged_in` cookies; `refresh` rotates access cookie; `logout` clears all three
- `api/routes/login.py` — legacy `POST /login/access-token` also sets `access_token` + `logged_in` cookies
- `api/deps.py` — `get_current_user` tries Bearer header first, falls back to `access_token` cookie; cookie is read via `request.cookies` to avoid polluting the OpenAPI schema
- `schemas/auth.py` — `LogoutRequest.refresh_token` and `RefreshTokenRequest.refresh_token` are now optional

### Frontend
- `client.ts` — `OpenAPI.WITH_CREDENTIALS = true`; `isAuthenticated()` reads `logged_in` cookie; removes localStorage token helpers
- `useAuth.ts` — `isLoggedIn()` checks `document.cookie`; `login()` no longer writes to localStorage; `logout()` calls backend to clear HttpOnly cookie
- `login.spec.ts` — "wrong token" test uses `context.addCookies()` instead of localStorage

### Tests
- 4 new backend cookie tests: `test_login_sets_httponly_cookies`, `test_cookie_auth_allows_protected_endpoint`, `test_logout_clears_cookies`, `test_logout_via_cookie_token`
- `conftest.py` — autouse fixture clears module-scoped client's cookie jar between tests

## Test plan
- [x] Backend tests pass: `pytest tests/api/routes/test_auth.py tests/api/routes/test_login.py`
- [x] TypeScript compiles with 0 errors: `bunx tsc --noEmit`
- [x] Pre-commit passes (incl. SDK regeneration)
- [x] Login/logout flow works end-to-end (no token in localStorage)
- [x] Swagger UI "Authorize" button still works (Bearer token)