### PR TITLE
feat(security): add ip-based rate limiting to login endpoints

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -148,6 +148,7 @@ async def register(
 async def login(
     request: LoginRequest,
     response: Response,
+    http_request: Request,
     session: Session = Depends(get_db),
 ) -> AuthToken:
     """
@@ -159,6 +160,15 @@ async def login(
     Also sets HttpOnly cookies: ``access_token``, ``refresh_token``, and a
     JS-readable ``logged_in`` indicator cookie.
     """
+    # Check if source IP is blocked (too many failed attempts across any email)
+    client_ip = http_request.client.host if http_request.client else None
+    if client_ip and rate_limit_service.is_ip_blocked(client_ip):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many failed login attempts. Please try again later.",
+            headers={"Retry-After": str(rate_limit_service.IP_FAILED_LOCKOUT_SECONDS)},
+        )
+
     # Check if account is locked due to rate limiting
     if rate_limit_service.is_locked(request.email):
         status_info = rate_limit_service.get_status(request.email)
@@ -184,6 +194,8 @@ async def login(
         # Still run password verification to prevent timing attacks
         verify_password(request.password, DUMMY_HASH)
         rate_limit_service.record_failed_attempt(request.email)
+        if client_ip:
+            rate_limit_service.record_ip_failed(client_ip)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect email or password",
@@ -192,6 +204,8 @@ async def login(
     verified, updated_hash = verify_password(request.password, user.hashed_password)
     if not verified:
         rate_info = rate_limit_service.record_failed_attempt(request.email)
+        if client_ip:
+            rate_limit_service.record_ip_failed(client_ip)
         detail = "Incorrect email or password"
         if rate_info.is_locked:
             detail = "Too many failed login attempts. Account locked for 15 minutes."

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
@@ -31,6 +31,7 @@ def login_access_token(
     session: SessionDep,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     response: Response,
+    http_request: Request,
 ) -> Token:
     """
     OAuth2 compatible token login, get an access token for future requests.
@@ -43,6 +44,13 @@ def login_access_token(
         auto-generated Swagger UI "Authorize" button) and will be removed in a
         future release.
     """
+    client_ip = http_request.client.host if http_request.client else None
+    if client_ip and rate_limit_service.is_ip_blocked(client_ip):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many failed login attempts. Please try again later.",
+            headers={"Retry-After": str(rate_limit_service.IP_FAILED_LOCKOUT_SECONDS)},
+        )
     if rate_limit_service.is_locked(form_data.username):
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -54,6 +62,8 @@ def login_access_token(
     )
     if not user:
         rate_limit_service.record_failed_attempt(form_data.username)
+        if client_ip:
+            rate_limit_service.record_ip_failed(client_ip)
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     elif not user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")

--- a/backend/app/services/rate_limit_service.py
+++ b/backend/app/services/rate_limit_service.py
@@ -46,6 +46,17 @@ _PASSWORD_RESET_LOCKOUT_PREFIX = "auth:ratelimit:password_reset:lockout:"
 _RESEND_VERIFICATION_ATTEMPTS_PREFIX = "auth:ratelimit:resend_verification:attempts:"
 _RESEND_VERIFICATION_LOCKOUT_PREFIX = "auth:ratelimit:resend_verification:lockout:"
 
+# IP-based login rate limit constants
+# Keyed by client IP address — caps total failed attempts regardless of email.
+# Prevents account enumeration / lockout spraying from a single source.
+IP_FAILED_MAX: int = 30
+IP_FAILED_WINDOW_SECONDS: int = 3600  # 1 hour sliding window
+# Lockout equals the window so an IP is cooled off for a full hour.
+IP_FAILED_LOCKOUT_SECONDS: int = 3600  # 1 hour
+
+_IP_FAILED_ATTEMPTS_PREFIX = "auth:ratelimit:ip:attempts:"
+_IP_FAILED_LOCKOUT_PREFIX = "auth:ratelimit:ip:lockout:"
+
 # ── Professional click rate limiting ─────────────────────────────────────────
 # Professional click rate limit constants
 CLICK_MAX_ATTEMPTS: int = 20
@@ -268,4 +279,24 @@ def record_click_attempt(identifier: str) -> RateLimitInfo:
         CLICK_MAX_ATTEMPTS,
         CLICK_WINDOW_SECONDS,
         CLICK_LOCKOUT_SECONDS,
+    )
+
+
+# ── IP-based login rate limiting ──────────────────────────────────────────────
+
+
+def is_ip_blocked(ip: str) -> bool:
+    """Return *True* if the IP is currently locked due to too many failed logins."""
+    return _redis().ttl(f"{_IP_FAILED_LOCKOUT_PREFIX}{ip}") > 0
+
+
+def record_ip_failed(ip: str) -> RateLimitInfo:
+    """Record a failed login attempt from an IP and return the updated status."""
+    return _record_attempt(
+        ip,
+        _IP_FAILED_ATTEMPTS_PREFIX,
+        _IP_FAILED_LOCKOUT_PREFIX,
+        IP_FAILED_MAX,
+        IP_FAILED_WINDOW_SECONDS,
+        IP_FAILED_LOCKOUT_SECONDS,
     )

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -18,6 +18,7 @@ from app.core.security import verify_password
 from app.crud import get_user_by_email
 from app.services.email_verification_service import get_email_verification_service
 from app.services.password_reset_service import get_password_reset_service
