### PR TITLE
feat(frontend): add disclaimer component with rose styling

### DIFF
--- a/frontend/src/components/Calculators/AfaCalculator.tsx
+++ b/frontend/src/components/Calculators/AfaCalculator.tsx
@@ -4,7 +4,7 @@
  * Covers all three AfA rate tiers: pre-1925 (2.5%), 1925-2022 (2.0%), 2023+ (3.0%).
  */
 
-import { Info, RefreshCw, TrendingDown } from "lucide-react"
+import { RefreshCw, TrendingDown } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import {
   Bar,
@@ -25,6 +25,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Disclaimer } from "@/components/ui/disclaimer"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { FormRow } from "./common/FormRow"
@@ -708,19 +709,15 @@ function AfaCalculator({ className }: Readonly<IProps>) {
               </div>
             </div>
 
-            <div className="flex items-start gap-2 rounded-lg bg-muted p-3">
-              <Info className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
-              <p className="text-xs text-muted-foreground">
-                Estimates only. The land/building split must be confirmed by
-                your Finanzamt via a Kaufpreisaufteilung. Foreign owners must
-                file a German Einkommensteuererklärung (income tax return) to
-                claim Werbungskosten deductions. Renovation costs before first
-                letting may also be depreciable. Consult a{" "}
-                <em>Steuerberater</em> for your exact position. The 3% AfA rate
-                applies to buildings completed on or after 1 January 2023
-                (Jahressteuergesetz 2022).
-              </p>
-            </div>
+            <Disclaimer>
+              Estimates only. The land/building split must be confirmed by your
+              Finanzamt via a Kaufpreisaufteilung. Foreign owners must file a
+              German Einkommensteuererklärung (income tax return) to claim
+              Werbungskosten deductions. Renovation costs before first letting
+              may also be depreciable. Consult a <em>Steuerberater</em> for your
+              exact position. The 3% AfA rate applies to buildings completed on
+              or after 1 January 2023 (Jahressteuergesetz 2022).
+            </Disclaimer>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/components/Calculators/GrundsteuerCalculator.tsx
+++ b/frontend/src/components/Calculators/GrundsteuerCalculator.tsx
@@ -5,7 +5,7 @@
  * Baden-Württemberg (Bodenwertmodell).
  */
 
-import { Home, Info, RefreshCw } from "lucide-react"
+import { Home, RefreshCw } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import {
   Bar,
@@ -27,6 +27,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Disclaimer } from "@/components/ui/disclaimer"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -953,18 +954,15 @@ function GrundsteuerCalculator({ className }: Readonly<IProps>) {
             </div>
 
             {/* Disclaimer */}
-            <div className="flex items-start gap-2 rounded-lg bg-muted p-3">
-              <Info className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
-              <p className="text-xs text-muted-foreground">
-                Estimates only. Actual Grundsteuer is determined by the official
-                Grundsteuerwertbescheid from your Finanzamt and the
-                Grundsteuerbescheid from your municipality. Hebesätze may change
-                annually. The Bavaria and Baden-Württemberg models use
-                simplified inputs — consult a <em>Steuerberater</em> for your
-                exact liability. For Bavaria: the Äquivalenzbetrag caps area at
-                100 sqm (building) and 500 sqm (land) for the full rate.
-              </p>
-            </div>
+            <Disclaimer>
+              Estimates only. Actual Grundsteuer is determined by the official
+              Grundsteuerwertbescheid from your Finanzamt and the
+              Grundsteuerbescheid from your municipality. Hebesätze may change
+              annually. The Bavaria and Baden-Württemberg models use simplified
+              inputs — consult a <em>Steuerberater</em> for your exact
+              liability. For Bavaria: the Äquivalenzbetrag caps area at 100 sqm
+              (building) and 500 sqm (land) for the full rate.
+            </Disclaimer>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/components/Calculators/RentCeilingCalculator.tsx
+++ b/frontend/src/components/Calculators/RentCeilingCalculator.tsx
@@ -20,6 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Disclaimer } from "@/components/ui/disclaimer"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -311,14 +312,10 @@ function RentCeilingCalculator(props: Readonly<IProps>) {
               />
             )}
 
-            <div className="space-y-1 border-t pt-3">
-              <p className="text-xs text-muted-foreground">
-                Source: {result.dataSource}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {result.disclaimer}
-              </p>
-            </div>
+            <Disclaimer className="mt-3">
+              <p>Source: {result.dataSource}</p>
+              <p className="mt-1">{result.disclaimer}</p>
+            </Disclaimer>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/components/Calculators/SpeculationTaxCalculator.tsx
+++ b/frontend/src/components/Calculators/SpeculationTaxCalculator.tsx
@@ -3,7 +3,7 @@
  * Calculates German capital-gains tax liability on property sales within 10 years
  */
 
-import { AlertTriangle, Euro, Info, RefreshCw, Scale } from "lucide-react"
+import { AlertTriangle, Euro, RefreshCw, Scale } from "lucide-react"
 import { useMemo, useState } from "react"
 import {
   Bar,
@@ -25,6 +25,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Disclaimer } from "@/components/ui/disclaimer"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
@@ -860,17 +861,14 @@ function SpeculationTaxCalculator({ className }: Readonly<IProps>) {
             </div>
 
             {/* Legal Disclaimer */}
-            <div className="flex items-start gap-2 rounded-lg bg-muted p-3">
-              <Info className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
-              <p className="text-xs text-muted-foreground">
-                This calculator provides estimates only and does not constitute
-                tax advice. The § 23 EStG speculation tax is assessed at your
-                personal marginal income tax rate. Consult a qualified{" "}
-                <em>Steuerberater</em> for your specific situation. Church tax
-                (Kirchensteuer) and solidarity surcharge (Solidaritätszuschlag)
-                are not included.
-              </p>
-            </div>
+            <Disclaimer>
+              This calculator provides estimates only and does not constitute
+              tax advice. The § 23 EStG speculation tax is assessed at your
+              personal marginal income tax rate. Consult a qualified{" "}
+              <em>Steuerberater</em> for your specific situation. Church tax
+              (Kirchensteuer) and solidarity surcharge (Solidaritätszuschlag)
+              are not included.
+            </Disclaimer>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/components/ui/disclaimer.tsx
+++ b/frontend/src/components/ui/disclaimer.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+interface IProps {
+  children: React.ReactNode
+  className?: string
+}
+
+function Disclaimer({ children, className }: Readonly<IProps>) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-xs text-rose-800 dark:border-rose-800/40 dark:bg-rose-950/20 dark:text-rose-300",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+export { Disclaimer }


### PR DESCRIPTION
## Summary
- Add `Disclaimer` component (`frontend/src/components/ui/disclaimer.tsx`) with light rose/burgundy background so legal caveats are visually distinct
- Replace the `bg-muted` Info-icon disclaimer boxes in SpeculationTaxCalculator, GrundsteuerCalculator, AfaCalculator, and RentCeilingCalculator with the new component
- Remove now-unused `Info` lucide imports from the three calculator files

## Test plan
- [ ] SpeculationTaxCalculator: disclaimer renders with rose background after computing a result
- [ ] GrundsteuerCalculator: same
- [ ] AfaCalculator: same
- [ ] RentCeilingCalculator: source + disclaimer text appears in rose box below result
- [ ] Dark mode: rose box uses reduced-opacity tones (dark:bg-rose-950/20)
- [ ] `bunx tsc --noEmit` — 0 errors