### PR TITLE
fix(auth): fix register 504 timeout and login cookie deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -54,7 +54,13 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
+            BACKEND_FQDN=$(az containerapp show \
+              --name heimpath-backend-prod \
+              --resource-group rg-heimpath-prod \
+              --query "properties.configuration.ingress.fqdn" \
+              --output tsv)
             az containerapp update \
               --name heimpath-frontend-prod \
               --resource-group rg-heimpath-prod \
-              --image ${{ steps.meta.outputs.prefix }}/frontend:${{ inputs.image_tag }}
+              --image ${{ steps.meta.outputs.prefix }}/frontend:${{ inputs.image_tag }} \
+              --set-env-vars "BACKEND_HOST=https://${BACKEND_FQDN}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,6 +59,7 @@ jobs:
               --resource-group rg-heimpath-prod \
               --query "properties.configuration.ingress.fqdn" \
               --output tsv)
+            [ -z "$BACKEND_FQDN" ] && echo "ERROR: could not resolve backend FQDN" >&2 && exit 1
             az containerapp update \
               --name heimpath-frontend-prod \
               --resource-group rg-heimpath-prod \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -88,6 +88,7 @@ jobs:
               --resource-group rg-heimpath-staging \
               --query "properties.configuration.ingress.fqdn" \
               --output tsv)
+            [ -z "$BACKEND_FQDN" ] && echo "ERROR: could not resolve backend FQDN" >&2 && exit 1
             az containerapp update \
               --name heimpath-frontend-staging \
               --resource-group rg-heimpath-staging \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -83,7 +83,13 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
+            BACKEND_FQDN=$(az containerapp show \
+              --name heimpath-backend-staging \
+              --resource-group rg-heimpath-staging \
+              --query "properties.configuration.ingress.fqdn" \
+              --output tsv)
             az containerapp update \
               --name heimpath-frontend-staging \
               --resource-group rg-heimpath-staging \
-              --image ${{ steps.meta.outputs.prefix }}/frontend:${{ steps.meta.outputs.tag }}
+              --image ${{ steps.meta.outputs.prefix }}/frontend:${{ steps.meta.outputs.tag }} \
+              --set-env-vars "BACKEND_HOST=https://${BACKEND_FQDN}"

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -6,6 +6,7 @@ Provides registration and login endpoints with:
 - JWT access and refresh tokens
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -134,7 +135,8 @@ async def register(
                 token=token_data.token,
                 valid_hours=EMAIL_VERIFICATION_TOKEN_EXPIRY_HOURS,
             )
-            send_email(
+            await asyncio.to_thread(
+                send_email,
                 email_to=user.email,
                 subject=email_data.subject,
                 html_content=email_data.html_content,
@@ -503,7 +505,8 @@ async def resend_verification(
                 token=token_data.token,
                 valid_hours=EMAIL_VERIFICATION_TOKEN_EXPIRY_HOURS,
             )
-            send_email(
+            await asyncio.to_thread(
+                send_email,
                 email_to=user.email,
                 subject=email_data.subject,
                 html_content=email_data.html_content,
@@ -562,7 +565,8 @@ async def forgot_password(
                 email=user.email,
                 token=token_data.token,
             )
-            send_email(
+            await asyncio.to_thread(
+                send_email,
                 email_to=user.email,
                 subject=email_data.subject,
                 html_content=email_data.html_content,

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -102,6 +102,7 @@ def _send_email_smtp(
     smtp_options: dict[str, Any] = {
         "host": settings.SMTP_HOST,
         "port": settings.SMTP_PORT,
+        "timeout": 10,
     }
     if settings.SMTP_TLS:
         smtp_options["tls"] = True


### PR DESCRIPTION
## Summary

- **Register 504**: `_send_email_smtp()` had no socket timeout — if the SMTP host was unreachable, it blocked forever until the Azure load balancer killed the connection (504). Fixed by adding `"timeout": 10` to SMTP options. Also wrapped all three async auth endpoints (`register`, `resend-verification`, `forgot-password`) with `asyncio.to_thread()` to prevent blocking the event loop during email I/O.

- **Login 200 no redirect**: PR #248 added the nginx proxy + `BACKEND_HOST` requirement but the CI deploy only ran `az containerapp update --image` without setting `BACKEND_HOST`. The new nginx container exited immediately with "BACKEND_HOST is required", so the old revision (cross-origin cookies) kept running. Fixed by querying the backend container app FQDN in both `deploy-staging.yml` and `deploy-production.yml` and passing it via `--set-env-vars`, making the deploy self-sufficient regardless of Terraform state.

## Test plan

- [x] `pytest tests/api/routes/test_auth.py` — 41 passed
- [x] `pre-commit run` — all checks pass
- [ ] After merge: trigger staging deploy; verify login redirects to dashboard and registration completes without 504