### PR TITLE
chore(frontend): show logo on mobile auth pages linking to landing

### DIFF
--- a/frontend/src/components/Common/AuthLayout.tsx
+++ b/frontend/src/components/Common/AuthLayout.tsx
@@ -97,8 +97,13 @@ function AuthLayout(props: IProps) {
       </div>
 
       <div className="flex flex-col gap-4 p-6 md:p-10">
-        <div className="flex items-center justify-end">
-          <Appearance />
+        <div className="flex items-center justify-between">
+          <div className="md:hidden">
+            <Logo variant="full" />
+          </div>
+          <div className="ml-auto">
+            <Appearance />
+          </div>
         </div>
         <div className="flex flex-1 items-center justify-center">
           <div className="w-full max-w-sm">{children}</div>


### PR DESCRIPTION
## Summary
- On mobile (< md breakpoint), the image sidebar is hidden — there was no logo or way to navigate back to the landing page
- Add the HeimPath logo to the top of the form panel, visible only on mobile (`md:hidden`)
- Logo uses the existing `<Logo variant="full" />` which already links to `/` (landing page)
- On desktop the logo remains in the image sidebar as before; the mobile-only logo is hidden

## Test plan
- [ ] Mobile viewport (< 768px): HeimPath logo visible at top-left of login page, clicking it navigates to `/`
- [ ] Mobile viewport: same on register page
- [ ] Desktop (≥ 768px): mobile logo not visible; image sidebar logo still present
- [ ] `bunx tsc --noEmit` — 0 errors