### PR TITLE
feat(security): fix stripe tier derivation and subscription cancellation

### DIFF
--- a/backend/app/_models_sqlmodel.py
+++ b/backend/app/_models_sqlmodel.py
@@ -74,6 +74,12 @@ class User(UserBase, table=True):
             nullable=False,
         ),
     )
+    stripe_customer_id: str | None = Field(
+        default=None, max_length=255, unique=True, index=True
+    )
+    stripe_subscription_id: str | None = Field(
+        default=None, max_length=255, unique=True
+    )
     avatar_url: str | None = Field(default=None)
     created_at: datetime | None = Field(
         default_factory=get_datetime_utc,

--- a/backend/app/alembic/versions/c2d3e4f5g6h7_add_stripe_subscription_fields.py
+++ b/backend/app/alembic/versions/c2d3e4f5g6h7_add_stripe_subscription_fields.py
@@ -1,0 +1,42 @@
+"""add stripe subscription fields to user
+
+Revision ID: c2d3e4f5g6h7
+Revises: b1m2n3p4q5r6
+Create Date: 2026-04-27 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c2d3e4f5g6h7"
+down_revision = "b1m2n3p4q5r6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column("stripe_customer_id", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "user",
+        sa.Column("stripe_subscription_id", sa.String(255), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_user_stripe_customer_id", "user", ["stripe_customer_id"]
+    )
+    op.create_unique_constraint(
+        "uq_user_stripe_subscription_id", "user", ["stripe_subscription_id"]
+    )
+    op.create_index(
+        "ix_user_stripe_customer_id", "user", ["stripe_customer_id"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_stripe_customer_id", table_name="user")
+    op.drop_constraint("uq_user_stripe_subscription_id", "user", type_="unique")
+    op.drop_constraint("uq_user_stripe_customer_id", "user", type_="unique")
+    op.drop_column("user", "stripe_subscription_id")
+    op.drop_column("user", "stripe_customer_id")

--- a/backend/app/alembic/versions/c2d3e4f5g6h7_add_stripe_subscription_fields.py
+++ b/backend/app/alembic/versions/c2d3e4f5g6h7_add_stripe_subscription_fields.py
@@ -23,20 +23,18 @@ def upgrade() -> None:
         "user",
         sa.Column("stripe_subscription_id", sa.String(255), nullable=True),
     )
-    op.create_unique_constraint(
-        "uq_user_stripe_customer_id", "user", ["stripe_customer_id"]
-    )
-    op.create_unique_constraint(
-        "uq_user_stripe_subscription_id", "user", ["stripe_subscription_id"]
-    )
+    # Unique index on stripe_customer_id (used for webhook lookups)
     op.create_index(
         "ix_user_stripe_customer_id", "user", ["stripe_customer_id"], unique=True
+    )
+    # Unique constraint on stripe_subscription_id (no index needed — not a lookup key)
+    op.create_unique_constraint(
+        "uq_user_stripe_subscription_id", "user", ["stripe_subscription_id"]
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_user_stripe_customer_id", table_name="user")
     op.drop_constraint("uq_user_stripe_subscription_id", "user", type_="unique")
-    op.drop_constraint("uq_user_stripe_customer_id", "user", type_="unique")
+    op.drop_index("ix_user_stripe_customer_id", table_name="user")
     op.drop_column("user", "stripe_subscription_id")
     op.drop_column("user", "stripe_customer_id")

--- a/backend/app/api/routes/subscriptions.py
+++ b/backend/app/api/routes/subscriptions.py
@@ -7,6 +7,7 @@ Provides Stripe-based subscription management including:
 """
 
 import logging
+import uuid as _uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, HttpUrl
@@ -224,6 +225,16 @@ async def handle_webhook(
         session_id = event["data"]["object"]["id"]
 
         if user_id:
+            try:
+                user_uuid = _uuid.UUID(user_id)
+            except ValueError:
+                logger.warning(
+                    "checkout.session.completed: invalid user_id %s in session %s",
+                    user_id,
+                    session_id,
+                )
+                return WebhookResponse(received=True)
+
             price_id = payment_service.get_checkout_price_id(session_id)
             if price_id is None:
                 logger.warning(
@@ -241,7 +252,7 @@ async def handle_webhook(
                 )
                 return WebhookResponse(received=True)
 
-            statement = select(User).where(User.id == user_id)
+            statement = select(User).where(User.id == user_uuid)
             user = session.exec(statement).first()
             if user:
                 user.subscription_tier = tier
@@ -303,8 +314,7 @@ async def cancel_subscription(
             detail="No active subscription to cancel",
         )
 
-    stripe_subscription_id = getattr(current_user, "stripe_subscription_id", None)
-    if not stripe_subscription_id:
+    if not current_user.stripe_subscription_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No Stripe subscription found — contact support",
@@ -312,7 +322,7 @@ async def cancel_subscription(
 
     try:
         await payment_service.cancel_subscription(
-            stripe_subscription_id, at_period_end=True
+            current_user.stripe_subscription_id, at_period_end=True
         )
     except SubscriptionError as e:
         raise HTTPException(
@@ -322,6 +332,6 @@ async def cancel_subscription(
 
     return SubscriptionResponse(
         tier=current_user.subscription_tier,
-        stripe_customer_id=getattr(current_user, "stripe_customer_id", None),
+        stripe_customer_id=current_user.stripe_customer_id,
         status="cancellation_scheduled",
     )

--- a/backend/app/api/routes/subscriptions.py
+++ b/backend/app/api/routes/subscriptions.py
@@ -6,6 +6,8 @@ Provides Stripe-based subscription management including:
 - Processing Stripe webhooks
 """
 
+import logging
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, HttpUrl
 from sqlmodel import Session, select
@@ -15,10 +17,13 @@ from app.models import SubscriptionTier, User
 from app.services.payment_service import (
     CheckoutSessionError,
     CustomerNotFoundError,
+    SubscriptionError,
     WebhookEventType,
     WebhookVerificationError,
     get_payment_service,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/subscriptions", tags=["subscriptions"])
 
@@ -213,34 +218,63 @@ async def handle_webhook(
 
     # Handle different event types
     if webhook_event.event_type == WebhookEventType.CHECKOUT_COMPLETED.value:
-        # Subscription purchased - update user tier
+        # Subscription purchased — derive tier from price_id, not metadata,
+        # to prevent tier elevation via attacker-controlled metadata values.
         user_id = webhook_event.metadata.get("user_id")
-        tier_value = webhook_event.metadata.get("tier")
+        session_id = event["data"]["object"]["id"]
 
-        if user_id and tier_value:
+        if user_id:
+            price_id = payment_service.get_checkout_price_id(session_id)
+            if price_id is None:
+                logger.warning(
+                    "checkout.session.completed: no line items for session %s",
+                    session_id,
+                )
+                return WebhookResponse(received=True)
+
+            tier = payment_service.get_tier_for_price(price_id)
+            if tier == SubscriptionTier.FREE:
+                logger.warning(
+                    "checkout.session.completed: unknown price_id %s for session %s",
+                    price_id,
+                    session_id,
+                )
+                return WebhookResponse(received=True)
+
             statement = select(User).where(User.id == user_id)
             user = session.exec(statement).first()
             if user:
-                try:
-                    user.subscription_tier = SubscriptionTier(tier_value)
-                    session.add(user)
-                    session.commit()
-                except ValueError:
-                    pass  # Invalid tier value, ignore
+                user.subscription_tier = tier
+                user.stripe_customer_id = webhook_event.customer_id
+                user.stripe_subscription_id = webhook_event.subscription_id
+                session.add(user)
+                session.commit()
 
     elif webhook_event.event_type == WebhookEventType.SUBSCRIPTION_UPDATED.value:
-        # Subscription changed - update tier based on price
+        # Subscription plan changed — update tier from the new price_id.
         if webhook_event.customer_id and webhook_event.price_id:
-            _new_tier = payment_service.get_tier_for_price(webhook_event.price_id)
-            statement = select(User)  # Would need stripe_customer_id on User model
-            # For now, we rely on checkout metadata
-            # In production, store stripe_customer_id on User
+            statement = select(User).where(
+                User.stripe_customer_id == webhook_event.customer_id
+            )
+            user = session.exec(statement).first()
+            if user:
+                new_tier = payment_service.get_tier_for_price(webhook_event.price_id)
+                user.subscription_tier = new_tier
+                session.add(user)
+                session.commit()
 
     elif webhook_event.event_type == WebhookEventType.SUBSCRIPTION_DELETED.value:
-        # Subscription cancelled - downgrade to free
-        # Would need stripe_customer_id on User model to find user
-        # For now, subscription cancellation is handled via portal
-        pass
+        # Subscription ended — downgrade to FREE.
+        if webhook_event.customer_id:
+            statement = select(User).where(
+                User.stripe_customer_id == webhook_event.customer_id
+            )
+            user = session.exec(statement).first()
+            if user:
+                user.subscription_tier = SubscriptionTier.FREE
+                user.stripe_subscription_id = None
+                session.add(user)
+                session.commit()
 
     return WebhookResponse(received=True)
 
@@ -248,15 +282,16 @@ async def handle_webhook(
 @router.post("/cancel", response_model=SubscriptionResponse)
 async def cancel_subscription(
     current_user: CurrentUser,
-    session: Session = Depends(get_db),
 ) -> SubscriptionResponse:
     """
     Cancel the current subscription.
 
-    The subscription will be cancelled at the end of the current billing period.
-    The user will retain access until then.
+    Calls Stripe to schedule cancellation at end of billing period.
+    The user retains access until the period ends; the DB tier is
+    only downgraded when the customer.subscription.deleted webhook fires.
     """
-    if get_payment_service() is None:
+    payment_service = get_payment_service()
+    if payment_service is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Payment service is not configured",
@@ -268,14 +303,25 @@ async def cancel_subscription(
             detail="No active subscription to cancel",
         )
 
-    # For MVP, just update the tier directly
-    # In production, this would cancel via Stripe and let webhook update the tier
-    current_user.subscription_tier = SubscriptionTier.FREE
-    session.add(current_user)
-    session.commit()
-    session.refresh(current_user)
+    stripe_subscription_id = getattr(current_user, "stripe_subscription_id", None)
+    if not stripe_subscription_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No Stripe subscription found — contact support",
+        )
+
+    try:
+        await payment_service.cancel_subscription(
+            stripe_subscription_id, at_period_end=True
+        )
+    except SubscriptionError as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(e),
+        )
 
     return SubscriptionResponse(
         tier=current_user.subscription_tier,
-        status="cancelled",
+        stripe_customer_id=getattr(current_user, "stripe_customer_id", None),
+        status="cancellation_scheduled",
     )

--- a/backend/app/api/routes/subscriptions.py
+++ b/backend/app/api/routes/subscriptions.py
@@ -87,7 +87,7 @@ def get_current_subscription(
     """
     return SubscriptionResponse(
         tier=current_user.subscription_tier,
-        stripe_customer_id=getattr(current_user, "stripe_customer_id", None),
+        stripe_customer_id=current_user.stripe_customer_id,
         status="active"
         if current_user.subscription_tier != SubscriptionTier.FREE
         else None,
@@ -131,7 +131,7 @@ async def create_checkout_session(
             tier=request.tier,
             success_url=str(request.success_url),
             cancel_url=str(request.cancel_url),
-            stripe_customer_id=getattr(current_user, "stripe_customer_id", None),
+            stripe_customer_id=current_user.stripe_customer_id,
         )
         return CheckoutResponse(session_id=result.session_id, url=result.url)
     except CheckoutSessionError as e:
@@ -159,7 +159,7 @@ async def create_portal_session(
             detail="Payment service is not configured",
         )
 
-    stripe_customer_id = getattr(current_user, "stripe_customer_id", None)
+    stripe_customer_id = current_user.stripe_customer_id
     if not stripe_customer_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -262,7 +262,7 @@ async def handle_webhook(
                 session.commit()
 
     elif webhook_event.event_type == WebhookEventType.SUBSCRIPTION_UPDATED.value:
-        # Subscription plan changed — update tier from the new price_id.
+        # Subscription plan changed — update tier and subscription ID from the new price_id.
         if webhook_event.customer_id and webhook_event.price_id:
             statement = select(User).where(
                 User.stripe_customer_id == webhook_event.customer_id
@@ -271,6 +271,8 @@ async def handle_webhook(
             if user:
                 new_tier = payment_service.get_tier_for_price(webhook_event.price_id)
                 user.subscription_tier = new_tier
+                if webhook_event.subscription_id:
+                    user.stripe_subscription_id = webhook_event.subscription_id
                 session.add(user)
                 session.commit()
 
@@ -324,10 +326,19 @@ async def cancel_subscription(
         await payment_service.cancel_subscription(
             current_user.stripe_subscription_id, at_period_end=True
         )
+        logger.info(
+            "cancellation scheduled at period end for sub_id=%s",
+            current_user.stripe_subscription_id,
+        )
     except SubscriptionError as e:
+        logger.warning(
+            "cancel_subscription failed for sub_id=%s: %s",
+            current_user.stripe_subscription_id,
+            e,
+        )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=str(e),
+            detail="Failed to cancel subscription. Please try again or contact support.",
         )
 
     return SubscriptionResponse(

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -38,6 +38,8 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         default=SubscriptionTier.FREE,
         nullable=False,
     )
+    stripe_customer_id = Column(String(255), nullable=True, unique=True, index=True)
+    stripe_subscription_id = Column(String(255), nullable=True, unique=True)
     avatar_url = Column(Text, nullable=True)
 
     journeys = relationship(

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -157,6 +157,26 @@ class PaymentService:
         """
         return self._price_to_tier.get(price_id, SubscriptionTier.FREE)
 
+    def get_checkout_price_id(self, session_id: str) -> str | None:
+        """Get the price ID from a completed checkout session's line items.
+
+        Used to derive the subscription tier from the verified Stripe price
+        rather than from attacker-controllable metadata.
+
+        Args:
+            session_id: Stripe checkout session ID.
+
+        Returns:
+            Price ID of the first line item, or None if unavailable.
+        """
+        try:
+            line_items = stripe.checkout.Session.list_line_items(session_id, limit=1)
+            if line_items.data:
+                return line_items.data[0].price.id
+            return None
+        except stripe.StripeError:
+            return None
+
     async def create_customer(
         self,
         user_id: uuid.UUID,
@@ -258,7 +278,9 @@ class PaymentService:
                 line_items=[{"price": price_id, "quantity": 1}],
                 success_url=success_url,
                 cancel_url=cancel_url,
-                metadata={"user_id": str(user_id), "tier": tier.value},
+                # Only store user_id — tier is derived from price_id on receipt
+                # to prevent metadata tampering.
+                metadata={"user_id": str(user_id)},
             )
 
             return CheckoutSessionResult(

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -4,10 +4,10 @@ Provides subscription management via Stripe including checkout sessions,
 customer portal, and webhook processing.
 """
 
+import logging
 import uuid
 from dataclasses import dataclass
 from enum import Enum
-from functools import lru_cache
 from typing import Any
 
 import stripe
@@ -15,6 +15,8 @@ from stripe import InvalidRequestError, SignatureVerificationError
 
 from app.core.config import settings
 from app.models import SubscriptionTier
+
+logger = logging.getLogger(__name__)
 
 
 class PaymentError(Exception):
@@ -174,7 +176,10 @@ class PaymentService:
             if line_items.data:
                 return line_items.data[0].price.id
             return None
-        except stripe.StripeError:
+        except stripe.StripeError as e:
+            logger.warning(
+                "get_checkout_price_id failed for session %s: %s", session_id, e
+            )
             return None
 
     async def create_customer(
@@ -466,7 +471,6 @@ class PaymentService:
 _payment_service: PaymentService | None = None
 
 
-@lru_cache
 def get_payment_service() -> PaymentService | None:
     """Get the payment service singleton.
 

--- a/backend/tests/api/routes/test_subscriptions.py
+++ b/backend/tests/api/routes/test_subscriptions.py
@@ -9,7 +9,10 @@ from app import crud
 from app.core.config import settings
 from app.models import SubscriptionTier, UserCreate
 from app.services.payment_service import (
+    CheckoutSessionError,
     CheckoutSessionResult,
+    CustomerNotFoundError,
+    SubscriptionError,
     WebhookEvent,
     WebhookEventType,
     WebhookVerificationError,
@@ -509,3 +512,193 @@ def test_webhook_subscription_updated_changes_tier(
 
     db.refresh(user)
     assert user.subscription_tier == SubscriptionTier.ENTERPRISE
+
+
+# ── Additional coverage: error paths ─────────────────────────────────────────
+
+
+def test_create_checkout_session_stripe_error(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    """Checkout returns 500 when Stripe raises CheckoutSessionError."""
+    mock_service = MagicMock()
+    mock_service.create_checkout_session = AsyncMock(
+        side_effect=CheckoutSessionError("Stripe API error")
+    )
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/checkout",
+            headers=normal_user_token_headers,
+            json={
+                "tier": "premium",
+                "success_url": "https://example.com/success",
+                "cancel_url": "https://example.com/cancel",
+            },
+        )
+        assert r.status_code == 500
+        assert "Stripe API error" in r.json()["detail"]
+
+
+def test_create_portal_session_stripe_not_configured(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    """Portal session returns 503 when Stripe is not configured."""
+    with patch("app.api.routes.subscriptions.get_payment_service", return_value=None):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/portal",
+            headers=normal_user_token_headers,
+            json={"return_url": "https://example.com/account"},
+        )
+        assert r.status_code == 503
+
+
+def test_create_portal_session_customer_not_found(
+    client: TestClient, db: Session
+) -> None:
+    """Portal session returns 404 when customer not found in Stripe."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    user.stripe_customer_id = f"cus_{random_lower_string()[:8]}"
+    db.add(user)
+    db.commit()
+    headers = _login_headers(client, username, password)
+
+    mock_service = MagicMock()
+    mock_service.create_portal_session = AsyncMock(
+        side_effect=CustomerNotFoundError("Customer not found")
+    )
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/portal",
+            headers=headers,
+            json={"return_url": "https://example.com/account"},
+        )
+        assert r.status_code == 404
+        assert "not found" in r.json()["detail"]
+
+
+def test_webhook_checkout_no_user_id_in_metadata(client: TestClient) -> None:
+    """checkout.session.completed with no user_id skips DB update."""
+    session_obj = {"id": "cs_noid", "customer": "cus_333", "subscription": "sub_333"}
+    raw_event, parsed_event = _make_webhook_event(
+        WebhookEventType.CHECKOUT_COMPLETED.value,
+        session_obj,
+        {},  # no user_id
+    )
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+        assert r.status_code == 200
+        assert r.json()["received"] is True
+    mock_service.get_checkout_price_id.assert_not_called()
+
+
+def test_webhook_checkout_invalid_uuid_user_id(client: TestClient) -> None:
+    """checkout.session.completed with invalid UUID user_id logs warning, returns received."""
+    session_obj = {"id": "cs_baduuid", "customer": "cus_444", "subscription": "sub_444"}
+    raw_event, parsed_event = _make_webhook_event(
+        WebhookEventType.CHECKOUT_COMPLETED.value,
+        session_obj,
+        {"user_id": "not-a-valid-uuid"},
+    )
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+        assert r.status_code == 200
+        assert r.json()["received"] is True
+    mock_service.get_checkout_price_id.assert_not_called()
+
+
+def test_webhook_checkout_no_line_items(client: TestClient, db: Session) -> None:
+    """checkout.session.completed with no line items logs warning, returns received."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    db.commit()
+
+    session_obj = {"id": "cs_noitems", "customer": "cus_555", "subscription": "sub_555"}
+    raw_event, parsed_event = _make_webhook_event(
+        WebhookEventType.CHECKOUT_COMPLETED.value,
+        session_obj,
+        {"user_id": str(user.id)},
+    )
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+    mock_service.get_checkout_price_id.return_value = None
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+        assert r.status_code == 200
+
+    db.refresh(user)
+    assert user.subscription_tier == SubscriptionTier.FREE
+
+
+def test_cancel_subscription_stripe_not_configured(
+    client: TestClient, db: Session
+) -> None:
+    """Cancel returns 503 when Stripe is not configured."""
+    user, username, password = _create_premium_user_with_stripe(db)
+    headers = _login_headers(client, username, password)
+
+    with patch("app.api.routes.subscriptions.get_payment_service", return_value=None):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/cancel",
+            headers=headers,
+        )
+        assert r.status_code == 503
+
+
+def test_cancel_subscription_stripe_error(client: TestClient, db: Session) -> None:
+    """Cancel returns 502 when Stripe raises SubscriptionError."""
+    user, username, password = _create_premium_user_with_stripe(db)
+    headers = _login_headers(client, username, password)
+
+    mock_service = MagicMock()
+    mock_service.cancel_subscription = AsyncMock(
+        side_effect=SubscriptionError("Stripe API unavailable")
+    )
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/cancel",
+            headers=headers,
+        )
+        assert r.status_code == 502
+        assert "Stripe API unavailable" in r.json()["detail"]

--- a/backend/tests/api/routes/test_subscriptions.py
+++ b/backend/tests/api/routes/test_subscriptions.py
@@ -10,6 +10,7 @@ from app.core.config import settings
 from app.models import SubscriptionTier, UserCreate
 from app.services.payment_service import (
     CheckoutSessionResult,
+    WebhookEvent,
     WebhookEventType,
     WebhookVerificationError,
 )
@@ -326,10 +327,8 @@ def test_checkout_already_subscribed_to_same_tier(
 
 def _make_webhook_event(
     event_type: str, data_object: dict, metadata: dict
-) -> MagicMock:
+) -> tuple[MagicMock, WebhookEvent]:
     """Build a MagicMock that quacks like a stripe.Event for webhook tests."""
-    from app.services.payment_service import WebhookEvent
-
     raw_event: MagicMock = MagicMock()
     raw_event.__getitem__ = MagicMock(
         side_effect=lambda k: {"data": {"object": data_object}}.get(k, MagicMock())
@@ -442,8 +441,6 @@ def test_webhook_subscription_deleted_downgrades_user(
     """M10: customer.subscription.deleted sets tier=FREE via stripe_customer_id."""
     user, _username, _password = _create_premium_user_with_stripe(db)
 
-    from app.services.payment_service import WebhookEvent
-
     parsed_event = WebhookEvent(
         event_type=WebhookEventType.SUBSCRIPTION_DELETED.value,
         customer_id=user.stripe_customer_id,
@@ -481,8 +478,6 @@ def test_webhook_subscription_updated_changes_tier(
 ) -> None:
     """customer.subscription.updated updates tier via stripe_customer_id."""
     user, _username, _password = _create_premium_user_with_stripe(db)
-
-    from app.services.payment_service import WebhookEvent
 
     parsed_event = WebhookEvent(
         event_type=WebhookEventType.SUBSCRIPTION_UPDATED.value,

--- a/backend/tests/api/routes/test_subscriptions.py
+++ b/backend/tests/api/routes/test_subscriptions.py
@@ -7,7 +7,7 @@ from sqlmodel import Session
 
 from app import crud
 from app.core.config import settings
-from app.models import SubscriptionTier, UserCreate
+from app.models import SubscriptionTier, User, UserCreate
 from app.services.payment_service import (
     CheckoutSessionError,
     CheckoutSessionResult,
@@ -26,7 +26,7 @@ def _create_premium_user_with_stripe(
     db: Session,
     customer_id: str = "",
     subscription_id: str = "",
-) -> tuple:
+) -> tuple[User, str, str]:
     """Create a PREMIUM user with Stripe IDs; return (user, username, password)."""
     username = random_email()
     password = random_lower_string()
@@ -41,7 +41,7 @@ def _create_premium_user_with_stripe(
     return user, username, password
 
 
-def _login_headers(client: TestClient, username: str, password: str) -> dict:
+def _login_headers(client: TestClient, username: str, password: str) -> dict[str, str]:
     r = client.post(
         f"{settings.API_V1_STR}/login/access-token",
         data={"username": username, "password": password},
@@ -420,8 +420,12 @@ def test_webhook_checkout_unknown_price_logs_warning(
     # Unknown price → FREE tier (default)
     mock_service.get_tier_for_price.return_value = SubscriptionTier.FREE
 
-    with patch(
-        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    with (
+        patch("app.api.routes.subscriptions.logger") as mock_logger,
+        patch(
+            "app.api.routes.subscriptions.get_payment_service",
+            return_value=mock_service,
+        ),
     ):
         r = client.post(
             f"{settings.API_V1_STR}/subscriptions/webhook",
@@ -429,6 +433,8 @@ def test_webhook_checkout_unknown_price_logs_warning(
             headers={"Stripe-Signature": "sig"},
         )
         assert r.status_code == 200
+        mock_logger.warning.assert_called()
+        assert "unknown price_id" in mock_logger.warning.call_args[0][0]
 
     db.refresh(user)
     # Tier must NOT be changed when price resolves to FREE (unknown)
@@ -479,13 +485,14 @@ def test_webhook_subscription_deleted_downgrades_user(
 def test_webhook_subscription_updated_changes_tier(
     client: TestClient, db: Session
 ) -> None:
-    """customer.subscription.updated updates tier via stripe_customer_id."""
+    """customer.subscription.updated updates tier and subscription_id via stripe_customer_id."""
     user, _username, _password = _create_premium_user_with_stripe(db)
+    new_subscription_id = f"sub_{random_lower_string()[:8]}_enterprise"
 
     parsed_event = WebhookEvent(
         event_type=WebhookEventType.SUBSCRIPTION_UPDATED.value,
         customer_id=user.stripe_customer_id,
-        subscription_id=user.stripe_subscription_id,
+        subscription_id=new_subscription_id,
         price_id="price_enterprise",
         status="active",
         metadata={},
@@ -512,6 +519,7 @@ def test_webhook_subscription_updated_changes_tier(
 
     db.refresh(user)
     assert user.subscription_tier == SubscriptionTier.ENTERPRISE
+    assert user.stripe_subscription_id == new_subscription_id
 
 
 # ── Additional coverage: error paths ─────────────────────────────────────────
@@ -701,4 +709,4 @@ def test_cancel_subscription_stripe_error(client: TestClient, db: Session) -> No
             headers=headers,
         )
         assert r.status_code == 502
-        assert "Stripe API unavailable" in r.json()["detail"]
+        assert "Failed to cancel subscription" in r.json()["detail"]

--- a/backend/tests/api/routes/test_subscriptions.py
+++ b/backend/tests/api/routes/test_subscriptions.py
@@ -10,9 +10,39 @@ from app.core.config import settings
 from app.models import SubscriptionTier, UserCreate
 from app.services.payment_service import (
     CheckoutSessionResult,
+    WebhookEventType,
     WebhookVerificationError,
 )
 from tests.utils.utils import random_email, random_lower_string
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _create_premium_user_with_stripe(
+    db: Session,
+    customer_id: str = "",
+    subscription_id: str = "",
+) -> tuple:
+    """Create a PREMIUM user with Stripe IDs; return (user, username, password)."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    user.subscription_tier = SubscriptionTier.PREMIUM
+    user.stripe_customer_id = customer_id or f"cus_{random_lower_string()[:8]}"
+    user.stripe_subscription_id = subscription_id or f"sub_{random_lower_string()[:8]}"
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user, username, password
+
+
+def _login_headers(client: TestClient, username: str, password: str) -> dict:
+    r = client.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        data={"username": username, "password": password},
+    )
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
 
 
 def test_get_current_subscription_free_user(
@@ -142,24 +172,12 @@ def test_cancel_subscription_no_active_subscription(
 
 
 def test_cancel_subscription_success(client: TestClient, db: Session) -> None:
-    """Test successful subscription cancellation."""
-    # Create a user with premium subscription
-    username = random_email()
-    password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
-    user = crud.create_user(session=db, user_create=user_in)
-    user.subscription_tier = SubscriptionTier.PREMIUM
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-
-    # Login
-    login_data = {"username": username, "password": password}
-    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
-    tokens = r.json()
-    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    """Cancel schedules via Stripe; DB tier stays until webhook fires."""
+    user, username, password = _create_premium_user_with_stripe(db)
+    headers = _login_headers(client, username, password)
 
     mock_service = MagicMock()
+    mock_service.cancel_subscription = AsyncMock(return_value=None)
 
     with patch(
         "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
@@ -170,12 +188,43 @@ def test_cancel_subscription_success(client: TestClient, db: Session) -> None:
         )
         assert r.status_code == 200
         data = r.json()
-        assert data["tier"] == "free"
-        assert data["status"] == "cancelled"
+        # Tier stays PREMIUM until SUBSCRIPTION_DELETED webhook fires
+        assert data["tier"] == "premium"
+        assert data["status"] == "cancellation_scheduled"
+        mock_service.cancel_subscription.assert_called_once_with(
+            user.stripe_subscription_id, at_period_end=True
+        )
 
-    # Verify user tier was updated
+    # DB tier must NOT be downgraded immediately
     db.refresh(user)
-    assert user.subscription_tier == SubscriptionTier.FREE
+    assert user.subscription_tier == SubscriptionTier.PREMIUM
+
+
+def test_cancel_subscription_no_stripe_subscription_id(
+    client: TestClient, db: Session
+) -> None:
+    """Cancel returns 400 when stripe_subscription_id is missing."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    user.subscription_tier = SubscriptionTier.PREMIUM
+    # Deliberately no stripe_subscription_id
+    db.add(user)
+    db.commit()
+    headers = _login_headers(client, username, password)
+
+    mock_service = MagicMock()
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/cancel",
+            headers=headers,
+        )
+        assert r.status_code == 400
+        assert "No Stripe subscription found" in r.json()["detail"]
 
 
 def test_webhook_stripe_not_configured(client: TestClient) -> None:
@@ -270,3 +319,198 @@ def test_checkout_already_subscribed_to_same_tier(
         )
         assert r.status_code == 400
         assert "Already subscribed" in r.json()["detail"]
+
+
+# ── Webhook: M1 — tier derived from price_id ──────────────────────────────────
+
+
+def _make_webhook_event(
+    event_type: str, data_object: dict, metadata: dict
+) -> MagicMock:
+    """Build a MagicMock that quacks like a stripe.Event for webhook tests."""
+    from app.services.payment_service import WebhookEvent
+
+    raw_event: MagicMock = MagicMock()
+    raw_event.__getitem__ = MagicMock(
+        side_effect=lambda k: {"data": {"object": data_object}}.get(k, MagicMock())
+    )
+
+    parsed = WebhookEvent(
+        event_type=event_type,
+        customer_id=data_object.get("customer"),
+        subscription_id=data_object.get("subscription"),
+        price_id=None,
+        status=None,
+        metadata=metadata,
+    )
+    return raw_event, parsed
+
+
+def test_webhook_checkout_derives_tier_from_price_id(
+    client: TestClient, db: Session
+) -> None:
+    """M1: checkout.session.completed uses price_id, not metadata, for tier."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    db.commit()
+
+    session_obj = {
+        "id": "cs_test",
+        "customer": "cus_111",
+        "subscription": "sub_111",
+    }
+    raw_event, parsed_event = _make_webhook_event(
+        WebhookEventType.CHECKOUT_COMPLETED.value,
+        session_obj,
+        {"user_id": str(user.id)},
+    )
+
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+    # Price lookup returns the premium price — this is the trusted source
+    mock_service.get_checkout_price_id.return_value = "price_premium"
+    mock_service.get_tier_for_price.return_value = SubscriptionTier.PREMIUM
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+        assert r.status_code == 200
+        assert r.json()["received"] is True
+
+    db.refresh(user)
+    assert user.subscription_tier == SubscriptionTier.PREMIUM
+    assert user.stripe_customer_id == "cus_111"
+    assert user.stripe_subscription_id == "sub_111"
+    # Verify tier was derived from price_id, not metadata
+    mock_service.get_checkout_price_id.assert_called_once_with("cs_test")
+    mock_service.get_tier_for_price.assert_called_once_with("price_premium")
+
+
+def test_webhook_checkout_unknown_price_logs_warning(
+    client: TestClient, db: Session
+) -> None:
+    """M1: unknown price_id logs a warning and does not change user tier."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    db.commit()
+
+    session_obj = {"id": "cs_unknown", "customer": "cus_222", "subscription": "sub_222"}
+    raw_event, parsed_event = _make_webhook_event(
+        WebhookEventType.CHECKOUT_COMPLETED.value,
+        session_obj,
+        {"user_id": str(user.id)},
+    )
+
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+    mock_service.get_checkout_price_id.return_value = "price_unknown"
+    # Unknown price → FREE tier (default)
+    mock_service.get_tier_for_price.return_value = SubscriptionTier.FREE
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+        assert r.status_code == 200
+
+    db.refresh(user)
+    # Tier must NOT be changed when price resolves to FREE (unknown)
+    assert user.subscription_tier == SubscriptionTier.FREE
+
+
+# ── Webhook: M10 — subscription_deleted downgrades tier ─────────────────────
+
+
+def test_webhook_subscription_deleted_downgrades_user(
+    client: TestClient, db: Session
+) -> None:
+    """M10: customer.subscription.deleted sets tier=FREE via stripe_customer_id."""
+    user, _username, _password = _create_premium_user_with_stripe(db)
+
+    from app.services.payment_service import WebhookEvent
+
+    parsed_event = WebhookEvent(
+        event_type=WebhookEventType.SUBSCRIPTION_DELETED.value,
+        customer_id=user.stripe_customer_id,
+        subscription_id=user.stripe_subscription_id,
+        price_id=None,
+        status="canceled",
+        metadata={},
+    )
+    raw_event = MagicMock()
+    raw_event.__getitem__ = MagicMock(
+        side_effect=lambda k: {"data": {"object": {}}}.get(k, MagicMock())
+    )
+
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+        assert r.status_code == 200
+
+    db.refresh(user)
+    assert user.subscription_tier == SubscriptionTier.FREE
+    assert user.stripe_subscription_id is None
+
+
+def test_webhook_subscription_updated_changes_tier(
+    client: TestClient, db: Session
+) -> None:
+    """customer.subscription.updated updates tier via stripe_customer_id."""
+    user, _username, _password = _create_premium_user_with_stripe(db)
+
+    from app.services.payment_service import WebhookEvent
+
+    parsed_event = WebhookEvent(
+        event_type=WebhookEventType.SUBSCRIPTION_UPDATED.value,
+        customer_id=user.stripe_customer_id,
+        subscription_id=user.stripe_subscription_id,
+        price_id="price_enterprise",
+        status="active",
+        metadata={},
+    )
+    raw_event = MagicMock()
+    raw_event.__getitem__ = MagicMock(
+        side_effect=lambda k: {"data": {"object": {}}}.get(k, MagicMock())
+    )
+
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+    mock_service.get_tier_for_price.return_value = SubscriptionTier.ENTERPRISE
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+        assert r.status_code == 200
+
+    db.refresh(user)
+    assert user.subscription_tier == SubscriptionTier.ENTERPRISE

--- a/backend/tests/services/test_payment_service.py
+++ b/backend/tests/services/test_payment_service.py
@@ -346,3 +346,49 @@ class TestGetSubscription:
         ):
             result = await payment_service.get_subscription("sub_invalid")
             assert result is None
+
+
+class TestGetCheckoutPriceId:
+    """Tests for get_checkout_price_id method."""
+
+    def test_returns_price_id_from_line_items(
+        self, payment_service: PaymentService
+    ) -> None:
+        """Test price ID returned from checkout session line items."""
+        mock_price = MagicMock()
+        mock_price.id = "price_premium_123"
+        mock_item = MagicMock()
+        mock_item.price = mock_price
+        mock_line_items = MagicMock()
+        mock_line_items.data = [mock_item]
+
+        with patch.object(
+            stripe.checkout.Session, "list_line_items", return_value=mock_line_items
+        ):
+            result = payment_service.get_checkout_price_id("cs_test_123")
+        assert result == "price_premium_123"
+
+    def test_returns_none_when_no_line_items(
+        self, payment_service: PaymentService
+    ) -> None:
+        """Test None returned when session has no line items."""
+        mock_line_items = MagicMock()
+        mock_line_items.data = []
+
+        with patch.object(
+            stripe.checkout.Session, "list_line_items", return_value=mock_line_items
+        ):
+            result = payment_service.get_checkout_price_id("cs_empty")
+        assert result is None
+
+    def test_returns_none_on_stripe_error(
+        self, payment_service: PaymentService
+    ) -> None:
+        """Test None returned when Stripe API raises an error."""
+        with patch.object(
+            stripe.checkout.Session,
+            "list_line_items",
+            side_effect=stripe.StripeError("API error"),
+        ):
+            result = payment_service.get_checkout_price_id("cs_error")
+        assert result is None

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3008,8 +3008,9 @@ export class SubscriptionsService {
      * Cancel Subscription
      * Cancel the current subscription.
      *
-     * The subscription will be cancelled at the end of the current billing period.
-     * The user will retain access until then.
+     * Calls Stripe to schedule cancellation at end of billing period.
+     * The user retains access until the period ends; the DB tier is
+     * only downgraded when the customer.subscription.deleted webhook fires.
      * @returns SubscriptionResponse Successful Response
      * @throws ApiError
      */


### PR DESCRIPTION
## Summary
- **M1 (tier derivation)**: `checkout.session.completed` webhook now derives tier from verified `price_id` via `stripe.checkout.Session.list_line_items()` instead of attacker-controlled `metadata.tier`. Removes `tier` from checkout session metadata entirely. Logs a warning on unknown price IDs rather than silently passing.
- **M10 (cancellation)**: Cancel endpoint now calls `stripe.Subscription.modify(cancel_at_period_end=True)` before any DB change. The DB tier is only downgraded to FREE when the `customer.subscription.deleted` webhook fires. Implements fully functional `SUBSCRIPTION_UPDATED` and `SUBSCRIPTION_DELETED` webhook handlers using new `stripe_customer_id` column for user lookup.
- Adds `stripe_customer_id` and `stripe_subscription_id` to the `User` model with migration `c2d3e4f5g6h7`.
- Adds `get_checkout_price_id()` method to `PaymentService`.

## Test plan
- [x] `test_webhook_checkout_derives_tier_from_price_id` — tier from price_id, not metadata
- [x] `test_webhook_checkout_unknown_price_logs_warning` — unknown price_id does not set tier
- [x] `test_cancel_subscription_success` — DB tier stays PREMIUM after cancel call; Stripe called with correct sub ID
- [x] `test_cancel_subscription_no_stripe_subscription_id` — 400 when stripe_subscription_id missing
- [x] `test_webhook_subscription_deleted_downgrades_user` — SUBSCRIPTION_DELETED sets tier=FREE
- [x] `test_webhook_subscription_updated_changes_tier` — SUBSCRIPTION_UPDATED changes tier
- [x] All 35 existing + new tests pass
- [x] `pre-commit run --all-files` clean