### PR TITLE
chore(frontend): add my properties section heading to portfolio page

### DIFF
--- a/frontend/src/components/Portfolio/PortfolioPage.tsx
+++ b/frontend/src/components/Portfolio/PortfolioPage.tsx
@@ -82,6 +82,17 @@ function PortfolioPage() {
         <PerformanceChart performance={performance} />
       )}
 
+      {/* Section heading */}
+      {!isLoadingProperties && (
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">My Properties</h2>
+          <span className="text-sm text-muted-foreground">
+            {propertiesData?.data?.length ?? 0}{" "}
+            {propertiesData?.data?.length === 1 ? "property" : "properties"}
+          </span>
+        </div>
+      )}
+
       {/* Property Grid */}
       {isLoadingProperties && (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- Add "My Properties" section heading with property count above the property grid on the Portfolio page
- Heading appears after data loads (hidden during skeleton state)
- Count is pluralised correctly ("1 property" vs "2 properties")
- Heading is visible even when portfolio is empty (shows "0 properties" above the empty state)

## Test plan
- [ ] Portfolio with 0 properties: heading "My Properties" + "0 properties" visible above empty state
- [ ] Portfolio with 1 property: heading + "1 property"
- [ ] Portfolio with 3+ properties: heading + "3 properties"
- [ ] Heading not visible while skeleton loading
- [ ] `bunx tsc --noEmit` — 0 errors