### PR TITLE
feat(security): validate pdf magic bytes and sanitize stored paths

### DIFF
--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -16,6 +16,7 @@ from app.schemas.contract import (
     NotaryQuestion,
 )
 from app.services import contract_service
+from app.services.document_service import _validate_pdf_bytes
 
 router = APIRouter(prefix="/contracts", tags=["contracts"])
 
@@ -128,6 +129,11 @@ async def analyze_contract(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail="File size must not exceed 20 MB",
         )
+
+    try:
+        _validate_pdf_bytes(file_bytes)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     record = await contract_service.analyze_contract_pdf(
         session=session,

--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -16,7 +16,7 @@ from app.schemas.contract import (
     NotaryQuestion,
 )
 from app.services import contract_service
-from app.services.document_service import _validate_pdf_bytes
+from app.services.document_service import validate_pdf_bytes
 
 router = APIRouter(prefix="/contracts", tags=["contracts"])
 
@@ -131,7 +131,7 @@ async def analyze_contract(
         )
 
     try:
-        _validate_pdf_bytes(file_bytes)
+        validate_pdf_bytes(file_bytes)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -166,7 +166,7 @@ TYPED_ANALYSIS_TYPES: frozenset[str] = frozenset(
 PDF_MAGIC = b"%PDF"
 
 
-def _validate_pdf_bytes(content: bytes) -> None:
+def validate_pdf_bytes(content: bytes) -> None:
     """Raise ValueError if content does not begin with the PDF magic bytes.
 
     Checking magic bytes prevents disguised files (HTML, JS polyglots, etc.)
@@ -261,7 +261,7 @@ async def save_upload(
         raise ValueError(f"File exceeds maximum size of {settings.MAX_FILE_SIZE_MB} MB")
 
     # Validate magic bytes — reject disguised non-PDF files regardless of Content-Type
-    _validate_pdf_bytes(file_content)
+    validate_pdf_bytes(file_content)
 
     # Write file to disk using a UUID-only name so the original filename can never
     # introduce path traversal components (M6: sanitize stored file paths).

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -11,6 +11,7 @@ import re
 import secrets
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import HTTPException, status
 from sqlalchemy import func, select
@@ -162,6 +163,19 @@ TYPED_ANALYSIS_TYPES: frozenset[str] = frozenset(
 )
 
 
+PDF_MAGIC = b"%PDF"
+
+
+def _validate_pdf_bytes(content: bytes) -> None:
+    """Raise ValueError if content does not begin with the PDF magic bytes.
+
+    Checking magic bytes prevents disguised files (HTML, JS polyglots, etc.)
+    from being accepted regardless of what Content-Type the client sends.
+    """
+    if not content.startswith(PDF_MAGIC):
+        raise ValueError("File does not appear to be a valid PDF")
+
+
 def _detect_document_type(text: str) -> DocumentType:
     """Detect document type based on keyword frequency in extracted text."""
     text_lower = text.lower()
@@ -246,12 +260,16 @@ async def save_upload(
     if len(file_content) > max_bytes:
         raise ValueError(f"File exceeds maximum size of {settings.MAX_FILE_SIZE_MB} MB")
 
-    # Write file to disk
-    upload_dir = settings.UPLOAD_DIR
+    # Validate magic bytes — reject disguised non-PDF files regardless of Content-Type
+    _validate_pdf_bytes(file_content)
+
+    # Write file to disk using a UUID-only name so the original filename can never
+    # introduce path traversal components (M6: sanitize stored file paths).
+    upload_dir = Path(settings.UPLOAD_DIR).resolve()
     os.makedirs(upload_dir, exist_ok=True)
 
-    stored_filename = f"{uuid.uuid4().hex}_{filename}"
-    file_path = os.path.join(upload_dir, stored_filename)
+    stored_filename = f"{uuid.uuid4().hex}.pdf"
+    file_path = str(upload_dir / stored_filename)
 
     with open(file_path, "wb") as f:
         f.write(file_content)

--- a/backend/tests/api/routes/test_contracts.py
+++ b/backend/tests/api/routes/test_contracts.py
@@ -341,3 +341,47 @@ def test_get_shared_analysis_not_found(client: TestClient) -> None:
     """Test retrieving a non-existent shared analysis returns 404."""
     r = client.get(f"{settings.API_V1_STR}/contracts/shared/nonexistent12")
     assert r.status_code == 404
+
+
+# ── M5: PDF magic-bytes validation ───────────────────────────────────────────
+
+
+def test_analyze_contract_rejects_non_pdf_magic_bytes(
+    client: TestClient, db: Session
+) -> None:
+    """HTML file renamed to .pdf must be rejected — magic bytes check."""
+    headers, _ = _get_auth_headers(client, db)
+    html_bytes = b"<html><body>not a pdf</body></html>"
+    r = client.post(
+        f"{settings.API_V1_STR}/contracts/analyze",
+        files={"file": ("evil.pdf", io.BytesIO(html_bytes), "application/pdf")},
+        headers=headers,
+    )
+    assert r.status_code == 400
+    assert "valid PDF" in r.json()["detail"]
+
+
+def test_analyze_contract_accepts_valid_pdf_regardless_of_content_type(
+    client: TestClient, db: Session
+) -> None:
+    """Valid PDF bytes must be accepted even if Content-Type is not application/pdf."""
+    headers, _ = _get_auth_headers(client, db)
+    with (
+        patch(
+            "app.services.contract_service.analyze_kaufvertrag",
+            new=AsyncMock(return_value=_MOCK_ANALYSIS),
+        ),
+        patch(
+            "app.services.contract_service._extract_pages_from_bytes",
+            return_value=[
+                {"page_number": 1, "original_text": "Test", "translated_text": ""}
+            ],
+        ),
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/contracts/analyze",
+            # content_type set to text/plain but extension is .pdf → should still pass
+            files={"file": ("document.pdf", io.BytesIO(_MINIMAL_PDF), "text/plain")},
+            headers=headers,
+        )
+    assert r.status_code == 201

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -10,6 +10,7 @@ from app.models.document import Document, DocumentStatus, DocumentType
 from app.services.document_service import (
     _detect_clauses,
     _detect_document_type,
+    _validate_pdf_bytes,
     get_documents_by_step_id,
 )
 
@@ -198,3 +199,85 @@ class TestGetDocumentsByStepId:
         assert "document.journey_step_id" in compiled
         assert "document.user_id" in compiled
         assert "ORDER BY document.created_at DESC" in compiled
+
+
+# ── M5: PDF magic-bytes validation ───────────────────────────────────────────
+
+
+class TestValidatePdfBytes:
+    def test_valid_pdf_passes(self) -> None:
+        valid_pdf = b"%PDF-1.4 minimal content"
+        # Should not raise
+        _validate_pdf_bytes(valid_pdf)
+
+    def test_html_disguised_as_pdf_raises(self) -> None:
+        html_bytes = b"<html><body>not a pdf</body></html>"
+        with pytest.raises(ValueError, match="does not appear to be a valid PDF"):
+            _validate_pdf_bytes(html_bytes)
+
+    def test_empty_bytes_raises(self) -> None:
+        with pytest.raises(ValueError, match="does not appear to be a valid PDF"):
+            _validate_pdf_bytes(b"")
+
+    def test_js_polyglot_raises(self) -> None:
+        js_bytes = b"alert('xss');"
+        with pytest.raises(ValueError, match="does not appear to be a valid PDF"):
+            _validate_pdf_bytes(js_bytes)
+
+
+# ── M6: Stored filename path sanitization ────────────────────────────────────
+
+
+class TestSaveUploadPathSanitization:
+    @pytest.mark.asyncio
+    async def test_stored_filename_is_uuid_only(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Stored filename must be <uuid>.pdf — no original filename embedded."""
+        import os
+        from unittest.mock import AsyncMock, patch
+
+        from app.services import document_service
+
+        minimal_pdf = (
+            b"%PDF-1.4\n"
+            b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]>>\nendobj\n"
+            b"xref\n0 4\n0000000000 65535 f\n"
+            b"0000000009 00000 n\n0000000068 00000 n\n0000000125 00000 n\n"
+            b"trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n197\n%%EOF"
+        )
+        mock_session = AsyncMock()
+        mock_session.refresh = AsyncMock()
+
+        with (
+            patch.object(document_service.settings, "UPLOAD_DIR", str(tmp_path)),
+            patch("app.services.document_service._count_pages_sync", return_value=1),
+            patch(
+                "app.services.document_service._extract_pages_sync",
+                return_value=[
+                    {"page_number": 1, "original_text": "", "translated_text": ""}
+                ],
+            ),
+        ):
+            doc = await document_service.save_upload(
+                session=mock_session,
+                user_id=uuid.uuid4(),
+                file_content=minimal_pdf,
+                filename="../../../etc/cron.d/evil",
+                is_premium=False,
+            )
+
+        # Stored filename must be <hex>.pdf — no path components from original name
+        assert doc.stored_filename.endswith(".pdf")
+        assert ".." not in doc.stored_filename
+        assert "/" not in doc.stored_filename
+        assert doc.stored_filename == doc.stored_filename.split("/")[-1]
+        # Original name is preserved in the DB field
+        assert doc.original_filename == "../../../etc/cron.d/evil"
+        # File must be inside tmp_path — no path traversal
+        written_files = list(tmp_path.iterdir())
+        assert len(written_files) == 1
+        assert written_files[0].name == doc.stored_filename
+        os.remove(written_files[0])

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -1,17 +1,20 @@
 """Tests for document upload and translation service."""
 
+import os
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.models.document import Document, DocumentStatus, DocumentType
+from app.services import document_service
 from app.services.document_service import (
     _detect_clauses,
     _detect_document_type,
-    _validate_pdf_bytes,
     get_documents_by_step_id,
+    validate_pdf_bytes,
 )
 
 # --- Document type detection tests ---
@@ -208,21 +211,21 @@ class TestValidatePdfBytes:
     def test_valid_pdf_passes(self) -> None:
         valid_pdf = b"%PDF-1.4 minimal content"
         # Should not raise
-        _validate_pdf_bytes(valid_pdf)
+        validate_pdf_bytes(valid_pdf)
 
     def test_html_disguised_as_pdf_raises(self) -> None:
         html_bytes = b"<html><body>not a pdf</body></html>"
         with pytest.raises(ValueError, match="does not appear to be a valid PDF"):
-            _validate_pdf_bytes(html_bytes)
+            validate_pdf_bytes(html_bytes)
 
     def test_empty_bytes_raises(self) -> None:
         with pytest.raises(ValueError, match="does not appear to be a valid PDF"):
-            _validate_pdf_bytes(b"")
+            validate_pdf_bytes(b"")
 
     def test_js_polyglot_raises(self) -> None:
         js_bytes = b"alert('xss');"
         with pytest.raises(ValueError, match="does not appear to be a valid PDF"):
-            _validate_pdf_bytes(js_bytes)
+            validate_pdf_bytes(js_bytes)
 
 
 # ── M6: Stored filename path sanitization ────────────────────────────────────
@@ -230,15 +233,8 @@ class TestValidatePdfBytes:
 
 class TestSaveUploadPathSanitization:
     @pytest.mark.asyncio
-    async def test_stored_filename_is_uuid_only(
-        self, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    async def test_stored_filename_is_uuid_only(self, tmp_path: Path) -> None:
         """Stored filename must be <uuid>.pdf — no original filename embedded."""
-        import os
-        from unittest.mock import AsyncMock, patch
-
-        from app.services import document_service
-
         minimal_pdf = (
             b"%PDF-1.4\n"
             b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"


### PR DESCRIPTION
## Summary

- **M5 — PDF magic-bytes validation**: Both `/documents/upload` and `/contracts/analyze` now verify the first 4 bytes of the uploaded file match `%PDF`. A disguised file (HTML, JS polyglot) is rejected with HTTP 400 regardless of the Content-Type header the client sends.
- **M6 — Stored filename path sanitization**: `document_service.save_upload()` now stores files as `<uuid>.pdf` instead of `<uuid>_<original_filename>`. The original filename is preserved in the `original_filename` DB column. Path is built via `pathlib.Path.resolve()` so `UPLOAD_DIR` is always absolute; original filenames with `../` components can never escape the upload directory.

## Test plan

- [x] `TestValidatePdfBytes` (4 cases) — valid PDF passes; HTML, empty, JS bytes raise ValueError
- [x] `TestSaveUploadPathSanitization` — traversal filename (`../../../etc/cron.d/evil`) stored as `<uuid>.pdf` inside tmp_path
- [x] `test_analyze_contract_rejects_non_pdf_magic_bytes` — HTML bytes → 400 on contracts endpoint
- [x] `test_analyze_contract_accepts_valid_pdf_regardless_of_content_type` — valid PDF bytes with `text/plain` Content-Type → 201
- [x] All existing contract and document tests still pass
- [x] `pre-commit run --all-files` clean