### PR TITLE
fix(professionals): fix seed_reviews idempotency and init_db call

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -3,6 +3,7 @@ from sqlmodel import Session, create_engine, select
 from app import crud
 from app.core.config import settings
 from app.core.seed_professionals import seed_professionals
+from app.core.seed_reviews import seed_reviews
 from app.models import User, UserCreate
 from app.seed_glossary import seed_glossary
 from app.seed_laws import seed_laws
@@ -40,4 +41,5 @@ def init_db(session: Session) -> None:
 
     seed_laws(session)
     seed_professionals(session)
+    seed_reviews(session)
     seed_glossary(session)

--- a/backend/app/core/seed_reviews.py
+++ b/backend/app/core/seed_reviews.py
@@ -247,26 +247,42 @@ def _get_or_create_seed_users(session: Session, count: int) -> list[uuid.UUID]:
 
 
 def seed_reviews(session: Session) -> None:
-    """Seed sample reviews into the database. Idempotent."""
-    existing = session.execute(select(ProfessionalReview).limit(1)).scalars().first()
-    if existing:
-        logger.info("Reviews already seeded, skipping.")
-        return
+    """Seed sample reviews into the database.
 
+    Idempotent per professional: if a professional already has reviews they are
+    left untouched, but professionals with no reviews will have theirs added.
+    This allows the seed data to grow over time without losing existing reviews.
+    """
     # Build name -> professional lookup
     professionals = list(session.execute(select(Professional)).scalars().all())
     name_to_prof: dict[str, Professional] = {p.name: p for p in professionals}
 
-    # Count total reviews needed to create enough seed users
+    # Create enough seed users for the full expected set (idempotent via get-or-create)
     total_reviews = sum(len(r) for r in REVIEWS_BY_PROFESSIONAL.values())
     user_ids = _get_or_create_seed_users(session, total_reviews)
 
     inserted = 0
     user_idx = 0
+    newly_inserted_prof_ids: list[str] = []
     for prof_name, reviews in REVIEWS_BY_PROFESSIONAL.items():
         professional = name_to_prof.get(prof_name)
         if not professional:
             logger.warning("Professional '%s' not found, skipping reviews.", prof_name)
+            user_idx += len(reviews)  # keep user_idx in sync
+            continue
+
+        # Per-professional idempotency: skip if this pro already has reviews
+        already_has_reviews = (
+            session.execute(
+                select(ProfessionalReview)
+                .where(ProfessionalReview.professional_id == professional.id)
+                .limit(1)
+            )
+            .scalars()
+            .first()
+        )
+        if already_has_reviews:
+            user_idx += len(reviews)  # keep user_idx in sync
             continue
 
         for review_data in reviews:
@@ -278,16 +294,19 @@ def seed_reviews(session: Session) -> None:
             session.add(review)
             inserted += 1
             user_idx += 1
+        newly_inserted_prof_ids.append(professional.id)
+
+    if inserted == 0:
+        logger.info("All reviews already seeded, skipping.")
+        return
 
     session.flush()
 
-    # Recompute denormalized fields for each professional that got reviews
+    # Recompute denormalized fields only for professionals that got new reviews
     from app.services.professional_service import recompute_professional_stats
 
-    for prof_name in REVIEWS_BY_PROFESSIONAL:
-        professional = name_to_prof.get(prof_name)
-        if professional:
-            recompute_professional_stats(session, professional.id)
+    for prof_id in newly_inserted_prof_ids:
+        recompute_professional_stats(session, prof_id)
 
     session.commit()
     logger.info("Seeded %d reviews.", inserted)


### PR DESCRIPTION
## Summary

- `seed_reviews` now uses per-professional idempotency: checks each professional individually instead of skipping all reviews when any exist. New professionals added to `REVIEWS_BY_PROFESSIONAL` get their reviews seeded without disrupting existing ones.
- `init_db` now calls `seed_reviews` directly (not only via `seed_professionals`), fixing a bug where reviews were never seeded when professionals already existed in the DB (e.g., from previous test runs).

## Root Cause

`seed_professionals` only called `seed_reviews` when it first inserted professionals. On subsequent `init_db` calls with existing professionals, `seed_professionals` returned early (`if existing_count: return`), so `seed_reviews` was never invoked. This caused `test_seed_reviews_creates_reviews` to fail with `assert 17 >= 23` after the seed data grew from 17 to 23 entries.

## Test Plan

- [x] `pytest tests/core/test_seed_reviews.py` — all 8 tests pass
- [x] Full suite `pytest tests/` — 1359 passed, 0 failed
- [x] `pre-commit run --all-files` — all hooks pass