### PR TITLE
feat(frontend): add supported document type cards to documents page

### DIFF
--- a/frontend/src/routes/_layout/documents/index.tsx
+++ b/frontend/src/routes/_layout/documents/index.tsx
@@ -7,6 +7,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { FileText } from "lucide-react"
 
 import { DocumentList, DocumentUploadForm } from "@/components/Documents"
+import { Card, CardContent } from "@/components/ui/card"
 
 /******************************************************************************
                               Route
@@ -20,8 +21,63 @@ export const Route = createFileRoute("/_layout/documents/")({
 })
 
 /******************************************************************************
+                              Constants
+******************************************************************************/
+
+const DOCUMENT_TYPE_META = [
+  {
+    title: "Purchase Contract (Kaufvertrag)",
+    description:
+      "Full translation + clause-by-clause analysis. We flag unusual terms, seller obligations, and financial risks.",
+  },
+  {
+    title: "Land Registry Extract (Grundbuch)",
+    description:
+      "Translation of ownership record, liens, easements, and encumbrances — critical before any purchase.",
+  },
+  {
+    title: "Condominium Declaration (Teilungserklärung)",
+    description:
+      "Explains your ownership share, shared costs, and usage rights in a multi-unit building.",
+  },
+  {
+    title: "Rental Agreement (Mietvertrag)",
+    description:
+      "Full translation highlighting rent terms, notice periods, deposit rules, and tenant obligations.",
+  },
+  {
+    title: "Owners' Meeting Minutes (WEG-Protokoll)",
+    description:
+      "Summary of decisions affecting shared costs, planned works, and community rules.",
+  },
+] as const
+
+/******************************************************************************
                               Components
 ******************************************************************************/
+
+/** Responsive grid showing what document types HeimPath can analyse. */
+function SupportedDocumentTypes() {
+  return (
+    <div>
+      <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+        What you can upload
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {DOCUMENT_TYPE_META.map((type) => (
+          <Card key={type.title} className="bg-muted/40">
+            <CardContent className="p-4 space-y-1">
+              <p className="text-sm font-medium leading-snug">{type.title}</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                {type.description}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 /** Default component. Documents listing page with upload. */
 function DocumentsPage() {
@@ -40,6 +96,9 @@ function DocumentsPage() {
 
       {/* Upload zone */}
       <DocumentUploadForm />
+
+      {/* Supported document types */}
+      <SupportedDocumentTypes />
 
       {/* Document list */}
       <div>


### PR DESCRIPTION
## Summary
- Add a "What you can upload" section between the upload zone and document list
- Shows 5 supported document types (Kaufvertrag, Grundbuch, Teilungserklärung, Mietvertrag, WEG-Protokoll) each with English title and 1-sentence description of what HeimPath analyses
- Responsive grid: 1 col mobile → 2 col sm → 3 col lg → 5 col xl
- Cards use muted background to distinguish from document list cards

## Test plan
- [ ] Documents page shows 5 type cards below the upload zone
- [ ] Each card shows German term in brackets after English title
- [ ] Cards responsive at 375px (1 column), 640px (2 columns), 1024px (3 columns)
- [ ] `bunx tsc --noEmit` — 0 errors