### PR TITLE
fix(infra): set staging backend min replicas to 1 to prevent cold-start 504s

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -77,7 +77,8 @@ jobs:
               --name heimpath-backend-staging \
               --resource-group rg-heimpath-staging \
               --image ${{ steps.meta.outputs.prefix }}/backend:${{ steps.meta.outputs.tag }} \
-              --set-env-vars "TRUSTED_PROXY_IPS=*"
+              --set-env-vars "TRUSTED_PROXY_IPS=*" \
+              --min-replicas 1
 
       - name: Deploy frontend
         uses: azure/cli@v2

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -130,7 +130,7 @@ variable "staging_frontend_url" {
 variable "staging_backend_min_replicas" {
   description = "Staging minimum backend replicas"
   type        = number
-  default     = 0
+  default     = 1
 }
 
 variable "staging_backend_max_replicas" {


### PR DESCRIPTION
## Summary

- With `min_replicas=0` the backend scales to zero when idle. The cold start on the first incoming request takes long enough to exceed the nginx proxy timeout, returning a 504 — symptoms are \"pending then 504\" when logging in.
- Changes `staging_backend_min_replicas` default from 0 → 1 in `variables.tf`.
- Adds `--min-replicas 1` to the staging deploy workflow so every CI deploy enforces the setting without requiring a separate Terraform apply.

## Hotfix Already Applied

`az containerapp update --min-replicas 1` was run manually — staging backend revision `--0000215` now has 1 replica running and login should work immediately.

## Test plan

- [ ] `pre-commit` passes
- [ ] CI checks pass
- [ ] Login on staging works without 504