### PR TITLE
feat(auth): enforce email verification on login

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -221,6 +221,13 @@ async def login(
             detail="User account is inactive",
         )
 
+    # Check if user has verified their email address
+    if not user.email_verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Please verify your email before logging in.",
+        )
+
     # Update password hash if needed (for hash algorithm upgrades)
     if updated_hash:
         user.hashed_password = updated_hash

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -26,7 +26,10 @@ class PasswordRecoveryRequest(BaseModel):
     email: EmailStr
 
 
-@router.post("/login/access-token")
+@router.post(
+    "/login/access-token",
+    responses={403: {"description": "Email not verified"}},
+)
 def login_access_token(
     session: SessionDep,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -67,6 +67,10 @@ def login_access_token(
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     elif not user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")
+    elif not user.email_verified:
+        raise HTTPException(
+            status_code=403, detail="Please verify your email before logging in."
+        )
     rate_limit_service.record_successful_login(form_data.username)
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = security.create_access_token(

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -136,10 +136,20 @@ def test_verify_email_token_consumed_on_use(client: TestClient, db: Session) -> 
 # ── login ─────────────────────────────────────────────────────────────────────
 
 
-def test_login_returns_tokens(client: TestClient) -> None:
+def _make_verified_user(client: TestClient, db: Session) -> str:
+    """Register a user, mark their email as verified in the DB, and return their email."""
     email = random_email()
     client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    user = get_user_by_email(session=db, email=email)
+    assert user is not None
+    user.email_verified = True
+    db.add(user)
+    db.commit()
+    return email
 
+
+def test_login_returns_tokens(client: TestClient, db: Session) -> None:
+    email = _make_verified_user(client, db)
     r = client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
     assert r.status_code == 200
     body = r.json()
@@ -163,6 +173,15 @@ def test_login_unknown_email_returns_401(client: TestClient) -> None:
     assert r.status_code == 401
 
 
+def test_login_unverified_email_returns_403(client: TestClient) -> None:
+    email = random_email()
+    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    # Attempt to log in without verifying email
+    r = client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
+    assert r.status_code == 403
+    assert "verify your email" in r.json()["detail"].lower()
+
+
 def test_login_inactive_user_returns_403(client: TestClient, db: Session) -> None:
     email = random_email()
     client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
@@ -176,10 +195,8 @@ def test_login_inactive_user_returns_403(client: TestClient, db: Session) -> Non
     assert r.status_code == 403
 
 
-def test_login_remember_me_issues_longer_token(client: TestClient) -> None:
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
-
+def test_login_remember_me_issues_longer_token(client: TestClient, db: Session) -> None:
+    email = _make_verified_user(client, db)
     r = client.post(
         f"{AUTH}/login",
         json={"email": email, "password": _VALID_PASSWORD, "remember_me": True},
@@ -188,11 +205,9 @@ def test_login_remember_me_issues_longer_token(client: TestClient) -> None:
     # A longer token is returned — the exact payload is validated in unit tests
 
 
-def test_login_sets_httponly_cookies(client: TestClient) -> None:
+def test_login_sets_httponly_cookies(client: TestClient, db: Session) -> None:
     """Successful login must set access_token and refresh_token as HttpOnly cookies."""
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
-
+    email = _make_verified_user(client, db)
     r = client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
     assert r.status_code == 200
     assert "access_token" in r.cookies
@@ -201,10 +216,9 @@ def test_login_sets_httponly_cookies(client: TestClient) -> None:
     assert r.cookies["logged_in"] == "1"
 
 
-def test_cookie_auth_allows_protected_endpoint(client: TestClient) -> None:
+def test_cookie_auth_allows_protected_endpoint(client: TestClient, db: Session) -> None:
     """access_token cookie must be accepted by the auth dependency (no Bearer header)."""
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    email = _make_verified_user(client, db)
     client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
     # TestClient persists cookies from previous responses automatically
     r = client.post(f"{settings.API_V1_STR}/login/test-token")
@@ -212,10 +226,9 @@ def test_cookie_auth_allows_protected_endpoint(client: TestClient) -> None:
     assert r.json()["email"] == email
 
 
-def test_logout_clears_cookies(client: TestClient) -> None:
+def test_logout_clears_cookies(client: TestClient, db: Session) -> None:
     """logout must delete access_token, refresh_token, and logged_in cookies."""
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    email = _make_verified_user(client, db)
     login_r = client.post(
         f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD}
     )
@@ -229,10 +242,9 @@ def test_logout_clears_cookies(client: TestClient) -> None:
     assert "logged_in" not in client.cookies
 
 
-def test_logout_via_cookie_token(client: TestClient) -> None:
+def test_logout_via_cookie_token(client: TestClient, db: Session) -> None:
     """logout without body must use the refresh_token cookie to blacklist the token."""
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    email = _make_verified_user(client, db)
     login_r = client.post(
         f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD}
     )
@@ -252,15 +264,16 @@ def test_logout_via_cookie_token(client: TestClient) -> None:
 # ── refresh ───────────────────────────────────────────────────────────────────
 
 
-def _register_and_login(client: TestClient) -> dict:
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+def _register_and_login(client: TestClient, db: Session) -> dict:
+    email = _make_verified_user(client, db)
     r = client.post(f"{AUTH}/login", json={"email": email, "password": _VALID_PASSWORD})
     return r.json()
 
 
-def test_refresh_issues_new_access_and_refresh_tokens(client: TestClient) -> None:
-    tokens = _register_and_login(client)
+def test_refresh_issues_new_access_and_refresh_tokens(
+    client: TestClient, db: Session
+) -> None:
+    tokens = _register_and_login(client, db)
     r = client.post(f"{AUTH}/refresh", json={"refresh_token": tokens["refresh_token"]})
     assert r.status_code == 200
     body = r.json()
@@ -276,16 +289,16 @@ def test_refresh_with_invalid_token_returns_401(client: TestClient) -> None:
     assert r.status_code == 401
 
 
-def test_refresh_with_access_token_returns_401(client: TestClient) -> None:
-    tokens = _register_and_login(client)
+def test_refresh_with_access_token_returns_401(client: TestClient, db: Session) -> None:
+    tokens = _register_and_login(client, db)
     # Pass the access token where a refresh token is expected
     r = client.post(f"{AUTH}/refresh", json={"refresh_token": tokens["access_token"]})
     assert r.status_code == 401
 
 
-def test_refresh_via_cookie_token(client: TestClient) -> None:
+def test_refresh_via_cookie_token(client: TestClient, db: Session) -> None:
     """Calling /auth/refresh with no body must use the refresh_token cookie."""
-    _register_and_login(client)
+    _register_and_login(client, db)
     # At this point client.cookies holds the refresh_token cookie from login
     assert client.cookies.get("refresh_token") is not None
 
@@ -300,14 +313,14 @@ def test_refresh_via_cookie_token(client: TestClient) -> None:
 # ── logout ────────────────────────────────────────────────────────────────────
 
 
-def test_logout_returns_204(client: TestClient) -> None:
-    tokens = _register_and_login(client)
+def test_logout_returns_204(client: TestClient, db: Session) -> None:
+    tokens = _register_and_login(client, db)
     r = client.post(f"{AUTH}/logout", json={"refresh_token": tokens["refresh_token"]})
     assert r.status_code == 204
 
 
-def test_logout_blacklists_refresh_token(client: TestClient) -> None:
-    tokens = _register_and_login(client)
+def test_logout_blacklists_refresh_token(client: TestClient, db: Session) -> None:
+    tokens = _register_and_login(client, db)
     client.post(f"{AUTH}/logout", json={"refresh_token": tokens["refresh_token"]})
     # Refresh should now be rejected
     r = client.post(f"{AUTH}/refresh", json={"refresh_token": tokens["refresh_token"]})
@@ -324,9 +337,9 @@ def test_logout_with_invalid_token_still_returns_204(client: TestClient) -> None
 
 
 def test_access_token_rejected_by_current_user_dependency(
-    client: TestClient,
+    client: TestClient, db: Session
 ) -> None:
-    tokens = _register_and_login(client)
+    tokens = _register_and_login(client, db)
     # Attempt to use the refresh token as a bearer token on a protected endpoint
     r = client.post(
         f"{settings.API_V1_STR}/login/test-token",
@@ -502,9 +515,8 @@ def test_forgot_password_rate_limit(client: TestClient) -> None:
     assert "Retry-After" in r.headers
 
 
-def test_rate_limit_cleared_on_success(client: TestClient) -> None:
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+def test_rate_limit_cleared_on_success(client: TestClient, db: Session) -> None:
+    email = _make_verified_user(client, db)
 
     # Build up some failures but not enough to lock
     for _ in range(3):
@@ -538,10 +550,9 @@ def test_ip_rate_limit_blocks_after_max_failures(client: TestClient) -> None:
     assert r.headers["Retry-After"] == str(IP_FAILED_LOCKOUT_SECONDS)
 
 
-def test_ip_rate_limit_not_cleared_on_success(client: TestClient) -> None:
+def test_ip_rate_limit_not_cleared_on_success(client: TestClient, db: Session) -> None:
     """A successful login from an IP does not reset the IP failure counter."""
-    email = random_email()
-    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+    email = _make_verified_user(client, db)
 
     # Accumulate IP_FAILED_MAX - 1 failures — not enough to trigger lockout yet.
     for _ in range(IP_FAILED_MAX - 1):

--- a/backend/tests/api/routes/test_login.py
+++ b/backend/tests/api/routes/test_login.py
@@ -149,7 +149,9 @@ def test_login_with_bcrypt_password_upgrades_to_argon2(
     bcrypt_hash = bcrypt_hasher.hash(password)
     assert bcrypt_hash.startswith("$2")  # bcrypt hashes start with $2
 
-    user = User(email=email, hashed_password=bcrypt_hash, is_active=True)
+    user = User(
+        email=email, hashed_password=bcrypt_hash, is_active=True, email_verified=True
+    )
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -183,7 +185,9 @@ def test_login_with_argon2_password_keeps_hash(client: TestClient, db: Session) 
     assert argon2_hash.startswith("$argon2")
 
     # Create user with argon2 hash
-    user = User(email=email, hashed_password=argon2_hash, is_active=True)
+    user = User(
+        email=email, hashed_password=argon2_hash, is_active=True, email_verified=True
+    )
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/backend/tests/api/routes/test_login.py
+++ b/backend/tests/api/routes/test_login.py
@@ -45,6 +45,24 @@ def test_get_access_token_incorrect_password(client: TestClient) -> None:
     assert r.status_code == 400
 
 
+def test_login_access_token_unverified_email_returns_403(
+    client: TestClient, db: Session
+) -> None:
+    email = random_email()
+    password = random_lower_string()
+    password_hash = get_password_hash(password)
+    user = User(email=email, hashed_password=password_hash, is_active=True)
+    db.add(user)
+    db.commit()
+
+    r = client.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        data={"username": email, "password": password},
+    )
+    assert r.status_code == 403
+    assert "verify your email" in r.json()["detail"].lower()
+
+
 def test_use_access_token(
     client: TestClient, superuser_token_headers: dict[str, str]
 ) -> None:

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -2030,6 +2030,7 @@ export class LoginService {
             formData: data.formData,
             mediaType: 'application/x-www-form-urlencoded',
             errors: {
+                403: 'Email not verified',
                 422: 'Validation Error'
             }
         });

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -88,10 +88,10 @@ function Login() {
     },
     onSuccess: () => {
       if (redirectTo) {
-        window.location.href = redirectTo
+        globalThis.location.href = redirectTo
         return
       }
-      void navigate({ to: "/dashboard" })
+      navigate({ to: "/dashboard" })
     },
     onError: (err: Error) => {
       const apiErr = err as ApiError

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -1,13 +1,20 @@
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "@tanstack/react-query"
 import {
   createFileRoute,
   Link as RouterLink,
   redirect,
+  useNavigate,
 } from "@tanstack/react-router"
+import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
-import type { Body_login_login_access_token as AccessToken } from "@/client"
+import type {
+  Body_login_login_access_token as AccessToken,
+  ApiError,
+} from "@/client"
+import { AuthService, LoginService } from "@/client"
 import { seoMeta } from "@/common/seo"
 import { AuthLayout } from "@/components/Common/AuthLayout"
 import {
@@ -21,7 +28,10 @@ import {
 import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { PasswordInput } from "@/components/ui/password-input"
-import useAuth, { isLoggedIn } from "@/hooks/useAuth"
+import { isLoggedIn } from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import { queryClient } from "@/query/client"
+import { handleError } from "@/utils"
 
 const formSchema = z.object({
   username: z
@@ -58,7 +68,9 @@ export const Route = createFileRoute("/login")({
 
 function Login() {
   const { redirect: redirectTo } = Route.useSearch()
-  const { loginMutation } = useAuth(redirectTo)
+  const navigate = useNavigate()
+  const { showErrorToast, showSuccessToast } = useCustomToast()
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null)
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     mode: "onBlur",
@@ -69,8 +81,40 @@ function Login() {
     },
   })
 
+  const loginMutation = useMutation({
+    mutationFn: async (data: AccessToken) => {
+      await LoginService.loginAccessToken({ formData: data })
+      queryClient.clear()
+    },
+    onSuccess: () => {
+      if (redirectTo) {
+        window.location.href = redirectTo
+        return
+      }
+      void navigate({ to: "/dashboard" })
+    },
+    onError: (err: Error) => {
+      const apiErr = err as ApiError
+      if (apiErr.status === 403) {
+        setUnverifiedEmail(form.getValues("username"))
+      } else {
+        handleError.call(showErrorToast, err)
+      }
+    },
+  })
+
+  const resendMutation = useMutation({
+    mutationFn: (email: string) =>
+      AuthService.resendVerification({ requestBody: { email } }),
+    onSuccess: () =>
+      showSuccessToast("Verification email sent. Check your inbox."),
+    onError: () =>
+      showErrorToast("Failed to send verification email. Please try again."),
+  })
+
   const onSubmit = (data: FormData) => {
     if (loginMutation.isPending) return
+    setUnverifiedEmail(null)
     loginMutation.mutate(data)
   }
 
@@ -144,6 +188,29 @@ function Login() {
               Sign In
             </LoadingButton>
           </div>
+
+          {unverifiedEmail !== null && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+              <p className="font-medium text-amber-800">
+                Please verify your email address
+              </p>
+              <p className="mt-1 text-amber-700">
+                We sent a verification link to{" "}
+                <span className="font-medium">{unverifiedEmail}</span>. Check
+                your inbox and click the link to activate your account.
+              </p>
+              <LoadingButton
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3 border-amber-300 bg-white text-amber-800 hover:bg-amber-50"
+                loading={resendMutation.isPending}
+                onClick={() => resendMutation.mutate(unverifiedEmail)}
+              >
+                Resend verification email
+              </LoadingButton>
+            </div>
+          )}
 
           <div className="text-center text-sm text-muted-foreground">
             New to HeimPath?

--- a/frontend/tests/reset-password.spec.ts
+++ b/frontend/tests/reset-password.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "@playwright/test"
 import { findLastEmail } from "./utils/mailcatcher"
+import { createUser } from "./utils/privateApi"
 import { randomEmail, randomPassword } from "./utils/random"
-import { logInUser, signUpNewUser } from "./utils/user"
+import { logInUser } from "./utils/user"
 
 test.use({ storageState: { cookies: [], origins: [] } })
 
@@ -33,13 +34,12 @@ test("User can reset password successfully using the link", async ({
   page,
   request,
 }) => {
-  const fullName = "Test User"
   const email = randomEmail()
   const password = randomPassword()
   const newPassword = randomPassword()
 
-  // Sign up a new user
-  await signUpNewUser(page, fullName, email, password)
+  // Create a verified user via admin API so the login step after reset succeeds
+  await createUser({ email, password })
 
   await page.goto("/recover-password")
   await page.getByTestId("email-input").fill(email)
@@ -93,13 +93,12 @@ test("Expired or invalid reset link", async ({ page }) => {
 })
 
 test("Weak new password validation", async ({ page, request }) => {
-  const fullName = "Test User"
   const email = randomEmail()
   const password = randomPassword()
   const weakPassword = "123"
 
-  // Sign up a new user
-  await signUpNewUser(page, fullName, email, password)
+  // Create a verified user via admin API
+  await createUser({ email, password })
 
   await page.goto("/recover-password")
   await page.getByTestId("email-input").fill(email)


### PR DESCRIPTION
## Summary
- Unverified users are now blocked at login (403) on both `/auth/login` and legacy `/login/access-token`
- Login page replaces generic error toast with an amber inline banner containing a "Resend verification email" button
- All existing tests updated to pre-verify users; new test added for the 403 unverified case

## Test plan
- [ ] `pytest tests/api/routes/test_auth.py` — all 41 tests pass, including new `test_login_unverified_email_returns_403`
- [ ] `pytest tests/api/routes/test_login.py` — all tests pass
- [ ] `bunx tsc --noEmit` — 0 TypeScript errors
- [ ] Manual: register new account, attempt login without verifying → see amber banner with resend button
- [ ] Manual: verify email, attempt login → succeeds