### PR TITLE
fix(sonarcloud): resolve S3735, S3516 and S3776 findings

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -48,6 +48,7 @@ from app.services.password_reset_service import (
 from app.services.password_reset_service import (
     generate_token as generate_reset_token,
 )
+from app.services.rate_limit_service import RateLimitInfo
 from app.utils import (
     generate_email_verification_email,
     generate_reset_password_email,
@@ -144,6 +145,14 @@ async def register(
     return user
 
 
+def _record_failed_login(email: str, client_ip: str | None) -> RateLimitInfo:
+    """Record a failed login attempt and optional IP failure for rate limiting."""
+    rate_info = rate_limit_service.record_failed_attempt(email)
+    if client_ip:
+        rate_limit_service.record_ip_failed(client_ip)
+    return rate_info
+
+
 @router.post("/login", response_model=AuthToken)
 async def login(
     request: LoginRequest,
@@ -193,9 +202,7 @@ async def login(
     if not user:
         # Still run password verification to prevent timing attacks
         verify_password(request.password, DUMMY_HASH)
-        rate_limit_service.record_failed_attempt(request.email)
-        if client_ip:
-            rate_limit_service.record_ip_failed(client_ip)
+        _record_failed_login(request.email, client_ip)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect email or password",
@@ -203,9 +210,7 @@ async def login(
 
     verified, updated_hash = verify_password(request.password, user.hashed_password)
     if not verified:
-        rate_info = rate_limit_service.record_failed_attempt(request.email)
-        if client_ip:
-            rate_limit_service.record_ip_failed(client_ip)
+        rate_info = _record_failed_login(request.email, client_ip)
         detail = "Incorrect email or password"
         if rate_info.is_locked:
             detail = "Too many failed login attempts. Account locked for 15 minutes."

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -350,9 +350,7 @@ async def read_user_by_id(
     user = session.get(User, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    if user == current_user:
-        return user
-    if not current_user.is_superuser:
+    if user != current_user and not current_user.is_superuser:
         raise HTTPException(
             status_code=403,
             detail="The user doesn't have enough privileges",

--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -366,14 +366,14 @@ function CalculatorsPage() {
   const navigate = useNavigate()
 
   const handleSelect = (value: string) => {
-    void navigate({
+    navigate({
       to: "/calculators",
       search: (prev) => ({ ...prev, tab: value }),
     })
   }
 
   const handleBack = () => {
-    void navigate({
+    navigate({
       to: "/calculators",
       search: (prev) => ({ ...prev, tab: undefined }),
     })


### PR DESCRIPTION
## Summary

- Remove `void` operator from `navigate()` calls in `calculators.tsx` (closes #244 — S3735 CRITICAL)
- Consolidate duplicate `return user` in `read_user_by_id` to a single return path (closes #246 — S3516 BLOCKER)
- Extract `_record_failed_login` private helper in `auth.py` to reduce cognitive complexity from 17 to 14 (closes #245 — S3776 CRITICAL)

## Test plan

- [x] All 108 backend tests pass (`test_auth`, `test_login`, `test_users`)
- [x] Pre-commit hooks pass (ruff, biome)
- [x] No logic changes — behaviour is identical in all three files