### PR TITLE
feat(ux): add calculator category filter and honest translation status

### DIFF
--- a/frontend/src/components/Documents/ProcessingStatus.tsx
+++ b/frontend/src/components/Documents/ProcessingStatus.tsx
@@ -14,6 +14,7 @@ interface IProps {
   documentId: string
   status: DocumentStatus
   pageCount: number
+  translatedPageCount?: number
   errorMessage?: string | null
 }
 
@@ -23,7 +24,8 @@ interface IProps {
 
 /** Default component. Document processing status indicator. */
 function ProcessingStatus(props: IProps) {
-  const { documentId, status, pageCount, errorMessage } = props
+  const { documentId, status, pageCount, translatedPageCount, errorMessage } =
+    props
   const queryClient = useQueryClient()
 
   const isProcessing = status === "uploaded" || status === "processing"
@@ -45,6 +47,44 @@ function ProcessingStatus(props: IProps) {
   }, [statusData, documentId, queryClient])
 
   if (currentStatus === "completed") {
+    const knownCount = translatedPageCount ?? pageCount
+    const allTranslated = knownCount >= pageCount
+    const noneTranslated = knownCount === 0
+
+    if (noneTranslated) {
+      return (
+        <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20 p-4">
+          <AlertCircle className="h-5 w-5 text-amber-600 shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-400">
+              Translation could not be completed
+            </p>
+            <p className="text-xs text-amber-600 dark:text-amber-500">
+              0 of {pageCount} {pageCount === 1 ? "page" : "pages"} were
+              translated — the document may be image-only or unsupported
+            </p>
+          </div>
+        </div>
+      )
+    }
+
+    if (!allTranslated) {
+      return (
+        <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20 p-4">
+          <AlertCircle className="h-5 w-5 text-amber-600 shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-400">
+              Partially translated
+            </p>
+            <p className="text-xs text-amber-600 dark:text-amber-500">
+              {knownCount} of {pageCount} {pageCount === 1 ? "page" : "pages"}{" "}
+              translated — some pages may be image-only
+            </p>
+          </div>
+        </div>
+      )
+    }
+
     return (
       <div className="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/20 p-4">
         <CheckCircle className="h-5 w-5 text-green-600 shrink-0" />

--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -25,6 +25,7 @@ import {
   Zap,
 } from "lucide-react"
 import type { ElementType } from "react"
+import { useState } from "react"
 import {
   AfaCalculator,
   CityComparison,
@@ -236,44 +237,85 @@ interface ICalculatorGridProps {
 
 /** Grouped card grid — landing view when no calculator is selected */
 function CalculatorGrid({ onSelect }: Readonly<ICalculatorGridProps>) {
+  const [activeFilter, setActiveFilter] = useState<string | null>(null)
+
+  const visibleCategories =
+    activeFilter == null
+      ? CATEGORIES
+      : CATEGORIES.filter((c) => c.id === activeFilter)
+
   return (
-    <div className="space-y-8">
-      {CATEGORIES.map((category) => (
-        <div key={category.id}>
-          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            {category.label}
-          </h2>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {category.items.map((item) => {
-              const Icon = item.icon
-              return (
-                <Card
-                  key={item.tab}
-                  className="cursor-pointer border transition-shadow hover:border-primary/40 hover:shadow-md"
-                  onClick={() => onSelect(item.tab)}
-                >
-                  <CardContent className="flex items-start gap-3 p-4">
-                    <div className="mt-0.5 shrink-0 rounded-md bg-primary/10 p-2">
-                      <Icon className="h-4 w-4 text-primary" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center justify-between gap-1">
-                        <p className="text-sm font-medium leading-snug">
-                          {item.label}
-                        </p>
-                        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+    <div className="space-y-6">
+      {/* Category filter pills */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => setActiveFilter(null)}
+          className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+            activeFilter == null
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
+          }`}
+        >
+          All
+        </button>
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.id}
+            type="button"
+            onClick={() =>
+              setActiveFilter(activeFilter === cat.id ? null : cat.id)
+            }
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              activeFilter === cat.id
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
+            }`}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Calculator cards grouped by category */}
+      <div className="space-y-8">
+        {visibleCategories.map((category) => (
+          <div key={category.id}>
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {category.label}
+            </h2>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {category.items.map((item) => {
+                const Icon = item.icon
+                return (
+                  <Card
+                    key={item.tab}
+                    className="cursor-pointer border transition-shadow hover:border-primary/40 hover:shadow-md"
+                    onClick={() => onSelect(item.tab)}
+                  >
+                    <CardContent className="flex items-start gap-3 p-4">
+                      <div className="mt-0.5 shrink-0 rounded-md bg-primary/10 p-2">
+                        <Icon className="h-4 w-4 text-primary" />
                       </div>
-                      <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
-                        {item.description}
-                      </p>
-                    </div>
-                  </CardContent>
-                </Card>
-              )
-            })}
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between gap-1">
+                          <p className="text-sm font-medium leading-snug">
+                            {item.label}
+                          </p>
+                          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        </div>
+                        <p className="mt-0.5 text-xs leading-snug text-muted-foreground">
+                          {item.description}
+                        </p>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/routes/_layout/documents/$documentId.tsx
+++ b/frontend/src/routes/_layout/documents/$documentId.tsx
@@ -105,6 +105,13 @@ function DocumentDetailPage() {
   const isCompleted = doc.status === "completed"
   const translation = doc.translation
 
+  // Pass 0 when completed but no translation record so banner shows amber, not green
+  const translatedPageCount = translation
+    ? translation.translatedPages.filter((p) => !!p.translatedText).length
+    : isCompleted
+      ? 0
+      : undefined
+
   return (
     <div className="space-y-6">
       {/* Back link and header */}
@@ -162,6 +169,7 @@ function DocumentDetailPage() {
         documentId={doc.id}
         status={doc.status}
         pageCount={doc.pageCount}
+        translatedPageCount={translatedPageCount}
         errorMessage={doc.errorMessage}
       />
 


### PR DESCRIPTION
## Summary
- **Calculators page**: adds category filter pills (All / Buying Costs / Investment Returns / Financing / Renting & Compliance) above the card grid; clicking narrows the view, clicking again deselects back to All
- **Document status**: `ProcessingStatus` now shows accurate status based on how many pages actually have translated text:
  - Green — all pages translated
  - Amber — partial translation (some image-only pages)
  - Amber — 0 pages translated (misleading green is gone)

## Test plan
- [ ] Calculators grid: filter pills visible; selecting a category shows only those cards; clicking active filter returns to All
- [ ] Document with all pages translated → green "Translation completed"
- [ ] Document with some pages missing translation → amber "Partially translated (X of Y pages)"
- [ ] Document status=completed but 0 pages translated → amber "Translation could not be completed"
- [ ] `bunx tsc --noEmit` — 0 errors