### PR TITLE
feat(security): add csp and security headers via traefik middleware

### DIFF
--- a/compose.override.yml
+++ b/compose.override.yml
@@ -107,9 +107,8 @@ services:
       - ./frontend:/app/frontend
     command: sh -c "bun install && bun run dev --host"
     labels:
-      - traefik.enable=true
       # Security headers middleware (local: connect-src covers HTTP API on localhost)
-      - "traefik.http.middlewares.security-headers.headers.contentSecurityPolicy=default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://api.${DOMAIN:-localhost.tiangolo.com} http://localhost:8000 https://sentry.io; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      - "traefik.http.middlewares.security-headers.headers.contentSecurityPolicy=default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://api.${DOMAIN:-localhost.tiangolo.com} http://localhost:8000 https://sentry.io; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
       - traefik.http.middlewares.security-headers.headers.xFrameOptions=DENY
       - traefik.http.middlewares.security-headers.headers.xContentTypeOptions=nosniff
       - traefik.http.middlewares.security-headers.headers.referrerPolicy=strict-origin-when-cross-origin

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -106,6 +106,16 @@ services:
     volumes:
       - ./frontend:/app/frontend
     command: sh -c "bun install && bun run dev --host"
+    labels:
+      - traefik.enable=true
+      # Security headers middleware (local: connect-src covers HTTP API on localhost)
+      - "traefik.http.middlewares.security-headers.headers.contentSecurityPolicy=default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://api.${DOMAIN:-localhost.tiangolo.com} http://localhost:8000 https://sentry.io; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      - traefik.http.middlewares.security-headers.headers.xFrameOptions=DENY
+      - traefik.http.middlewares.security-headers.headers.xContentTypeOptions=nosniff
+      - traefik.http.middlewares.security-headers.headers.referrerPolicy=strict-origin-when-cross-origin
+      - "traefik.http.middlewares.security-headers.headers.permissionsPolicy=camera=(), microphone=(), geolocation=()"
+      # Local dev uses HTTP router — include both https-redirect (no-op locally) and security headers
+      - traefik.http.routers.${STACK_NAME?Variable not set}-frontend-http.middlewares=https-redirect,security-headers
 
   playwright:
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -164,7 +164,7 @@ services:
       - traefik.http.routers.${STACK_NAME?Variable not set}-frontend-http.middlewares=https-redirect
 
       # Security headers middleware
-      - "traefik.http.middlewares.security-headers.headers.contentSecurityPolicy=default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.${DOMAIN} https://sentry.io; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      - "traefik.http.middlewares.security-headers.headers.contentSecurityPolicy=default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.${DOMAIN?Variable not set} https://sentry.io; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
       - traefik.http.middlewares.security-headers.headers.xFrameOptions=DENY
       - traefik.http.middlewares.security-headers.headers.xContentTypeOptions=nosniff
       - traefik.http.middlewares.security-headers.headers.referrerPolicy=strict-origin-when-cross-origin

--- a/compose.yml
+++ b/compose.yml
@@ -162,6 +162,15 @@ services:
 
       # Enable redirection for HTTP and HTTPS
       - traefik.http.routers.${STACK_NAME?Variable not set}-frontend-http.middlewares=https-redirect
+
+      # Security headers middleware
+      - "traefik.http.middlewares.security-headers.headers.contentSecurityPolicy=default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.${DOMAIN} https://sentry.io; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      - traefik.http.middlewares.security-headers.headers.xFrameOptions=DENY
+      - traefik.http.middlewares.security-headers.headers.xContentTypeOptions=nosniff
+      - traefik.http.middlewares.security-headers.headers.referrerPolicy=strict-origin-when-cross-origin
+      - "traefik.http.middlewares.security-headers.headers.permissionsPolicy=camera=(), microphone=(), geolocation=()"
+      # Apply security headers to the HTTPS router only — not the API router
+      - traefik.http.routers.${STACK_NAME?Variable not set}-frontend-https.middlewares=security-headers
 volumes:
   app-db-data:
   app-redis-data:


### PR DESCRIPTION
## Summary

- Adds a `security-headers` Traefik middleware to `compose.yml` (production) and `compose.override.yml` (local dev) with the following headers on all frontend responses:
  - `Content-Security-Policy` — restricts script, style, image, font, and connect sources; disallows framing and form-action exfiltration
  - `X-Frame-Options: DENY` — belt-and-suspenders clickjacking protection
  - `X-Content-Type-Options: nosniff` — prevents MIME-type sniffing
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy` — disables camera, microphone, geolocation
- Middleware is applied to the **frontend HTTPS router only** in production (backend API is deliberately excluded — CSP would break Swagger UI)
- Local dev override applies to the frontend HTTP router (no TLS locally) and widens `connect-src` to also allow `http://localhost:8000`

## Test plan

- [x] `docker compose config` validates without error
- [x] Backend routers remain unaffected (no `security-headers` on `heimpath-backend-*` routers)
- [x] Frontend HTTPS router has `security-headers` middleware in production compose
- [x] Frontend HTTP router has `https-redirect,security-headers` in local override
- [x] `pre-commit run --all-files` clean
- [ ] Post-deploy: `curl -I https://{DOMAIN} | grep -i content-security-policy` shows policy header