### PR TITLE
fix(frontend): use proxy_host header so nginx proxy reaches backend

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -13,7 +13,8 @@ server {
     proxy_pass ${BACKEND_HOST}/api/;
     proxy_http_version 1.1;
     proxy_set_header Connection "";
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary

- nginx was sending `Host: staging.heimpath.com` to the upstream backend at `https://api.staging.heimpath.com`
- Azure Container Apps ingress routes requests by the `Host` header — it could not find a matching Container App for `staging.heimpath.com` on that ingress endpoint, so the connection hung indefinitely → users saw 504
- Fix: use `Host: $proxy_host` (the upstream's own hostname) so Azure Container Apps ingress routes correctly
- Add `X-Forwarded-Host: $http_host` so the backend still knows the original frontend hostname

## Root cause

This bug was introduced in PR #248 when the nginx proxy was added. It has silently broken all `/api/` proxying since that deploy. All staging 504 errors on login trace back to this.

## Test plan

- [ ] Login works end-to-end through `staging.heimpath.com` after deploy
- [ ] API calls (calculators, journey, etc.) work through the proxy