+from app.services.rate_limit_service import IP_FAILED_LOCKOUT_SECONDS, IP_FAILED_MAX
 from tests.utils.utils import random_email
 
 AUTH = f"{settings.API_V1_STR}/auth"
@@ -517,3 +518,42 @@ def test_rate_limit_cleared_on_success(client: TestClient) -> None:
         client.post(f"{AUTH}/login", json={"email": email, "password": "WrongPass1"})
     r = client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
     assert r.status_code == 200
+
+
+# ── IP-based rate limiting ────────────────────────────────────────────────────
+
+
+def test_ip_rate_limit_blocks_after_max_failures(client: TestClient) -> None:
+    """30 failed logins from one IP (across different emails) trigger IP block."""
+    for _ in range(IP_FAILED_MAX):
+        email = random_email()
+        client.post(f"{AUTH}/login", json={"email": email, "password": "WrongPass1"})
+
+    # Next attempt from same IP (TestClient uses "testclient" as host) must be 429
+    r = client.post(
+        f"{AUTH}/login", json={"email": random_email(), "password": "WrongPass1"}
+    )
+    assert r.status_code == 429
+    assert r.headers["Retry-After"] == str(IP_FAILED_LOCKOUT_SECONDS)
+
+
+def test_ip_rate_limit_not_cleared_on_success(client: TestClient) -> None:
+    """A successful login from an IP does not reset the IP failure counter."""
+    email = random_email()
+    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+
+    # Hit the IP limit using non-existent emails (30 failures → lock set on 30th)
+    for _ in range(IP_FAILED_MAX):
+        client.post(
+            f"{AUTH}/login",
+            json={"email": random_email(), "password": "WrongPass1"},
+        )
+
+    # A successful login does NOT clear the IP counter (by design)
+    client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
+
+    # IP is still blocked — next attempt must return 429
+    r = client.post(
+        f"{AUTH}/login", json={"email": random_email(), "password": "WrongPass1"}
+    )
+    assert r.status_code == 429

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -542,17 +542,24 @@ def test_ip_rate_limit_not_cleared_on_success(client: TestClient) -> None:
     email = random_email()
     client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
 
-    # Hit the IP limit using non-existent emails (30 failures → lock set on 30th)
-    for _ in range(IP_FAILED_MAX):
+    # Accumulate IP_FAILED_MAX - 1 failures — not enough to trigger lockout yet.
+    for _ in range(IP_FAILED_MAX - 1):
         client.post(
             f"{AUTH}/login",
             json={"email": random_email(), "password": "WrongPass1"},
         )
 
-    # A successful login does NOT clear the IP counter (by design)
-    client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
+    # A successful login must not reset the IP failure counter.
+    r = client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
+    assert r.status_code == 200
 
