### PR TITLE
feat(ux): add english translations for german real estate terms in ui

### DIFF
--- a/frontend/src/components/Calculators/AfaCalculator.tsx
+++ b/frontend/src/components/Calculators/AfaCalculator.tsx
@@ -409,7 +409,7 @@ function AfaCalculator({ className }: Readonly<IProps>) {
                 htmlFor="managementFee"
                 label="Management Fee (€)"
                 optional
-                tooltip="Hausverwaltungsgebühr — typically 3–5% of annual gross rent."
+                tooltip="Hausverwaltungsgebühr (property management fee) — typically 3–5% of annual gross rent."
               >
                 <Input
                   id="managementFee"
@@ -441,9 +441,9 @@ function AfaCalculator({ className }: Readonly<IProps>) {
 
               <FormRow
                 htmlFor="grundsteuer"
-                label="Grundsteuer (€)"
+                label="Grundsteuer (Property Tax, €)"
                 optional
-                tooltip="Annual property tax from your Grundsteuerbescheid. Use the Property Tax tab to estimate this."
+                tooltip="Annual Grundsteuer (property tax) from your Grundsteuerbescheid (tax assessment notice). Use the Property Tax tab to estimate this."
               >
                 <Input
                   id="grundsteuer"

--- a/frontend/src/components/Calculators/GegRetrofitCalculator.tsx
+++ b/frontend/src/components/Calculators/GegRetrofitCalculator.tsx
@@ -605,8 +605,9 @@ function GegRetrofitCalculator(props: Readonly<IProps>) {
           </h2>
           <p className="mt-1 text-sm text-muted-foreground">
             Estimate mandatory energy upgrade costs under the
-            Gebäudeenergiegesetz (GEG). Enter the energy class from the
-            property's Energieausweis.
+            Gebäudeenergiegesetz (GEG — Building Energy Act). Enter the energy
+            class from the property's Energieausweis (energy performance
+            certificate).
           </p>
         </div>
         <Button variant="ghost" size="sm" onClick={handleReset}>

--- a/frontend/src/components/Calculators/GrundsteuerCalculator.tsx
+++ b/frontend/src/components/Calculators/GrundsteuerCalculator.tsx
@@ -487,7 +487,7 @@ function ModelInputs(
           htmlFor="landArea"
           label="Land Area (sqm)"
           optional
-          tooltip="Grundstücksfläche. Enter 0 for apartments with no private land share."
+          tooltip="Grundstücksfläche (plot area). Enter 0 for apartments with no private land share."
         >
           <Input
             id="landArea"
@@ -509,7 +509,7 @@ function ModelInputs(
         <FormRow
           htmlFor="bwLandArea"
           label="Land Area (sqm)"
-          tooltip="Grundstücksfläche from the Grundbuch or listing. For condos use your share of the total land area (Miteigentumsanteil × Gesamtfläche)."
+          tooltip="Grundstücksfläche (plot area) from the Grundbuch (land registry) or listing. For condos use your share of the total land area (Miteigentumsanteil × Gesamtfläche)."
         >
           <Input
             id="bwLandArea"
@@ -523,8 +523,8 @@ function ModelInputs(
         </FormRow>
         <FormRow
           htmlFor="bodenrichtwert"
-          label="Bodenrichtwert (€/sqm)"
-          tooltip="Official land reference value for your area, published by the Gutachterausschuss. Look it up at boris-bw.de."
+          label="Bodenrichtwert (Standard Land Value, €/sqm)"
+          tooltip="Official standard land value for your area, published by the Gutachterausschuss (Expert Valuation Committee). Look it up at boris-bw.de."
         >
           <Input
             id="bodenrichtwert"

--- a/frontend/src/components/Calculators/GrundsteuerCalculator.tsx
+++ b/frontend/src/components/Calculators/GrundsteuerCalculator.tsx
@@ -509,7 +509,7 @@ function ModelInputs(
         <FormRow
           htmlFor="bwLandArea"
           label="Land Area (sqm)"
-          tooltip="Grundstücksfläche (plot area) from the Grundbuch (land registry) or listing. For condos use your share of the total land area (Miteigentumsanteil × Gesamtfläche)."
+          tooltip="Grundstücksfläche (plot area) from the Grundbuch (land registry) or listing. For condos use your share of the total land area (Miteigentumsanteil × Gesamtfläche — co-ownership share × total floor area)."
         >
           <Input
             id="bwLandArea"

--- a/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
+++ b/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
@@ -444,7 +444,7 @@ function HiddenCostsCalculator(props: IProps) {
                     label={`Transfer Tax (${selectedState?.transferTaxRate}%)`}
                     amount={costs.transferTax}
                     percentage={(costs.transferTax / costs.propertyPrice) * 100}
-                    info="Grunderwerbsteuer - varies by state"
+                    info="Grunderwerbsteuer (Property Transfer Tax) - varies by state"
                   />
                   <CostLineItem
                     label="Notary Fee"
@@ -458,7 +458,7 @@ function HiddenCostsCalculator(props: IProps) {
                     percentage={
                       (costs.landRegistryFee / costs.propertyPrice) * 100
                     }
-                    info="Grundbucheintragung"
+                    info="Grundbucheintragung (Land Registry Registration)"
                   />
                   {costs.agentCommission > 0 && (
                     <CostLineItem
@@ -467,7 +467,7 @@ function HiddenCostsCalculator(props: IProps) {
                       percentage={
                         (costs.agentCommission / costs.propertyPrice) * 100
                       }
-                      info="Buyer's share of Maklergebühr"
+                      info="Buyer's share of Maklergebühr (agent commission)"
                     />
                   )}
                 </div>

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
@@ -77,7 +77,7 @@ function OperatingCostsSection(props: IProps) {
           </div>
           <div className="flex justify-between text-sm border-t pt-2 mt-2">
             <span className="text-muted-foreground">
-              Overall Mgmt. Costs (Hausgeld)
+              Overall Mgmt. Costs (Hausgeld / Service Charge)
             </span>
             <span className="font-medium text-orange-600 dark:text-orange-400">
               {CURRENCY_FORMATTER.format(overallHausgeld)}
@@ -92,7 +92,7 @@ function OperatingCostsSection(props: IProps) {
           </p>
           <FormRow
             htmlFor="hausgeldAllocable"
-            label="Allocable Hausgeld (EUR/mo)"
+            label="Allocable Hausgeld (Service Charge, EUR/mo)"
             tooltip="Umlagefähige Nebenkosten — costs passed through to the tenant (heating, water, garbage, cleaning, etc.)"
           >
             <Input
@@ -135,7 +135,7 @@ function OperatingCostsSection(props: IProps) {
 
           <FormRow
             htmlFor="hausgeldNonAllocable"
-            label="Non-alloc. Hausgeld (EUR/mo)"
+            label="Non-alloc. Hausgeld (Service Charge, EUR/mo)"
             tooltip="Nicht umlagefähige Kosten — landlord-only costs that cannot be passed to the tenant (property management fees, etc.)"
           >
             <Input

--- a/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
+++ b/frontend/src/components/Calculators/PropertyEvaluationCalculator/sections/OperatingCostsSection.tsx
@@ -93,7 +93,7 @@ function OperatingCostsSection(props: IProps) {
           <FormRow
             htmlFor="hausgeldAllocable"
             label="Allocable Hausgeld (Service Charge, EUR/mo)"
-            tooltip="Umlagefähige Nebenkosten — costs passed through to the tenant (heating, water, garbage, cleaning, etc.)"
+            tooltip="Umlagefähige Nebenkosten (allocable ancillary costs) — costs passed through to the tenant (heating, water, garbage, cleaning, etc.)"
           >
             <Input
               id="hausgeldAllocable"
@@ -136,7 +136,7 @@ function OperatingCostsSection(props: IProps) {
           <FormRow
             htmlFor="hausgeldNonAllocable"
             label="Non-alloc. Hausgeld (Service Charge, EUR/mo)"
-            tooltip="Nicht umlagefähige Kosten — landlord-only costs that cannot be passed to the tenant (property management fees, etc.)"
+            tooltip="Nicht umlagefähige Kosten (non-allocable costs) — landlord-only costs that cannot be passed to the tenant (property management fees, etc.)"
           >
             <Input
               id="hausgeldNonAllocable"

--- a/frontend/src/components/Calculators/RentCeilingCalculator.tsx
+++ b/frontend/src/components/Calculators/RentCeilingCalculator.tsx
@@ -157,10 +157,10 @@ function RentCeilingCalculator(props: Readonly<IProps>) {
       {/* Input Card */}
       <Card>
         <CardHeader>
-          <CardTitle>Mietpreisbremse Rent Check</CardTitle>
+          <CardTitle>Mietpreisbremse (Rent Brake) Check</CardTitle>
           <CardDescription>
-            Check whether your current rent exceeds the legal cap
-            (Mietspiegel&nbsp;×&nbsp;1.10) under §556d BGB
+            Check whether your current rent exceeds the legal cap (Mietspiegel
+            rent index&nbsp;×&nbsp;1.10) under §556d BGB
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/frontend/src/components/Calculators/TenantTrapCalculator.tsx
+++ b/frontend/src/components/Calculators/TenantTrapCalculator.tsx
@@ -302,7 +302,7 @@ function TenantTrapCalculator(props: Readonly<IProps>) {
             <FormRow
               label="Other fixed costs / unit"
               htmlFor="monthlyFixedCosts"
-              tooltip="Hausgeld, insurance, property tax — per unit per month"
+              tooltip="Hausgeld (service charge), insurance, property tax — per unit per month"
             >
               <Input
                 id="monthlyFixedCosts"
@@ -559,7 +559,7 @@ function TenantTrapCalculator(props: Readonly<IProps>) {
           <p className="mt-3 text-xs text-muted-foreground">
             Total timeline: typically <strong>18–24 months</strong> from first
             missed payment to vacant possession. During this period, mortgage
-            and Hausgeld obligations continue uninterrupted.
+            and Hausgeld (service charge) obligations continue uninterrupted.
           </p>
         </CardContent>
       </Card>

--- a/frontend/src/components/Journey/StepContent/OwnershipManagement.tsx
+++ b/frontend/src/components/Journey/StepContent/OwnershipManagement.tsx
@@ -38,15 +38,15 @@ function OwnershipManagement(_props: Readonly<IProps>) {
           },
           {
             icon: CreditCard,
-            label: "Hausgeld Payments",
+            label: "Hausgeld (Service Charge) Payments",
             detail:
-              "Set up a Dauerauftrag (standing order) for monthly Hausgeld — typically 2-4 EUR/sqm covering maintenance reserves, building insurance, and communal services.",
+              "Set up a Dauerauftrag (standing order) for monthly Hausgeld (service charge) — typically 2-4 EUR/sqm covering maintenance reserves, building insurance, and communal services.",
           },
           {
             icon: Building2,
-            label: "Teilungserklarung & Hausordnung",
+            label: "Teilungserklärung & Hausordnung",
             detail:
-              "Review the declaration of division (Teilungserklarung) to understand your rights and obligations. The Hausordnung defines house rules for all owners.",
+              "Review the Teilungserklärung (declaration of division) to understand your rights and obligations. The Hausordnung (house rules) defines conduct rules for all owners.",
           },
         ]}
         tip="Attend the annual owners' meeting (Eigentumerversammlung) — important decisions about renovations and special levies (Sonderumlage) are made there."
@@ -65,7 +65,7 @@ function OwnershipManagement(_props: Readonly<IProps>) {
             icon: Recycle,
             label: "Waste Collection (Mullabfuhr)",
             detail:
-              "Register for waste collection service with your local municipality. Choose the right bin sizes to keep Nebenkosten reasonable.",
+              "Register for waste collection service with your local municipality. Choose the right bin sizes to keep Nebenkosten (ancillary costs) reasonable.",
           },
           {
             icon: ThermometerSun,

--- a/frontend/src/components/Journey/StepContent/RentalPropertyManagement.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalPropertyManagement.tsx
@@ -36,7 +36,7 @@ function RentalPropertyManagement(_props: Readonly<IProps>) {
               "Saves the management fee but requires time and knowledge of German rental law. You'll need to handle tenant inquiries, maintenance requests, and the annual Nebenkostenabrechnung (utility cost statement) yourself.",
           },
         ]}
-        tip="Even if you self-manage, keep a Hausverwaltung contact ready as a backup. Some issues (legal disputes, emergency repairs) benefit from professional handling."
+        tip="Even if you self-manage, keep a Hausverwaltung (property management company) contact ready as a backup. Some issues (legal disputes, emergency repairs) benefit from professional handling."
       />
       <GuidanceCard
         title="Ongoing Responsibilities"

--- a/frontend/src/components/Journey/StepContent/RentalPropertyManagement.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalPropertyManagement.tsx
@@ -33,7 +33,7 @@ function RentalPropertyManagement(_props: Readonly<IProps>) {
             icon: Euro,
             label: "Self-Management",
             detail:
-              "Saves the management fee but requires time and knowledge of German rental law. You'll need to handle tenant inquiries, maintenance requests, and the annual Nebenkostenabrechnung yourself.",
+              "Saves the management fee but requires time and knowledge of German rental law. You'll need to handle tenant inquiries, maintenance requests, and the annual Nebenkostenabrechnung (utility cost statement) yourself.",
           },
         ]}
         tip="Even if you self-manage, keep a Hausverwaltung contact ready as a backup. Some issues (legal disputes, emergency repairs) benefit from professional handling."

--- a/frontend/src/components/Portfolio/RunningCostsTab.tsx
+++ b/frontend/src/components/Portfolio/RunningCostsTab.tsx
@@ -69,7 +69,8 @@ function RunningCostsTab(props: Readonly<IProps>) {
           No running cost data yet
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
-          Add transactions with a cost category to start tracking Nebenkosten.
+          Add transactions with a cost category to start tracking Nebenkosten
+          (ancillary costs).
         </p>
       </div>
     )
@@ -107,7 +108,7 @@ function RunningCostsTab(props: Readonly<IProps>) {
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground">
-              Total Monthly Nebenkosten
+              Total Monthly Nebenkosten (Ancillary Costs)
             </CardTitle>
           </CardHeader>
           <CardContent>

--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -107,7 +107,8 @@ const CATEGORIES: ICategory[] = [
       {
         tab: "compare",
         label: "State Comparison",
-        description: "Compare Grunderwerbsteuer rates across German states",
+        description:
+          "Compare Grunderwerbsteuer (Property Transfer Tax) rates across German states",
         icon: ArrowUpDown,
       },
       {
@@ -143,7 +144,8 @@ const CATEGORIES: ICategory[] = [
       {
         tab: "speculation-tax",
         label: "Exit Tax",
-        description: "Spekulationssteuer on property sale within 10 years",
+        description:
+          "Spekulationssteuer (Speculation Tax) on property sale within 10 years",
         icon: TrendingDown,
       },
       {
@@ -197,13 +199,15 @@ const CATEGORIES: ICategory[] = [
       {
         tab: "rent-ceiling",
         label: "Rent Ceiling Check",
-        description: "Mietpreisbremse compliance check for your property",
+        description:
+          "Mietpreisbremse (Rent Brake) compliance check for your property",
         icon: Scale,
       },
       {
         tab: "grundsteuer",
         label: "Property Tax",
-        description: "Annual Grundsteuer estimate for any German property",
+        description:
+          "Annual Grundsteuer (Property Tax) estimate for any German property",
         icon: Home,
       },
       {


### PR DESCRIPTION
## Summary
- Adds English translations in brackets for all standalone German real estate terms in user-visible UI strings
- Covers calculators, journey step content, and portfolio components
- Preserves German terms (educational value) while making the app accessible to foreign investors

## Affected files
- `calculators.tsx`: card descriptions for Grunderwerbsteuer, Spekulationssteuer, Mietpreisbremse, Grundsteuer
- `HiddenCostsCalculator`: info tooltips for Grunderwerbsteuer, Grundbucheintragung, Maklergebühr
- `GrundsteuerCalculator`: Bodenrichtwert label, Grundstücksfläche/Miteigentumsanteil/Gutachterausschuss tooltips
- `AfaCalculator`: Hausverwaltungsgebühr tooltip, Grundsteuer label + Grundsteuerbescheid tooltip
- `GegRetrofitCalculator`: Gebäudeenergiegesetz description, Energieausweis reference
- `RentCeilingCalculator`: Mietpreisbremse card title, Mietspiegel description
- `TenantTrapCalculator`: Hausgeld tooltip and timeline text
- `OperatingCostsSection`: Hausgeld field labels (3 occurrences)
- `OwnershipManagement`: Hausgeld, Teilungserklärung, Hausordnung, Nebenkosten
- `RentalPropertyManagement`: Nebenkostenabrechnung
- `RunningCostsTab`: Nebenkosten empty state and KPI card title

## Test plan
- [ ] Verify calculator card descriptions show English translations in brackets
- [ ] Open GrundsteuerCalculator — Bodenrichtwert label shows "Standard Land Value"
- [ ] Open HiddenCostsCalculator — info tooltips show English for transfer tax and registry fee
- [ ] Open OwnershipManagement journey step — Hausgeld card shows "(Service Charge)"
- [ ] TypeScript: `bunx tsc --noEmit` passes