### PR TITLE
fix(auth): mark superuser and test users as email-verified on seed

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -36,6 +36,7 @@ def init_db(session: Session) -> None:
         )
         user = crud.create_user(session=session, user_create=user_in)
         user.onboarding_completed = True
+        user.email_verified = True
         session.add(user)
         session.commit()
 

--- a/backend/tests/utils/user.py
+++ b/backend/tests/utils/user.py
@@ -24,6 +24,10 @@ def create_random_user(db: Session) -> User:
     password = random_lower_string()
     user_in = UserCreate(email=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
+    user.email_verified = True
+    db.add(user)
+    db.commit()
+    db.refresh(user)
     return user
 
 
@@ -34,6 +38,8 @@ def authentication_token_from_email(
     Return a valid token for the user with given email.
 
     If the user doesn't exist it is created first.
+    Email is pre-verified so the test user can log in without going through
+    the email verification flow.
     """
     password = random_lower_string()
     user = crud.get_user_by_email(session=db, email=email)
@@ -45,5 +51,9 @@ def authentication_token_from_email(
         if not user.id:
             raise Exception("User id not set")
         user = crud.update_user(session=db, db_user=user, user_in=user_in_update)
+
+    user.email_verified = True
+    db.add(user)
+    db.commit()
 
     return user_authentication_headers(client=client, email=email, password=password)


### PR DESCRIPTION
## Summary

- `init_db` was seeding `FIRST_SUPERUSER` with `email_verified=False` (the model default). Login enforces email verification, so the admin account was blocked on every fresh deployment — causing 403 for all users on staging.
- Test helper `authentication_token_from_email` / `create_random_user` had the same issue: test users couldn't authenticate, breaking any test that relies on `normal_user_token_headers`.

## Changes

- `backend/app/core/db.py`: Set `email_verified = True` when seeding the bootstrapped superuser in `init_db`
- `backend/tests/utils/user.py`: Set `email_verified = True` in `create_random_user` and `authentication_token_from_email` so test users can log in without completing the email-verification flow

## Root cause

The `email_verified` column was added with `server_default=false`. The `init_db` seeder and test helpers never set it to `True`, so any fresh deploy or test run left all system-created accounts unable to log in.

## Test plan

- [ ] `pytest tests/` passes locally and in CircleCI
- [ ] Staging login works end-to-end after deploy