-    # IP is still blocked — next attempt must return 429
+    # One more failure pushes the counter to IP_FAILED_MAX, setting the lockout.
+    client.post(
+        f"{AUTH}/login",
+        json={"email": random_email(), "password": "WrongPass1"},
+    )
+
+    # IP is now locked — next attempt must return 429.
     r = client.post(
         f"{AUTH}/login", json={"email": random_email(), "password": "WrongPass1"}
     )

--- a/backend/tests/api/routes/test_login.py
+++ b/backend/tests/api/routes/test_login.py
@@ -10,6 +10,7 @@ from app.core.config import settings
 from app.core.security import get_password_hash, verify_password
 from app.crud import create_user
 from app.models import User, UserCreate
+from app.services.rate_limit_service import IP_FAILED_LOCKOUT_SECONDS, IP_FAILED_MAX
 from app.utils import generate_password_reset_token
 from tests.utils.user import user_authentication_headers
 from tests.utils.utils import random_email, random_lower_string
@@ -249,8 +250,6 @@ def test_legacy_login_ip_rate_limit_blocks_after_max_failures(
     isolated_rate_limiter: fakeredis.FakeRedis,  # noqa: ARG001
 ) -> None:
     """After IP_FAILED_MAX failures from one IP the legacy endpoint returns 429."""
-    from app.services.rate_limit_service import IP_FAILED_LOCKOUT_SECONDS, IP_FAILED_MAX
-
     # Use non-existent emails so each attempt hits auth and increments IP counter.
     # The lock is set on the IP_FAILED_MAX-th attempt but that request still returns
     # 400; the *next* request after the lock is set returns 429.

--- a/backend/tests/api/routes/test_login.py
+++ b/backend/tests/api/routes/test_login.py
@@ -244,6 +244,31 @@ def test_legacy_login_rate_limit_cleared_on_success(
         assert r.status_code == 400
 
 
+def test_legacy_login_ip_rate_limit_blocks_after_max_failures(
+    client: TestClient,
+    isolated_rate_limiter: fakeredis.FakeRedis,  # noqa: ARG001
+) -> None:
+    """After IP_FAILED_MAX failures from one IP the legacy endpoint returns 429."""
+    from app.services.rate_limit_service import IP_FAILED_LOCKOUT_SECONDS, IP_FAILED_MAX
+
+    # Use non-existent emails so each attempt hits auth and increments IP counter.
+    # The lock is set on the IP_FAILED_MAX-th attempt but that request still returns
+    # 400; the *next* request after the lock is set returns 429.
+    for _ in range(IP_FAILED_MAX):
+        r = client.post(
+            f"{settings.API_V1_STR}/login/access-token",
+            data={"username": random_email(), "password": "wrong"},
+        )
+        assert r.status_code == 400
+
+    r = client.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        data={"username": random_email(), "password": "wrong"},
+    )
+    assert r.status_code == 429
+    assert r.headers["Retry-After"] == str(IP_FAILED_LOCKOUT_SECONDS)
+
+
 # ── L3: password-recovery-html-content enumeration fix ───────────────────────
 
 


### PR DESCRIPTION
## Summary

- Add IP-based rate-limit layer to `POST /api/v1/auth/login` (JSON endpoint)
- Add IP-based rate-limit layer to `POST /api/v1/login/access-token` (legacy OAuth2 form endpoint)
- New constants in `rate_limit_service`: `IP_FAILED_MAX=30`, `IP_FAILED_WINDOW_SECONDS=3600`, `IP_FAILED_LOCKOUT_SECONDS=3600`
- IP lockout is **not** cleared on successful login (unlike per-email counter) — prevents lockout spraying via single known credential

## Test plan

- [x] `test_ip_rate_limit_blocks_after_max_failures` — 30 failures from one IP triggers 429 with `Retry-After` header on the 31st
- [x] `test_ip_rate_limit_not_cleared_on_success` — successful login does not reset IP failure counter
- [x] `test_legacy_login_ip_rate_limit_blocks_after_max_failures` — same behaviour on legacy endpoint
- [x] All existing auth and login tests still pass
- [x] `pre-commit run --all-files` clean