### PR TITLE
feat(security): enforce secret_key startup log and missing-key test

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ async def _run_recurring_generation() -> None:
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    logger.info("SECRET_KEY loaded, length=%d", len(settings.SECRET_KEY))
     scheduler = AsyncIOScheduler()
     scheduler.add_job(
         _run_recurring_generation,

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -1,6 +1,7 @@
 """Tests for Settings validation in app.core.config."""
 
 import pytest
+from pydantic import ValidationError
 
 from app.core.config import Settings
 
@@ -102,3 +103,16 @@ def test_postgres_password_empty_allowed_in_local() -> None:
     kwargs = {**_base_settings_kwargs(), "POSTGRES_PASSWORD": ""}
     s = Settings(**kwargs, ENVIRONMENT="local", _env_file=None)
     assert s.POSTGRES_PASSWORD == ""
+
+
+# ── SECRET_KEY missing ─────────────────────────────────────────────────────
+
+
+def test_secret_key_missing_raises_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting SECRET_KEY entirely must raise ValidationError at startup."""
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    kwargs = {k: v for k, v in _base_settings_kwargs().items() if k != "SECRET_KEY"}
+    with pytest.raises(ValidationError):
+        Settings(**kwargs, ENVIRONMENT="local", _env_file=None)


### PR DESCRIPTION
## Summary
- Adds a startup log on app lifespan init that records `SECRET_KEY` length (never the value), confirming the key was loaded from the environment
- Adds `test_secret_key_missing_raises_validation_error` to verify omitting `SECRET_KEY` causes `ValidationError` at boot, preventing silent fallback to a generated key

## Related
Closes Task #153 (SECURITY H6: Enforce SECRET_KEY as required env var with startup validation)

Task #152 (H2+H3) was already fully implemented in a prior commit (rate limiting on legacy login endpoint + `TRUSTED_PROXY_IPS` startup validator with full test coverage in `test_config.py` and `test_login.py`).

## Test plan
- [x] `tests/core/test_config.py` — 9 tests pass including new `test_secret_key_missing_raises_validation_error`
- [x] `pre-commit run --all-files` — clean