### PR TITLE
chore(frontend): hide auth image panel on mobile screens

### DIFF
--- a/frontend/src/components/Common/AuthLayout.tsx
+++ b/frontend/src/components/Common/AuthLayout.tsx
@@ -71,7 +71,7 @@ function AuthLayout(props: IProps) {
   return (
     <div className="grid min-h-svh md:grid-cols-2">
       <div
-        className="relative flex max-h-[50vh] flex-col justify-center overflow-hidden p-6 md:max-h-none md:p-12 bg-cover bg-center"
+        className="relative hidden flex-col justify-center overflow-hidden p-6 md:flex md:p-12 bg-cover bg-center"
         style={{ backgroundImage: "url('/images/auth-bg.jpg')" }}
       >
         <div className="absolute inset-0 bg-black/55" />


### PR DESCRIPTION
## Summary
- Hide the branding/image sidebar on sign-in and register pages on mobile screens
- Panel is `hidden` by default; renders as `flex` only at `md` breakpoint (768px+)
- On mobile, the form takes the full screen width

## Test plan
- [ ] Open `/login` on mobile viewport — image panel not visible, form fills screen
- [ ] Open `/signup` on mobile viewport — image panel not visible, form fills screen
- [ ] On desktop (≥768px) — image panel visible on the left as before