### PR TITLE
feat(security): restrict shared previews and move avatars to fs

### DIFF
--- a/backend/app/alembic/versions/d3e4f5g6h7i8_avatar_url_filesystem_migration.py
+++ b/backend/app/alembic/versions/d3e4f5g6h7i8_avatar_url_filesystem_migration.py
@@ -1,0 +1,50 @@
+"""Migrate avatar_url to filesystem storage
+
+Clears any legacy base64-encoded avatar values that were stored directly in
+the database and changes the column type to String(500) to hold filesystem
+URLs only.
+
+NOTE: This migration is NOT fully reversible. The upgrade irreversibly
+NULLs base64 blobs (they cannot be reconstructed from the filesystem).
+Running downgrade reverts the column type to Text but leaves previously-
+uploaded avatars with a NULL avatar_url.
+
+Revision ID: d3e4f5g6h7i8
+Revises: c2d3e4f5g6h7
+Create Date: 2026-04-27 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d3e4f5g6h7i8"
+down_revision = "c2d3e4f5g6h7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Clear legacy base64-encoded avatar values (they start with "data:")
+    op.execute(
+        "UPDATE \"user\" SET avatar_url = NULL WHERE avatar_url LIKE 'data:%'"
+    )
+    # Change column type from Text to String(500)
+    op.alter_column(
+        "user",
+        "avatar_url",
+        existing_type=sa.Text(),
+        type_=sa.String(500),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "user",
+        "avatar_url",
+        existing_type=sa.String(500),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )

--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -13,6 +13,7 @@ from app.schemas.contract import (
     ContractAnalysisListItem,
     ContractAnalysisListResponse,
     ContractAnalysisResponse,
+    ContractSharedPreviewResponse,
     NotaryQuestion,
 )
 from app.services import contract_service
@@ -82,12 +83,16 @@ def _build_response(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/shared/{share_id}", response_model=ContractAnalysisResponse)
+@router.get("/shared/{share_id}", response_model=ContractSharedPreviewResponse)
 async def get_shared_analysis(
     share_id: str,
     session: SessionDep,
-) -> ContractAnalysisResponse:
-    """Retrieve a shared contract analysis by share_id (no auth required)."""
+) -> ContractSharedPreviewResponse:
+    """Retrieve a shared contract analysis by share_id (no auth required).
+
+    Returns a limited preview with at most 3 clauses and an upgrade CTA.
+    Full analysis requires an authenticated premium subscription.
+    """
     try:
         record = contract_service.get_analysis_by_share_id(session, share_id)
     except contract_service.ContractAnalysisNotFoundError:
@@ -95,7 +100,8 @@ async def get_shared_analysis(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Shared analysis not found",
         )
-    return _build_response(record, is_premium=True)
+    full = _build_response(record, is_premium=True)
+    return ContractSharedPreviewResponse.from_full_response(full)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -37,6 +37,9 @@ from app.services import document_service
 router = APIRouter(prefix="/documents", tags=["documents"])
 
 
+_DOCUMENT_UPGRADE_CTA = "Sign up to see the full translation — all pages, detected clauses, and risk warnings."
+
+
 def _build_detail_response(document: Document) -> DocumentDetailResponse:
     """Build DocumentDetailResponse from a Document model instance."""
     translation_response = None
@@ -184,13 +187,28 @@ async def get_shared_document(
     share_id: str,
     session: AsyncSessionDep,
 ) -> DocumentDetailResponse:
-    """
-    Get a shared document by share_id.
+    """Get a shared document by share_id (no authentication required).
 
-    No authentication required.
+    Returns document metadata and the first translated page only.
+    Full translation requires an authenticated subscription.
     """
     document = await document_service.get_by_share_id(session, share_id)
-    return _build_detail_response(document)
+    response = _build_detail_response(document)
+    # Restrict shared preview: keep only the first translated page and
+    # explicitly zero all premium-only fields so any future additions to
+    # _build_detail_response cannot accidentally leak premium content.
+    if response.translation:
+        response.translation.translated_pages = response.translation.translated_pages[
+            :1
+        ]
+        response.translation.clauses_detected = []
+        response.translation.risk_warnings = []
+        response.translation.kaufvertrag_analysis = None
+        response.translation.type_analysis = None
+        response.translation.glossary_links = []
+    response.requires_subscription = True
+    response.upgrade_cta = _DOCUMENT_UPGRADE_CTA
+    return response
 
 
 @router.get("/by-step/{step_id}", response_model=list[DocumentSummary])

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,7 +1,8 @@
-import base64
 import io
