### PR TITLE
feat(dashboard): show day-of-journey indicator in ring chart

### DIFF
--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -32,6 +32,7 @@ class JourneyOverview(BaseModel):
     completed_steps: int
     total_steps: int
     estimated_days_remaining: int | None = None
+    total_estimated_days: int | None = None
     started_at: datetime | None = None
     next_step_title: str | None = None
     next_step_id: uuid.UUID | None = None

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -86,6 +86,7 @@ def get_journey_overview(
         completed_steps=progress["completed_steps"],
         total_steps=progress["total_steps"],
         estimated_days_remaining=progress["estimated_days_remaining"],
+        total_estimated_days=progress["total_estimated_days"],
         started_at=journey.started_at,
         next_step_title=next_step.title if next_step else None,
         next_step_id=next_step.id if next_step else None,

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -1802,11 +1802,14 @@ def get_progress(
             ),
         }
 
-    # Estimate remaining days
+    # Estimate remaining days (only uncompleted/unskipped steps)
     remaining_steps = [
         s for s in steps if s.status not in (StepStatus.COMPLETED, StepStatus.SKIPPED)
     ]
     estimated_days = sum(s.estimated_duration_days or 0 for s in remaining_steps)
+
+    # Total estimated duration across all steps (fixed target for progress gauge)
+    total_estimated_days = sum(s.estimated_duration_days or 0 for s in steps)
 
     return {
         "journey_id": journey.id,
@@ -1818,5 +1821,8 @@ def get_progress(
         if total_steps > 0
         else 0,
         "estimated_days_remaining": estimated_days if estimated_days > 0 else None,
+        "total_estimated_days": total_estimated_days
+        if total_estimated_days > 0
+        else None,
         "phases": phases,
     }

--- a/backend/tests/services/test_dashboard_service.py
+++ b/backend/tests/services/test_dashboard_service.py
@@ -71,6 +71,7 @@ class TestGetDashboardOverview:
             completed_steps=0,
             total_steps=10,
             estimated_days_remaining=60,
+            total_estimated_days=90,
             started_at=None,
             next_step_title=None,
             next_step_id=None,
@@ -171,6 +172,7 @@ class TestGetJourneyOverview:
             "completed_steps": 0,
             "total_steps": 15,
             "estimated_days_remaining": 120,
+            "total_estimated_days": 120,
             "phases": {
                 "research": {"total": 3, "completed": 0},
                 "preparation": {"total": 4, "completed": 0},
@@ -191,6 +193,7 @@ class TestGetJourneyOverview:
         assert result.estimated_total_cost == 250_000.0
         assert result.days_to_target is not None
         assert result.days_to_target >= 0
+        assert result.total_estimated_days == 120
 
     @patch("app.services.dashboard_service._get_estimated_total_cost")
     @patch("app.services.dashboard_service.journey_service")
@@ -215,6 +218,7 @@ class TestGetJourneyOverview:
             "completed_steps": 15,
             "total_steps": 15,
             "estimated_days_remaining": None,
+            "total_estimated_days": None,
             "phases": {
                 "research": {"total": 3, "completed": 3},
                 "preparation": {"total": 4, "completed": 4},
@@ -230,6 +234,39 @@ class TestGetJourneyOverview:
         assert result.progress_percentage == 100.0
         assert result.next_step_title is None
         assert result.next_step_id is None
+
+    @patch("app.services.dashboard_service._get_estimated_total_cost")
+    @patch("app.services.dashboard_service.journey_service")
+    def test_total_estimated_days_exposed_in_overview(
+        self, mock_js, mock_cost, user_id: uuid.UUID
+    ) -> None:
+        """Test that total_estimated_days is populated from progress data."""
+        mock_cost.return_value = None
+
+        mock_journey = MagicMock(spec=Journey)
+        mock_journey.id = uuid.uuid4()
+        mock_journey.title = "Test Journey"
+        mock_journey.started_at = None
+        mock_journey.budget_euros = None
+        mock_journey.target_purchase_date = None
+
+        mock_js.get_user_journeys.return_value = [mock_journey]
+        mock_js.get_progress.return_value = {
+            "current_phase": JourneyPhase.RESEARCH,
+            "current_step_number": 1,
+            "progress_percentage": 20.0,
+            "completed_steps": 1,
+            "total_steps": 5,
+            "estimated_days_remaining": 72,
+            "total_estimated_days": 90,
+            "phases": {"research": {"total": 5, "completed": 1}},
+        }
+        mock_js.get_next_step.return_value = None
+
+        result = get_journey_overview(MagicMock(), user_id)
+
+        assert result is not None
+        assert result.total_estimated_days == 90
 
 
 class TestGetRecentDocuments:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3881,6 +3881,17 @@ export const JourneyOverviewSchema = {
             ],
             title: 'Estimated Days Remaining'
         },
+        total_estimated_days: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Total Estimated Days'
+        },
         started_at: {
             anyOf: [
                 {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1159,6 +1159,7 @@ export type JourneyOverview = {
     completed_steps: number;
     total_steps: number;
     estimated_days_remaining?: (number | null);
+    total_estimated_days?: (number | null);
     started_at?: (string | null);
     next_step_title?: (string | null);
     next_step_id?: (string | null);

--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -139,6 +139,8 @@ function JourneyOverviewCard(props: { journey: JourneyOverview }) {
         <JourneyRingChart
           phases={journey.phases}
           overallPercentage={journey.progressPercentage}
+          startedAt={journey.startedAt}
+          totalEstimatedDays={journey.totalEstimatedDays}
         />
 
         {journey.nextStepTitle && (

--- a/frontend/src/components/Dashboard/JourneyRingChart.tsx
+++ b/frontend/src/components/Dashboard/JourneyRingChart.tsx
@@ -15,6 +15,8 @@ interface IProps {
   phases: Record<string, PhaseData>
   overallPercentage: number
   size?: number
+  startedAt?: string | null
+  totalEstimatedDays?: number | null
 }
 
 /******************************************************************************
@@ -99,9 +101,26 @@ function PhaseArc(props: {
   )
 }
 
+/** Number of whole days elapsed since a UTC ISO date string. */
+function daysSince(isoDate: string): number {
+  const start = new Date(isoDate)
+  const now = new Date()
+  return Math.floor((now.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))
+}
+
 /** Default component. Donut chart with per-phase arcs. */
 function JourneyRingChart(props: Readonly<IProps>) {
-  const { phases, overallPercentage, size = 160 } = props
+  const {
+    phases,
+    overallPercentage,
+    size = 160,
+    startedAt,
+    totalEstimatedDays,
+  } = props
+
+  const dayNumber =
+    startedAt != null ? Math.max(1, daysSince(startedAt) + 1) : null
+  const showDayLabel = dayNumber != null && totalEstimatedDays != null
 
   const cx = size / 2
   const cy = size / 2
@@ -170,6 +189,11 @@ function JourneyRingChart(props: Readonly<IProps>) {
             {Math.round(overallPercentage)}%
           </span>
           <span className="text-xs text-muted-foreground">Complete</span>
+          {showDayLabel && (
+            <span className="mt-0.5 text-[10px] text-muted-foreground">
+              Day {dayNumber} of {totalEstimatedDays}
+            </span>
+          )}
         </div>
       </div>
 

--- a/frontend/src/models/dashboard.ts
+++ b/frontend/src/models/dashboard.ts
@@ -21,6 +21,7 @@ export interface JourneyOverview {
   completedSteps: number
   totalSteps: number
   estimatedDaysRemaining: number | null
+  totalEstimatedDays: number | null
   startedAt: string | null
   nextStepTitle: string | null
   nextStepId: string | null


### PR DESCRIPTION
## Summary
- Adds `total_estimated_days` (sum of all journey steps' `estimated_duration_days`) to the backend `get_progress` dict and the `JourneyOverview` dashboard schema
- Frontend ring chart now shows **"Day X of Y"** below the completion % — X is days elapsed since `started_at`, Y is the total estimated duration
- Gracefully omitted when either value is null
- New backend test: `test_total_estimated_days_exposed_in_overview`

## Test plan
- [ ] Journey in progress with `started_at` set: ring shows "Day X of Y" below percentage
- [ ] New journey with no `started_at`: label absent
- [ ] Journey steps with no `estimated_duration_days`: Y absent, label hidden
- [ ] `bunx tsc --noEmit` — 0 errors
- [ ] Backend: `pytest tests/services/test_dashboard_service.py` — 28 pass