### PR TITLE
feat(security): shorten access token to 15min and rotate refresh tokens

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -230,21 +230,21 @@ async def login(
     # Clear failed attempts on successful login
     rate_limit_service.record_successful_login(request.email)
 
-    # Generate tokens
-    access_token = auth_service.create_access_token(
-        subject=str(user.id),
-        remember_me=request.remember_me,
+    # Generate tokens — access token is always short-lived (15 min).
+    # "Remember me" extends the refresh token, not the access token.
+    access_token = auth_service.create_access_token(subject=str(user.id))
+    refresh_token_value = auth_service.create_refresh_token(
+        subject=str(user.id), remember_me=request.remember_me
     )
-    refresh_token_value = auth_service.create_refresh_token(subject=str(user.id))
 
     # Set HttpOnly cookies so the browser never exposes tokens to JS
     secure = settings.ENVIRONMENT != "local"
-    access_max_age = (
+    access_max_age = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60  # always 15 min
+    refresh_max_age = (
         settings.REMEMBER_ME_EXPIRE_DAYS * 24 * 60 * 60
         if request.remember_me
-        else settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+        else settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60
     )
-    refresh_max_age = settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60
 
     response.set_cookie(
         key="access_token",
@@ -267,13 +267,15 @@ async def login(
     # JS-readable indicator so the frontend can check login state synchronously.
     # httponly=False is intentional: this cookie contains no secret, only the
     # boolean "1" to signal to isLoggedIn() that an HttpOnly access token exists.
+    # Lifetime follows refresh_max_age so the indicator stays valid as long as
+    # silent refresh is possible.
     response.set_cookie(  # NOSONAR - S3330: httponly=False intentional for UI indicator
         key="logged_in",
         value="1",
         httponly=False,
         secure=secure,
         samesite="lax",
-        max_age=access_max_age,
+        max_age=refresh_max_age,
         path="/",
     )
 
@@ -305,15 +307,18 @@ async def refresh_token(
             detail="Invalid or expired refresh token",
         )
 
-    new_access_token = auth_service.refresh_access_token(token)
-    if new_access_token is None:
+    result = auth_service.refresh_access_token(token)
+    if result is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
         )
 
-    # Rotate the access_token cookie
+    new_access_token, new_refresh_token = result
+
+    # Rotate both cookies — new access token + new refresh token
     secure = settings.ENVIRONMENT != "local"
+    refresh_max_age = settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60
     response.set_cookie(
         key="access_token",
         value=new_access_token,
@@ -323,8 +328,15 @@ async def refresh_token(
         max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         path="/",
     )
-    # logged_in follows the refresh token lifetime so the indicator stays valid
-    # as long as silent refresh is possible (not just the current access token window).
+    response.set_cookie(
+        key="refresh_token",
+        value=new_refresh_token,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        max_age=refresh_max_age,
+        path="/",
+    )
     # httponly=False is intentional: see the login endpoint comment.
     response.set_cookie(  # NOSONAR - S3330: httponly=False intentional for UI indicator
         key="logged_in",
@@ -332,13 +344,13 @@ async def refresh_token(
         httponly=False,
         secure=secure,
         samesite="lax",
-        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        max_age=refresh_max_age,
         path="/",
     )
 
     return AuthToken(
         access_token=new_access_token,
-        refresh_token=token,  # Return same refresh token
+        refresh_token=new_refresh_token,
     )
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
     # Token expiration settings
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
     REMEMBER_ME_EXPIRE_DAYS: int = 30
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     # Redis (token blacklist + rate limiting)
     REDIS_URL: str = "redis://localhost:6379"
     # Comma-separated list of trusted proxy IPs for X-Forwarded-* headers.

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -240,9 +240,14 @@ def refresh_access_token(refresh_token: str) -> tuple[str, str] | None:
         return None
     if token_data.type != TokenType.REFRESH:
         return None
-    assert token_data.jti is not None  # refresh tokens always carry jti
+    if token_data.jti is None:
+        # Refresh tokens always carry a jti; reject if somehow missing
+        return None
     _rotate_refresh_token(token_data.jti, token_data.exp)
     new_access = create_access_token(subject=token_data.sub)
+    # New refresh token uses the default lifetime. The remember_me extended
+    # lifetime applies only to the initial login token; subsequent rotations
+    # issue standard 7-day tokens (users remain active via silent refresh).
     new_refresh = create_refresh_token(subject=token_data.sub)
     return new_access, new_refresh
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -20,6 +20,8 @@ from app.services.redis_client import get_redis
 
 ALGORITHM = "HS256"
 _BLACKLIST_PREFIX = "auth:blacklist:"
+_GRACE_PREFIX = "auth:refresh_grace:"
+REFRESH_ROTATION_GRACE_SECONDS = 30
 
 # Module-level Redis client (connection pool, created lazily)
 _redis_client: redis_lib.Redis | None = None
@@ -55,16 +57,50 @@ def _redis() -> redis_lib.Redis:
 def create_access_token(
     subject: str,
     expires_delta: timedelta | None = None,
-    remember_me: bool = False,
 ) -> str:
     """Create a signed JWT access token.
 
+    Access tokens are always short-lived (``ACCESS_TOKEN_EXPIRE_MINUTES``).
+    "Remember me" UX is handled by extending the refresh token lifetime, not
+    the access token.
+
     Args:
         subject: The user ID to embed as the ``sub`` claim.
-        expires_delta: Custom lifetime. Overrides ``remember_me`` and the
-            default 1-hour window when provided.
+        expires_delta: Custom lifetime override (used in tests).
+
+    Returns:
+        Encoded JWT string.
+    """
+    expire = (
+        datetime.now(timezone.utc) + expires_delta
+        if expires_delta is not None
+        else datetime.now(timezone.utc)
+        + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode: dict[str, Any] = {
+        "sub": subject,
+        "type": TokenType.ACCESS.value,
+        "exp": expire,
+    }
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_refresh_token(
+    subject: str,
+    expires_delta: timedelta | None = None,
+    remember_me: bool = False,
+) -> str:
+    """Create a signed JWT refresh token.
+
+    Refresh tokens carry a unique ``jti`` claim so they can be individually
+    blacklisted on logout or rotation.
+
+    Args:
+        subject: The user ID to embed as the ``sub`` claim.
+        expires_delta: Custom lifetime override (used in tests).
         remember_me: When *True* the token lives for
-            ``settings.REMEMBER_ME_EXPIRE_DAYS`` days instead of 1 hour.
+            ``settings.REMEMBER_ME_EXPIRE_DAYS`` days instead of the
+            default ``REFRESH_TOKEN_EXPIRE_DAYS``.
 
     Returns:
         Encoded JWT string.
@@ -77,40 +113,8 @@ def create_access_token(
         )
     else:
         expire = datetime.now(timezone.utc) + timedelta(
-            minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
+            days=settings.REFRESH_TOKEN_EXPIRE_DAYS
         )
-
-    to_encode: dict[str, Any] = {
-        "sub": subject,
-        "type": TokenType.ACCESS.value,
-        "exp": expire,
-    }
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
-
-
-def create_refresh_token(
-    subject: str,
-    expires_delta: timedelta | None = None,
-) -> str:
-    """Create a signed JWT refresh token.
-
-    Refresh tokens carry a unique ``jti`` claim so they can be individually
-    blacklisted on logout.
-
-    Args:
-        subject: The user ID to embed as the ``sub`` claim.
-        expires_delta: Custom lifetime. Defaults to
-            ``settings.REFRESH_TOKEN_EXPIRE_DAYS`` days.
-
-    Returns:
-        Encoded JWT string.
-    """
-    expire = (
-        datetime.now(timezone.utc) + expires_delta
-        if expires_delta is not None
-        else datetime.now(timezone.utc)
-        + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
-    )
     jti = str(uuid.uuid4())
     to_encode: dict[str, Any] = {
         "sub": subject,
@@ -139,6 +143,10 @@ def decode_token(token: str) -> dict[str, Any] | None:
 def verify_token(token: str) -> TokenData | None:
     """Fully validate a token: signature, expiry, and blacklist.
 
+    Blacklisted refresh tokens in their rotation grace window are still
+    accepted to handle concurrent refresh requests (see
+    :func:`_rotate_refresh_token`).
+
     Args:
         token: Encoded JWT string.
 
@@ -152,7 +160,9 @@ def verify_token(token: str) -> TokenData | None:
 
     jti = payload.get("jti")
     if jti and is_token_blacklisted(jti):
-        return None
+        # Allow the token if it is within the post-rotation grace window
+        if not is_token_in_grace_period(jti):
+            return None
 
     try:
         return TokenData(
@@ -187,26 +197,54 @@ def is_token_blacklisted(jti: str) -> bool:
     return bool(_redis().exists(f"{_BLACKLIST_PREFIX}{jti}"))
 
 
+def is_token_in_grace_period(jti: str) -> bool:
+    """Return *True* if a rotation grace window is active for this JTI.
+
+    After refresh token rotation the old JTI is blacklisted but a short
+    grace key is set so concurrent in-flight refresh requests still succeed.
+    """
+    return bool(_redis().exists(f"{_GRACE_PREFIX}{jti}"))
+
+
+def _rotate_refresh_token(jti: str, expires_at: datetime) -> None:
+    """Blacklist *jti* and set a short grace window for concurrent requests.
+
+    Called during refresh token rotation so that two near-simultaneous
+    refresh requests with the same old token both succeed within the
+    :data:`REFRESH_ROTATION_GRACE_SECONDS` window.
+    """
+    blacklist_token(jti, expires_at)
+    _redis().setex(f"{_GRACE_PREFIX}{jti}", REFRESH_ROTATION_GRACE_SECONDS, "1")
+
+
 # ── higher-level operations ───────────────────────────────────────────────────
 
 
-def refresh_access_token(refresh_token: str) -> str | None:
-    """Issue a new access token from a valid, non-blacklisted refresh token.
+def refresh_access_token(refresh_token: str) -> tuple[str, str] | None:
+    """Issue new access and refresh tokens from a valid refresh token.
+
+    The old refresh token is blacklisted immediately and a
+    :data:`REFRESH_ROTATION_GRACE_SECONDS` grace window is set to handle
+    concurrent requests that arrive with the same old token.
 
     Args:
         refresh_token: A refresh token previously issued by
             :func:`create_refresh_token`.
 
     Returns:
-        New access token string, or *None* if the refresh token is invalid,
-        expired, or blacklisted.
+        ``(new_access_token, new_refresh_token)`` tuple, or *None* if the
+        refresh token is invalid, expired, or past its grace window.
     """
     token_data = verify_token(refresh_token)
     if token_data is None:
         return None
     if token_data.type != TokenType.REFRESH:
         return None
-    return create_access_token(subject=token_data.sub)
+    assert token_data.jti is not None  # refresh tokens always carry jti
+    _rotate_refresh_token(token_data.jti, token_data.exp)
+    new_access = create_access_token(subject=token_data.sub)
+    new_refresh = create_refresh_token(subject=token_data.sub)
+    return new_access, new_refresh
 
 
 def logout(refresh_token: str) -> bool:

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -259,15 +259,16 @@ def _register_and_login(client: TestClient) -> dict:
     return r.json()
 
 
-def test_refresh_issues_new_access_token(client: TestClient) -> None:
+def test_refresh_issues_new_access_and_refresh_tokens(client: TestClient) -> None:
     tokens = _register_and_login(client)
     r = client.post(f"{AUTH}/refresh", json={"refresh_token": tokens["refresh_token"]})
     assert r.status_code == 200
     body = r.json()
     assert "access_token" in body
     assert body["token_type"] == "bearer"
-    # Refresh token is echoed back unchanged
-    assert body["refresh_token"] == tokens["refresh_token"]
+    # Refresh token rotation: response contains a NEW refresh token
+    assert "refresh_token" in body
+    assert body["refresh_token"] != tokens["refresh_token"]
 
 
 def test_refresh_with_invalid_token_returns_401(client: TestClient) -> None:

--- a/backend/tests/services/test_auth_service.py
+++ b/backend/tests/services/test_auth_service.py
@@ -16,6 +16,7 @@ from app.services.auth_service import (
     create_refresh_token,
     decode_token,
     is_token_blacklisted,
+    is_token_in_grace_period,
     logout,
     refresh_access_token,
     verify_token,
@@ -71,13 +72,13 @@ class TestCreateAccessToken:
         token = create_access_token(subject=str(uuid.uuid4()))
         assert isinstance(token, str) and len(token) > 0
 
-    def test_default_expiry_1h(self) -> None:
+    def test_default_expiry_15m(self) -> None:
         token = create_access_token(subject=str(uuid.uuid4()))
         payload = decode_token(token)
         assert payload is not None
         exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         diff = exp - datetime.now(timezone.utc)
-        assert timedelta(minutes=55) < diff < timedelta(minutes=65)
+        assert timedelta(minutes=14) < diff < timedelta(minutes=16)
 
     def test_custom_expiry(self) -> None:
         token = create_access_token(
@@ -88,14 +89,6 @@ class TestCreateAccessToken:
         exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         diff = exp - datetime.now(timezone.utc)
         assert timedelta(hours=1, minutes=59) < diff < timedelta(hours=2, minutes=1)
-
-    def test_remember_me_30d(self) -> None:
-        token = create_access_token(subject=str(uuid.uuid4()), remember_me=True)
-        payload = decode_token(token)
-        assert payload is not None
-        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
-        diff = exp - datetime.now(timezone.utc)
-        assert timedelta(days=29) < diff < timedelta(days=31)
 
     def test_type_claim_is_access(self) -> None:
         payload = decode_token(create_access_token(subject=str(uuid.uuid4())))
@@ -123,6 +116,15 @@ class TestCreateRefreshToken:
         payload = decode_token(create_refresh_token(subject=str(uuid.uuid4())))
         assert payload is not None
         assert "jti" in payload and payload["jti"]
+
+    def test_remember_me_30d(self) -> None:
+        payload = decode_token(
+            create_refresh_token(subject=str(uuid.uuid4()), remember_me=True)
+        )
+        assert payload is not None
+        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        diff = exp - datetime.now(timezone.utc)
+        assert timedelta(days=29) < diff < timedelta(days=31)
 
 
 # ── decode_token ──────────────────────────────────────────────────────────────
@@ -205,15 +207,57 @@ class TestBlacklist:
 
 
 class TestRefreshAccessToken:
-    def test_issues_new_access_token(self) -> None:
+    def test_returns_new_access_and_refresh_tokens(self) -> None:
         user_id = str(uuid.uuid4())
-        refresh = create_refresh_token(subject=user_id)
-        new_access = refresh_access_token(refresh)
-        assert new_access is not None
-        payload = decode_token(new_access)
+        old_refresh = create_refresh_token(subject=user_id)
+        result = refresh_access_token(old_refresh)
+        assert result is not None
+        new_access, new_refresh = result
+        access_payload = decode_token(new_access)
+        assert access_payload is not None
+        assert access_payload["sub"] == user_id
+        assert access_payload["type"] == TokenType.ACCESS.value
+        assert new_refresh != old_refresh
+
+    def test_new_refresh_token_is_valid(self) -> None:
+        user_id = str(uuid.uuid4())
+        old_refresh = create_refresh_token(subject=user_id)
+        result = refresh_access_token(old_refresh)
+        assert result is not None
+        _, new_refresh = result
+        payload = decode_token(new_refresh)
         assert payload is not None
         assert payload["sub"] == user_id
-        assert payload["type"] == TokenType.ACCESS.value
+        assert payload["type"] == TokenType.REFRESH.value
+
+    def test_old_refresh_blacklisted_but_in_grace_period(self) -> None:
+        old_refresh = create_refresh_token(subject=str(uuid.uuid4()))
+        old_payload = decode_token(old_refresh)
+        assert old_payload is not None
+        result = refresh_access_token(old_refresh)
+        assert result is not None
+        assert is_token_blacklisted(old_payload["jti"])
+        assert is_token_in_grace_period(old_payload["jti"])
+
+    def test_grace_period_allows_concurrent_refresh(self) -> None:
+        """Two near-simultaneous refreshes with the same old token both succeed."""
+        old_refresh = create_refresh_token(subject=str(uuid.uuid4()))
+        result1 = refresh_access_token(old_refresh)
+        result2 = refresh_access_token(old_refresh)  # within grace window
+        assert result1 is not None
+        assert result2 is not None
+
+    def test_expired_grace_period_rejects_old_token(
+        self, fake_redis_client: fakeredis.FakeRedis
+    ) -> None:
+        """After the grace key expires the old token is definitively rejected."""
+        old_refresh = create_refresh_token(subject=str(uuid.uuid4()))
+        old_payload = decode_token(old_refresh)
+        assert old_payload is not None
+        refresh_access_token(old_refresh)
+        # Simulate grace period expiry by removing the grace key
+        fake_redis_client.delete(f"auth:refresh_grace:{old_payload['jti']}")
+        assert refresh_access_token(old_refresh) is None
 
     def test_invalid_refresh_returns_none(self) -> None:
         assert refresh_access_token("invalid.refresh.token") is None
@@ -222,7 +266,7 @@ class TestRefreshAccessToken:
         access = create_access_token(subject=str(uuid.uuid4()))
         assert refresh_access_token(access) is None
 
-    def test_blacklisted_refresh_returns_none(self) -> None:
+    def test_hard_blacklisted_refresh_returns_none(self) -> None:
         refresh = create_refresh_token(subject=str(uuid.uuid4()))
         payload = decode_token(refresh)
         assert payload is not None
@@ -230,6 +274,7 @@ class TestRefreshAccessToken:
             payload["jti"],
             datetime.fromtimestamp(payload["exp"], tz=timezone.utc),
         )
+        # No grace key → rejected
         assert refresh_access_token(refresh) is None
 
 
@@ -251,7 +296,8 @@ class TestLogout:
     def test_invalid_token_returns_false(self) -> None:
         assert logout("invalid.token") is False
 
-    def test_second_refresh_after_logout_fails(self) -> None:
+    def test_refresh_after_logout_fails(self) -> None:
         refresh = create_refresh_token(subject=str(uuid.uuid4()))
         logout(refresh)
+        # logout uses blacklist_token (no grace key) so refresh is immediately rejected
         assert refresh_access_token(refresh) is None


### PR DESCRIPTION
## Summary

- **M3**: Access tokens are now always 15 minutes. The `remember_me` flag no longer extends the access token — it extends the refresh token to 30 days instead. This limits the stolen-token abuse window to 15 minutes maximum.
- **L2**: Refresh token rotation on every use. Old token is blacklisted immediately; a 30-second grace window handles concurrent in-flight requests. Both new tokens are returned and set as HttpOnly cookies.

## Test plan

- [ ] `pytest tests/services/test_auth_service.py` — 31 tests including rotation, grace period, remember_me on refresh token
- [ ] `pytest tests/api/routes/test_auth.py` — verify new `test_refresh_issues_new_access_and_refresh_tokens`
- [ ] CI green (commitlint, pre-commit, test-backend, SonarCloud)