+import os
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from fastapi import (
@@ -13,6 +14,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from fastapi.responses import FileResponse
 from PIL import Image
 from sqlmodel import func, select
 
@@ -46,6 +48,21 @@ ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
 ALLOWED_IMAGE_FORMATS = {"JPEG", "PNG", "WEBP"}
 MAX_AVATAR_DIMENSION = 256
 AVATAR_WEBP_QUALITY = 80
+
+
+def _avatar_dir() -> Path:
+    """Return the directory where avatar files are stored."""
+    return Path(settings.UPLOAD_DIR).resolve().parent / "avatars"
+
+
+def _avatar_path(user_id: uuid.UUID) -> Path:
+    """Return the filesystem path for a user's avatar file."""
+    return _avatar_dir() / f"{user_id}.webp"
+
+
+def _avatar_url(user_id: uuid.UUID) -> str:
+    """Return the absolute URL used to serve a user's avatar."""
+    return f"{settings.backend_url}{settings.API_V1_STR}/users/avatars/{user_id}"
 
 
 @router.get(
@@ -190,6 +207,10 @@ async def delete_user_me(
             status_code=403, detail="Super users are not allowed to delete themselves"
         )
     refresh_token = http_request.cookies.get("refresh_token")
+    # Remove avatar file from disk (GDPR right-to-erasure)
+    avatar_path = _avatar_path(current_user.id)
+    if avatar_path.exists():
+        avatar_path.unlink()
     session.delete(current_user)
     session.commit()
     # Invalidate the refresh token after the account is confirmed deleted so that
@@ -206,6 +227,25 @@ async def delete_user_me(
     )
     response.delete_cookie(
         key="logged_in", path="/", secure=secure, httponly=False, samesite="lax"
+    )
+
+
+# NOTE: This route must be declared BEFORE the generic /{user_id} catch-all
+# below, otherwise FastAPI would match "avatars" as a user_id UUID (and fail).
+# include_in_schema=False: the frontend uses the absolute URL stored in
+# avatar_url directly, so no generated client type is needed.
+@router.get("/avatars/{user_id}", include_in_schema=False)
+async def serve_avatar(user_id: uuid.UUID) -> FileResponse:
+    """Serve a user avatar image file (no authentication required)."""
+    path = _avatar_path(user_id)
+    if not path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Avatar not found"
+        )
+    return FileResponse(
+        path,
+        media_type="image/webp",
+        headers={"Cache-Control": "public, max-age=3600"},
     )
 
 
@@ -249,9 +289,14 @@ async def upload_avatar(
 
     buf = io.BytesIO()
     img.save(buf, format="WEBP", quality=AVATAR_WEBP_QUALITY)
-    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
 
-    current_user.avatar_url = f"data:image/webp;base64,{encoded}"
+    # Write avatar to filesystem instead of storing base64 in the DB
+    avatar_dir = _avatar_dir()
+    os.makedirs(avatar_dir, exist_ok=True)
+    path = _avatar_path(current_user.id)
+    path.write_bytes(buf.getvalue())
+
+    current_user.avatar_url = _avatar_url(current_user.id)
     session.add(current_user)
     session.commit()
     session.refresh(current_user)
@@ -264,6 +309,10 @@ async def delete_avatar(
     current_user: CurrentUser,
 ) -> None:
     """Remove the current user's avatar."""
+    # Remove file from disk if it exists
+    path = _avatar_path(current_user.id)
+    if path.exists():
+        path.unlink()
     current_user.avatar_url = None
     session.add(current_user)
     session.commit()
@@ -361,5 +410,9 @@ async def delete_user(
         raise HTTPException(
             status_code=403, detail="Super users are not allowed to delete themselves"
         )
+    # Remove avatar file from disk (GDPR right-to-erasure)
+    avatar_path = _avatar_path(user.id)
+    if avatar_path.exists():
+        avatar_path.unlink()
     session.delete(user)
     session.commit()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -172,6 +172,17 @@ class Settings(BaseSettings):
     MAX_PAGES_FREE: int = 10
     MAX_PAGES_PREMIUM: int = 20
 
+    # Domain used to construct absolute backend URLs (e.g. avatar serving)
+    DOMAIN: str = "localhost"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def backend_url(self) -> str:
+        """Absolute base URL for the backend API."""
+        if self.ENVIRONMENT == "local":
+            return "http://localhost:8000"
+        return f"https://api.{self.DOMAIN}"
+
     def _check_default_secret(self, var_name: str, value: str | None) -> None:
         if not value and self.ENVIRONMENT != "local":
             raise ValueError(

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -2,7 +2,7 @@
 
 from enum import Enum as PyEnum
 
-from sqlalchemy import Boolean, Column, Enum, String, Text
+from sqlalchemy import Boolean, Column, Enum, String
 from sqlalchemy.orm import relationship
 
 from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
@@ -40,7 +40,7 @@ class User(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     stripe_customer_id = Column(String(255), nullable=True, unique=True, index=True)
     stripe_subscription_id = Column(String(255), nullable=True, unique=True)
-    avatar_url = Column(Text, nullable=True)
+    avatar_url = Column(String(500), nullable=True)
 
     journeys = relationship(
         "Journey",

--- a/backend/app/schemas/contract.py
+++ b/backend/app/schemas/contract.py
@@ -6,6 +6,12 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
+_SHARED_UPGRADE_CTA = "Sign up to see the full analysis — all clauses, notary checklist, and risk assessment."
+
+# Must match contract_service.FREE_TIER_CLAUSE_LIMIT — kept here to avoid a
+# circular import between schemas and services.
+_SHARED_PREVIEW_CLAUSE_LIMIT = 3
+
 
 class ClauseExplanation(BaseModel):
     """A single analyzed clause from a Kaufvertrag."""
@@ -48,6 +54,47 @@ class ContractAnalysisResponse(BaseModel):
     clause_count: int
     is_truncated: bool
     created_at: datetime
+
+
+class ContractSharedPreviewResponse(BaseModel):
+    """Limited response for unauthenticated shared contract previews.
+
+    Exposes at most 3 clauses and the overall risk level to encourage
+    sign-up, without giving away the full premium analysis.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    filename: str
+    share_id: str | None
+    summary: str | None
+    analyzed_clauses: list[ClauseExplanation]  # max 3
+    overall_risk_assessment: str | None
+    clause_count: int
+    is_truncated: bool
+    requires_subscription: bool
+    upgrade_cta: str
+    created_at: datetime
+
+    @classmethod
+    def from_full_response(
+        cls, r: "ContractAnalysisResponse"
+    ) -> "ContractSharedPreviewResponse":
+        preview_clauses = (r.analyzed_clauses or [])[:_SHARED_PREVIEW_CLAUSE_LIMIT]
+        return cls(
+            id=r.id,
+            filename=r.filename,
+            share_id=r.share_id,
+            summary=r.summary,
+            analyzed_clauses=preview_clauses,
+            overall_risk_assessment=r.overall_risk_assessment,
+            clause_count=r.clause_count,
+            is_truncated=r.clause_count > _SHARED_PREVIEW_CLAUSE_LIMIT,
+            requires_subscription=True,
+            upgrade_cta=_SHARED_UPGRADE_CTA,
+            created_at=r.created_at,
+        )
 
 
 class ContractAnalysisListItem(BaseModel):

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -193,6 +193,9 @@ class DocumentDetailResponse(BaseModel):
     journey_step_id: uuid.UUID | None = None
     created_at: datetime
     translation: DocumentTranslationResponse | None = None
+    # Shared preview fields — only set on unauthenticated shared responses
+    requires_subscription: bool = False
+    upgrade_cta: str | None = None
 
 
 class DocumentShareResponse(BaseModel):

--- a/backend/tests/api/routes/test_contracts.py
+++ b/backend/tests/api/routes/test_contracts.py
@@ -328,13 +328,17 @@ def test_share_and_retrieve_analysis(client: TestClient, db: Session) -> None:
     share_id = r.json()["share_id"]
     assert share_id is not None
 
-    # Retrieve via public endpoint (no auth) — shared view shows all clauses
+    # Retrieve via public endpoint (no auth) — shared view is limited preview
     r = client.get(f"{settings.API_V1_STR}/contracts/shared/{share_id}")
     assert r.status_code == 200
     data = r.json()
+    # Full clause count is preserved for display
     assert data["clause_count"] == 4
-    assert len(data["analyzed_clauses"]) == 4
-    assert data["is_truncated"] is False
+    # Preview shows at most 3 clauses (M4: shared content paywall)
+    assert len(data["analyzed_clauses"]) <= 3
+    assert data["is_truncated"] is True
+    assert data["requires_subscription"] is True
+    assert data["upgrade_cta"] is not None
 
 
 def test_get_shared_analysis_not_found(client: TestClient) -> None:

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -1,4 +1,3 @@
-import base64
 import io
 import uuid
 from unittest.mock import patch
@@ -735,7 +734,7 @@ def _create_test_image(
 def test_upload_avatar(
     client: TestClient, normal_user_token_headers: dict[str, str]
 ) -> None:
-    """Upload a valid PNG avatar and verify the response."""
+    """Upload a valid PNG avatar and verify the response returns a URL."""
     buf = _create_test_image("PNG")
     r = client.put(
         f"{settings.API_V1_STR}/users/me/avatar",
@@ -744,7 +743,8 @@ def test_upload_avatar(
     )
     assert r.status_code == 200
     data = r.json()
-    assert data["avatar_url"].startswith("data:image/webp;base64,")
+    assert data["avatar_url"] is not None
+    assert "/users/avatars/" in data["avatar_url"]
 
 
 def test_upload_avatar_jpeg(
@@ -758,7 +758,7 @@ def test_upload_avatar_jpeg(
         files={"file": ("avatar.jpg", buf, "image/jpeg")},
     )
     assert r.status_code == 200
-    assert r.json()["avatar_url"].startswith("data:image/webp;base64,")
+    assert "/users/avatars/" in r.json()["avatar_url"]
 
 
 def test_upload_avatar_webp(
@@ -772,7 +772,7 @@ def test_upload_avatar_webp(
         files={"file": ("avatar.webp", buf, "image/webp")},
     )
     assert r.status_code == 200
-    assert r.json()["avatar_url"].startswith("data:image/webp;base64,")
+    assert "/users/avatars/" in r.json()["avatar_url"]
 
 
 def test_upload_avatar_invalid_content_type(
@@ -846,10 +846,14 @@ def test_upload_avatar_resizes_large_image(
     )
     assert r.status_code == 200
     avatar_url = r.json()["avatar_url"]
-    # Decode and verify dimensions
-    b64_data = avatar_url.split(",", 1)[1]
-    decoded = base64.b64decode(b64_data)
-    result_img = Image.open(io.BytesIO(decoded))
+    assert "/users/avatars/" in avatar_url
+
+    # Fetch the served file and verify dimensions
+    # Extract path portion from absolute URL for TestClient
+    path = avatar_url.split("/api/v1", 1)[1]
+    file_r = client.get(f"{settings.API_V1_STR}{path}")
+    assert file_r.status_code == 200
+    result_img = Image.open(io.BytesIO(file_r.content))
     assert result_img.width <= 256
     assert result_img.height <= 256
 
@@ -911,6 +915,78 @@ def test_delete_avatar_unauthenticated(client: TestClient) -> None:
     assert r.status_code == 401
 
 
+def test_serve_avatar_not_found(client: TestClient) -> None:
+    """GET /users/avatars/{user_id} returns 404 when no avatar file exists."""
+    r = client.get(f"{settings.API_V1_STR}/users/avatars/{uuid.uuid4()}")
+    assert r.status_code == 404
+    assert r.json()["detail"] == "Avatar not found"
+
+
+def test_serve_avatar_returns_webp(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    """After upload, the serving endpoint returns the WebP file."""
+    buf = _create_test_image("PNG")
+    r = client.put(
+        f"{settings.API_V1_STR}/users/me/avatar",
+        headers=normal_user_token_headers,
+        files={"file": ("avatar.png", buf, "image/png")},
+    )
+    assert r.status_code == 200
+    avatar_url = r.json()["avatar_url"]
+
+    # Derive the path for TestClient
+    path = avatar_url.split("/api/v1", 1)[1]
+    file_r = client.get(f"{settings.API_V1_STR}{path}")
+    assert file_r.status_code == 200
+    assert file_r.headers["content-type"] == "image/webp"
+
+
+def test_upload_avatar_returns_absolute_url(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    """Avatar URL stored in the DB is an absolute URL (protocol + host)."""
+    buf = _create_test_image("PNG")
+    r = client.put(
+        f"{settings.API_V1_STR}/users/me/avatar",
+        headers=normal_user_token_headers,
+        files={"file": ("avatar.png", buf, "image/png")},
+    )
+    assert r.status_code == 200
+    assert r.json()["avatar_url"].startswith("http")
+
+
+def test_delete_user_me_removes_avatar_file(client: TestClient, db: Session) -> None:
+    """Account deletion removes the avatar file from the filesystem (GDPR)."""
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    crud.create_user(session=db, user_create=user_in)
+
+    login_data = {"username": username, "password": password}
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    headers = {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+    # Upload an avatar
+    buf = _create_test_image("PNG")
+    r = client.put(
+        f"{settings.API_V1_STR}/users/me/avatar",
+        headers=headers,
+        files={"file": ("avatar.png", buf, "image/png")},
+    )
+    assert r.status_code == 200
+    avatar_url = r.json()["avatar_url"]
+
+    # Delete the account
+    r = client.delete(f"{settings.API_V1_STR}/users/me", headers=headers)
+    assert r.status_code == 204
+
+    # The avatar file should no longer be served
+    path = avatar_url.split("/api/v1", 1)[1]
+    file_r = client.get(f"{settings.API_V1_STR}{path}")
+    assert file_r.status_code == 404
+
+
 def test_export_includes_avatar_url(
     client: TestClient, normal_user_token_headers: dict[str, str]
 ) -> None:
@@ -928,4 +1004,4 @@ def test_export_includes_avatar_url(
         headers=normal_user_token_headers,
     )
     assert r.status_code == 200
-    assert r.json()["avatar_url"].startswith("data:image/webp;base64,")
+    assert "/users/avatars/" in r.json()["avatar_url"]

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1706,6 +1706,88 @@ export const ContractAnalysisResponseSchema = {
     description: 'Full response for a contract analysis.'
 } as const;
 
+export const ContractSharedPreviewResponseSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        filename: {
+            type: 'string',
+            title: 'Filename'
+        },
+        share_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Share Id'
+        },
+        summary: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Summary'
+        },
+        analyzed_clauses: {
+            items: {
+                '$ref': '#/components/schemas/ClauseExplanation'
+            },
+            type: 'array',
+            title: 'Analyzed Clauses'
+        },
+        overall_risk_assessment: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Overall Risk Assessment'
+        },
+        clause_count: {
+            type: 'integer',
+            title: 'Clause Count'
+        },
+        is_truncated: {
+            type: 'boolean',
+            title: 'Is Truncated'
+        },
+        requires_subscription: {
+            type: 'boolean',
+            title: 'Requires Subscription'
+        },
+        upgrade_cta: {
+            type: 'string',
+            title: 'Upgrade Cta'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'filename', 'share_id', 'summary', 'analyzed_clauses', 'overall_risk_assessment', 'clause_count', 'is_truncated', 'requires_subscription', 'upgrade_cta', 'created_at'],
+    title: 'ContractSharedPreviewResponse',
+    description: `Limited response for unauthenticated shared contract previews.
+
+Exposes at most 3 clauses and the overall risk level to encourage
+sign-up, without giving away the full premium analysis.`
+} as const;
+
 export const CostCategorySchema = {
     type: 'string',
     enum: ['hausgeld', 'grundsteuer', 'insurance', 'heating', 'water', 'electricity', 'maintenance', 'misc'],
@@ -2126,6 +2208,22 @@ export const DocumentDetailResponseSchema = {
                     type: 'null'
                 }
             ]
+        },
+        requires_subscription: {
+            type: 'boolean',
+            title: 'Requires Subscription',
+            default: false
+        },
+        upgrade_cta: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Upgrade Cta'
         }
     },
     type: 'object',

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -980,9 +980,12 @@ export class ContractsService {
     /**
      * Get Shared Analysis
      * Retrieve a shared contract analysis by share_id (no auth required).
+     *
+     * Returns a limited preview with at most 3 clauses and an upgrade CTA.
+     * Full analysis requires an authenticated premium subscription.
      * @param data The data for the request.
      * @param data.shareId
-     * @returns ContractAnalysisResponse Successful Response
+     * @returns ContractSharedPreviewResponse Successful Response
      * @throws ApiError
      */
     public static getSharedAnalysis(data: ContractsGetSharedAnalysisData): CancelablePromise<ContractsGetSharedAnalysisResponse> {
@@ -1152,9 +1155,10 @@ export class DocumentsService {
     
     /**
      * Get Shared Document
-     * Get a shared document by share_id.
+     * Get a shared document by share_id (no authentication required).
      *
-     * No authentication required.
+     * Returns document metadata and the first translated page only.
+     * Full translation requires an authenticated subscription.
      * @param data The data for the request.
      * @param data.shareId
      * @returns DocumentDetailResponse Successful Response

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -502,6 +502,26 @@ export type ContractAnalysisResponse = {
 };
 
 /**
+ * Limited response for unauthenticated shared contract previews.
+ *
+ * Exposes at most 3 clauses and the overall risk level to encourage
+ * sign-up, without giving away the full premium analysis.
+ */
+export type ContractSharedPreviewResponse = {
+    id: string;
+    filename: string;
+    share_id: (string | null);
+    summary: (string | null);
+    analyzed_clauses: Array<ClauseExplanation>;
+    overall_risk_assessment: (string | null);
+    clause_count: number;
+    is_truncated: boolean;
+    requires_subscription: boolean;
+    upgrade_cta: string;
+    created_at: string;
+};
+
+/**
  * Fine-grained Nebenkosten (running cost) categories.
  */
 export type CostCategory = 'hausgeld' | 'grundsteuer' | 'insurance' | 'heating' | 'water' | 'electricity' | 'maintenance' | 'misc';
@@ -631,6 +651,8 @@ export type DocumentDetailResponse = {
     journey_step_id?: (string | null);
     created_at: string;
     translation?: (DocumentTranslationResponse | null);
+    requires_subscription?: boolean;
+    upgrade_cta?: (string | null);
 };
 
 /**
@@ -3050,7 +3072,7 @@ export type ContractsGetSharedAnalysisData = {
     shareId: string;
 };
 
-export type ContractsGetSharedAnalysisResponse = (ContractAnalysisResponse);
+export type ContractsGetSharedAnalysisResponse = (ContractSharedPreviewResponse);
 
 export type ContractsAnalyzeContractData = {
     formData: Body_contracts_analyze_contract;

--- a/infra/terraform/prod.tf
+++ b/infra/terraform/prod.tf
@@ -143,6 +143,11 @@ resource "azurerm_container_app" "prod_backend" {
       }
 
       env {
+        name  = "DOMAIN"
+        value = var.domain
+      }
+
+      env {
         name  = "WEB_CONCURRENCY"
         value = "1"
       }

--- a/infra/terraform/staging.tf
+++ b/infra/terraform/staging.tf
@@ -139,6 +139,11 @@ resource "azurerm_container_app" "staging_backend" {
       }
 
       env {
+        name  = "DOMAIN"
+        value = var.domain
+      }
+
+      env {
         name  = "WEB_CONCURRENCY"
         value = "1"
       }


### PR DESCRIPTION
## Summary

- **M4 (Shared content paywall bypass)**: Unauthenticated visitors to shared contract/document links were seeing full premium AI analysis. Contracts now return `ContractSharedPreviewResponse` (max 3 clauses, no notary checklist, `requires_subscription=True`, `upgrade_cta`). Shared documents are restricted to the first translated page only with clauses/risk warnings cleared.
- **M8 (Avatar DB bloat)**: Base64 avatar blobs (up to 2.7 MB) were stored inline in User rows, degrading all User queries. Avatars are now written to `UPLOAD_DIR/../avatars/{user_id}.webp` and served via an unauthenticated `GET /api/v1/users/avatars/{user_id}` endpoint. Alembic migration clears legacy `data:` values and narrows the column to `String(500)`.

## Test plan

- [ ] `test_share_and_retrieve_analysis` — shared contract returns ≤3 clauses, `is_truncated=True`, `requires_subscription=True`
- [ ] `test_upload_avatar` / `test_upload_avatar_jpeg` / `test_upload_avatar_webp` — URL contains `/users/avatars/`
- [ ] `test_upload_avatar_resizes_large_image` — fetches served file, verifies dimensions ≤ 256
- [ ] `test_serve_avatar_not_found` — 404 when no file on disk
- [ ] `test_serve_avatar_returns_webp` — serving endpoint returns `image/webp`
- [ ] `test_export_includes_avatar_url` — GDPR export returns URL (not base64)