### PR TITLE
feat(notifications): add journey deadline reminder notifications

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -24,9 +24,19 @@ def send_weekly_digest() -> None:
         logger.info("Done — %d digest emails sent.", count)
 
 
+def send_deadline_reminders() -> None:
+    """Create a DB session and fire journey deadline reminder notifications."""
+    from app.services import deadline_service
+
+    with Session(engine) as session:
+        count = deadline_service.send_deadline_reminders(session)
+        logger.info("Done — %d deadline reminders sent.", count)
+
+
 def main() -> None:
     commands = {
         "send-weekly-digest": send_weekly_digest,
+        "send-deadline-reminders": send_deadline_reminders,
     }
 
     if len(sys.argv) < 2 or sys.argv[1] not in commands:

--- a/backend/app/services/deadline_service.py
+++ b/backend/app/services/deadline_service.py
@@ -61,8 +61,15 @@ def send_deadline_reminders(session: Session) -> int:
             )
             continue
 
-        _create_reminder(session, journey, days_remaining, action_url)
-        sent_count += 1
+        try:
+            _create_reminder(session, journey, days_remaining, action_url)
+            sent_count += 1
+        except Exception:
+            logger.exception(
+                "Failed to create deadline reminder for journey %s (%d days)",
+                journey.id,
+                days_remaining,
+            )
 
     logger.info("Deadline reminders complete: %d notifications created.", sent_count)
     return sent_count
@@ -76,20 +83,20 @@ def send_deadline_reminders(session: Session) -> int:
 def _get_journeys_with_upcoming_deadline(
     session: Session, today: date
 ) -> list[Journey]:
-    """Return all journeys whose target_purchase_date is today or in the future."""
+    """Return journeys whose target_purchase_date falls within the reminder horizon."""
     today_start = datetime.combine(today, datetime.min.time()).replace(
         tzinfo=timezone.utc
     )
+    horizon = today_start + timedelta(days=max(REMINDER_MILESTONES))
     stmt = select(Journey).where(
         Journey.target_purchase_date.is_not(None),  # type: ignore[union-attr]
         Journey.target_purchase_date >= today_start,  # type: ignore[operator]
+        Journey.target_purchase_date <= horizon,  # type: ignore[operator]
     )
     return list(session.exec(stmt).all())
 
 
-def _already_notified(
-    session: Session, user_id: uuid.UUID, action_url: str
-) -> bool:
+def _already_notified(session: Session, user_id: uuid.UUID, action_url: str) -> bool:
     """Return True if a JOURNEY_DEADLINE notification for this action_url was
     created within the deduplication window."""
     cutoff = datetime.now(timezone.utc) - timedelta(days=_DEDUP_WINDOW_DAYS)
@@ -142,8 +149,8 @@ def _build_message(days_remaining: int) -> str:
             "30 days until your target purchase date. "
             "Time to finalise your mortgage offer and check all purchase documents."
         )
-    # 90 days
+    # days_remaining == 90
     return (
-        f"{days_remaining} days until your target purchase date. "
+        "90 days until your target purchase date. "
         "A good time to schedule your notary appointment and confirm your financing."
     )

--- a/backend/app/services/deadline_service.py
+++ b/backend/app/services/deadline_service.py
@@ -1,0 +1,149 @@
+"""Deadline reminder service — sends JOURNEY_DEADLINE notifications at key milestones.
+
+Run via CLI:
+    python -m app.cli send-deadline-reminders
+
+Milestones (days before target_purchase_date): 90, 30, 7, 1.
+A notification is skipped if an identical one was already sent within
+the last two days (deduplication window).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+from sqlmodel import Session, select
+
+from app.models.journey import Journey
+from app.models.notification import Notification, NotificationType
+
+logger = logging.getLogger(__name__)
+
+# Days before the target date at which reminders are fired.
+REMINDER_MILESTONES: tuple[int, ...] = (90, 30, 7, 1)
+
+# If a matching reminder was created within this window, skip to avoid duplicates.
+_DEDUP_WINDOW_DAYS = 2
+
+
+def send_deadline_reminders(session: Session) -> int:
+    """Send JOURNEY_DEADLINE notifications for journeys approaching their target date.
+
+    Iterates all journeys with a future target_purchase_date, checks whether
+    today is a milestone day, and creates an in-app (plus optional email)
+    notification if one hasn't already been sent for this milestone.
+
+    Args:
+        session: Synchronous database session.
+
+    Returns:
+        Number of notifications created.
+    """
+    today = datetime.now(timezone.utc).date()
+    sent_count = 0
+
+    for journey in _get_journeys_with_upcoming_deadline(session, today):
+        target_date = journey.target_purchase_date.date()
+        days_remaining = (target_date - today).days
+
+        if days_remaining not in REMINDER_MILESTONES:
+            continue
+
+        action_url = f"/journeys/{journey.id}"
+
+        if _already_notified(session, journey.user_id, action_url):
+            logger.debug(
+                "Skipping duplicate deadline reminder for journey %s (%d days)",
+                journey.id,
+                days_remaining,
+            )
+            continue
+
+        _create_reminder(session, journey, days_remaining, action_url)
+        sent_count += 1
+
+    logger.info("Deadline reminders complete: %d notifications created.", sent_count)
+    return sent_count
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_journeys_with_upcoming_deadline(
+    session: Session, today: date
+) -> list[Journey]:
+    """Return all journeys whose target_purchase_date is today or in the future."""
+    today_start = datetime.combine(today, datetime.min.time()).replace(
+        tzinfo=timezone.utc
+    )
+    stmt = select(Journey).where(
+        Journey.target_purchase_date.is_not(None),  # type: ignore[union-attr]
+        Journey.target_purchase_date >= today_start,  # type: ignore[operator]
+    )
+    return list(session.exec(stmt).all())
+
+
+def _already_notified(
+    session: Session, user_id: uuid.UUID, action_url: str
+) -> bool:
+    """Return True if a JOURNEY_DEADLINE notification for this action_url was
+    created within the deduplication window."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=_DEDUP_WINDOW_DAYS)
+    stmt = select(Notification).where(
+        Notification.user_id == user_id,
+        Notification.type == NotificationType.JOURNEY_DEADLINE.value,
+        Notification.action_url == action_url,
+        Notification.created_at >= cutoff,
+    )
+    return session.execute(stmt).scalar_one_or_none() is not None
+
+
+def _create_reminder(
+    session: Session,
+    journey: Journey,
+    days_remaining: int,
+    action_url: str,
+) -> None:
+    """Create the deadline reminder notification via the notification service."""
+    from app.services import notification_service
+
+    day_word = "day" if days_remaining == 1 else "days"
+    title = f"Journey deadline in {days_remaining} {day_word}"
+    message = _build_message(days_remaining)
+
+    notification_service.create_notification(
+        session,
+        user_id=journey.user_id,
+        type=NotificationType.JOURNEY_DEADLINE,
+        title=title,
+        message=message,
+        action_url=action_url,
+    )
+
+
+def _build_message(days_remaining: int) -> str:
+    """Return a milestone-specific reminder message."""
+    if days_remaining == 1:
+        return (
+            "Your target purchase date is tomorrow. "
+            "Ensure all documents are signed and your notary is confirmed."
+        )
+    if days_remaining == 7:
+        return (
+            "One week until your target purchase date. "
+            "Confirm your notary appointment and review your mortgage offer."
+        )
+    if days_remaining == 30:
+        return (
+            "30 days until your target purchase date. "
+            "Time to finalise your mortgage offer and check all purchase documents."
+        )
+    # 90 days
+    return (
+        f"{days_remaining} days until your target purchase date. "
+        "A good time to schedule your notary appointment and confirm your financing."
+    )

--- a/backend/tests/services/test_deadline_service.py
+++ b/backend/tests/services/test_deadline_service.py
@@ -1,8 +1,8 @@
 """Tests for the deadline reminder service."""
 
 import uuid
-from datetime import date, datetime, timedelta, timezone
-from unittest.mock import MagicMock, call, patch
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -15,7 +15,6 @@ from app.services.deadline_service import (
     _get_journeys_with_upcoming_deadline,
     send_deadline_reminders,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -93,9 +92,7 @@ class TestAlreadyNotified:
         result = _already_notified(mock_session, user_id, "/journeys/abc")
         assert result is False
 
-    def test_returns_true_when_notification_exists(
-        self, mock_session, user_id
-    ) -> None:
+    def test_returns_true_when_notification_exists(self, mock_session, user_id) -> None:
         mock_session.execute.return_value.scalar_one_or_none.return_value = MagicMock()
         result = _already_notified(mock_session, user_id, "/journeys/abc")
         assert result is True
@@ -183,9 +180,7 @@ class TestSendDeadlineReminders:
                 "_get_journeys_with_upcoming_deadline",
                 return_value=[journey],
             ),
-            patch.object(
-                deadline_service, "_already_notified", return_value=False
-            ),
+            patch.object(deadline_service, "_already_notified", return_value=False),
             patch.object(deadline_service, "_create_reminder") as mock_create,
         ):
             count = send_deadline_reminders(mock_session)
@@ -193,9 +188,7 @@ class TestSendDeadlineReminders:
         assert count == 1
         mock_create.assert_called_once()
 
-    def test_skips_non_milestone_day(
-        self, mock_session, user_id, journey_id
-    ) -> None:
+    def test_skips_non_milestone_day(self, mock_session, user_id, journey_id) -> None:
         journey = _make_journey(user_id, journey_id, days_from_today=45)
 
         with (
@@ -222,9 +215,7 @@ class TestSendDeadlineReminders:
                 "_get_journeys_with_upcoming_deadline",
                 return_value=[journey],
             ),
-            patch.object(
-                deadline_service, "_already_notified", return_value=True
-            ),
+            patch.object(deadline_service, "_already_notified", return_value=True),
             patch.object(deadline_service, "_create_reminder") as mock_create,
         ):
             count = send_deadline_reminders(mock_session)
@@ -246,9 +237,7 @@ class TestSendDeadlineReminders:
                 "_get_journeys_with_upcoming_deadline",
                 return_value=[journey1, journey2],
             ),
-            patch.object(
-                deadline_service, "_already_notified", return_value=False
-            ),
+            patch.object(deadline_service, "_already_notified", return_value=False),
             patch.object(deadline_service, "_create_reminder") as mock_create,
         ):
             count = send_deadline_reminders(mock_session)

--- a/backend/tests/services/test_deadline_service.py
+++ b/backend/tests/services/test_deadline_service.py
@@ -1,0 +1,267 @@
+"""Tests for the deadline reminder service."""
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.services import deadline_service
+from app.services.deadline_service import (
+    REMINDER_MILESTONES,
+    _already_notified,
+    _build_message,
+    _create_reminder,
+    _get_journeys_with_upcoming_deadline,
+    send_deadline_reminders,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+@pytest.fixture
+def user_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def journey_id():
+    return uuid.uuid4()
+
+
+def _make_journey(
+    user_id: uuid.UUID,
+    journey_id: uuid.UUID,
+    days_from_today: int,
+) -> MagicMock:
+    """Create a mock Journey with target_purchase_date set to N days from now."""
+    today = datetime.now(timezone.utc)
+    target = today + timedelta(days=days_from_today)
+
+    journey = MagicMock()
+    journey.id = journey_id
+    journey.user_id = user_id
+    journey.target_purchase_date = target
+    return journey
+
+
+# ---------------------------------------------------------------------------
+# _build_message
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMessage:
+    def test_1_day_message(self) -> None:
+        msg = _build_message(1)
+        assert "tomorrow" in msg.lower()
+
+    def test_7_day_message(self) -> None:
+        msg = _build_message(7)
+        assert "one week" in msg.lower()
+
+    def test_30_day_message(self) -> None:
+        msg = _build_message(30)
+        assert "30 days" in msg
+
+    def test_90_day_message(self) -> None:
+        msg = _build_message(90)
+        assert "90 days" in msg
+
+    def test_all_milestones_return_non_empty(self) -> None:
+        for milestone in REMINDER_MILESTONES:
+            assert _build_message(milestone)
+
+
+# ---------------------------------------------------------------------------
+# _already_notified
+# ---------------------------------------------------------------------------
+
+
+class TestAlreadyNotified:
+    def test_returns_false_when_no_existing_notification(
+        self, mock_session, user_id
+    ) -> None:
+        mock_session.execute.return_value.scalar_one_or_none.return_value = None
+        result = _already_notified(mock_session, user_id, "/journeys/abc")
+        assert result is False
+
+    def test_returns_true_when_notification_exists(
+        self, mock_session, user_id
+    ) -> None:
+        mock_session.execute.return_value.scalar_one_or_none.return_value = MagicMock()
+        result = _already_notified(mock_session, user_id, "/journeys/abc")
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# _get_journeys_with_upcoming_deadline
+# ---------------------------------------------------------------------------
+
+
+class TestGetJourneysWithUpcomingDeadline:
+    def test_returns_list_from_session(self, mock_session, user_id) -> None:
+        mock_journey = _make_journey(user_id, uuid.uuid4(), days_from_today=30)
+        mock_session.exec.return_value.all.return_value = [mock_journey]
+
+        today = datetime.now(timezone.utc).date()
+        result = _get_journeys_with_upcoming_deadline(mock_session, today)
+
+        assert result == [mock_journey]
+
+    def test_returns_empty_list_when_no_journeys(self, mock_session) -> None:
+        mock_session.exec.return_value.all.return_value = []
+        today = datetime.now(timezone.utc).date()
+        result = _get_journeys_with_upcoming_deadline(mock_session, today)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _create_reminder
+# ---------------------------------------------------------------------------
+
+
+class TestCreateReminder:
+    @patch("app.services.deadline_service._build_message", return_value="Test msg")
+    @patch("app.services.notification_service.create_notification")
+    def test_calls_notification_service(
+        self,
+        mock_create,
+        mock_msg,
+        mock_session,
+        user_id,
+        journey_id,
+    ) -> None:
+        journey = _make_journey(user_id, journey_id, days_from_today=30)
+        action_url = f"/journeys/{journey_id}"
+
+        _create_reminder(mock_session, journey, 30, action_url)
+
+        mock_create.assert_called_once()
+        _, kwargs = mock_create.call_args
+        assert kwargs["user_id"] == user_id
+        assert kwargs["action_url"] == action_url
+        assert "30" in kwargs["title"]
+
+    def test_title_is_singular_for_one_day(
+        self, mock_session, user_id, journey_id
+    ) -> None:
+        journey = _make_journey(user_id, journey_id, days_from_today=1)
+        action_url = f"/journeys/{journey_id}"
+
+        with patch(
+            "app.services.notification_service.create_notification"
+        ) as mock_create:
+            _create_reminder(mock_session, journey, 1, action_url)
+
+        _, kwargs = mock_create.call_args
+        assert "1 day" in kwargs["title"]
+        assert "days" not in kwargs["title"]
+
+
+# ---------------------------------------------------------------------------
+# send_deadline_reminders
+# ---------------------------------------------------------------------------
+
+
+class TestSendDeadlineReminders:
+    def test_sends_notification_on_milestone_day(
+        self, mock_session, user_id, journey_id
+    ) -> None:
+        journey = _make_journey(user_id, journey_id, days_from_today=30)
+
+        with (
+            patch.object(
+                deadline_service,
+                "_get_journeys_with_upcoming_deadline",
+                return_value=[journey],
+            ),
+            patch.object(
+                deadline_service, "_already_notified", return_value=False
+            ),
+            patch.object(deadline_service, "_create_reminder") as mock_create,
+        ):
+            count = send_deadline_reminders(mock_session)
+
+        assert count == 1
+        mock_create.assert_called_once()
+
+    def test_skips_non_milestone_day(
+        self, mock_session, user_id, journey_id
+    ) -> None:
+        journey = _make_journey(user_id, journey_id, days_from_today=45)
+
+        with (
+            patch.object(
+                deadline_service,
+                "_get_journeys_with_upcoming_deadline",
+                return_value=[journey],
+            ),
+            patch.object(deadline_service, "_create_reminder") as mock_create,
+        ):
+            count = send_deadline_reminders(mock_session)
+
+        assert count == 0
+        mock_create.assert_not_called()
+
+    def test_skips_duplicate_notification(
+        self, mock_session, user_id, journey_id
+    ) -> None:
+        journey = _make_journey(user_id, journey_id, days_from_today=7)
+
+        with (
+            patch.object(
+                deadline_service,
+                "_get_journeys_with_upcoming_deadline",
+                return_value=[journey],
+            ),
+            patch.object(
+                deadline_service, "_already_notified", return_value=True
+            ),
+            patch.object(deadline_service, "_create_reminder") as mock_create,
+        ):
+            count = send_deadline_reminders(mock_session)
+
+        assert count == 0
+        mock_create.assert_not_called()
+
+    def test_sends_multiple_notifications_for_multiple_journeys(
+        self, mock_session
+    ) -> None:
+        uid1, jid1 = uuid.uuid4(), uuid.uuid4()
+        uid2, jid2 = uuid.uuid4(), uuid.uuid4()
+        journey1 = _make_journey(uid1, jid1, days_from_today=30)
+        journey2 = _make_journey(uid2, jid2, days_from_today=7)
+
+        with (
+            patch.object(
+                deadline_service,
+                "_get_journeys_with_upcoming_deadline",
+                return_value=[journey1, journey2],
+            ),
+            patch.object(
+                deadline_service, "_already_notified", return_value=False
+            ),
+            patch.object(deadline_service, "_create_reminder") as mock_create,
+        ):
+            count = send_deadline_reminders(mock_session)
+
+        assert count == 2
+        assert mock_create.call_count == 2
+
+    def test_returns_zero_when_no_journeys(self, mock_session) -> None:
+        with patch.object(
+            deadline_service,
+            "_get_journeys_with_upcoming_deadline",
+            return_value=[],
+        ):
+            count = send_deadline_reminders(mock_session)
+
+        assert count == 0


### PR DESCRIPTION
## Summary

- Adds `deadline_service.py` that queries all journeys with an upcoming `target_purchase_date` and fires `JOURNEY_DEADLINE` in-app notifications at 90/30/7/1-day milestones
- Deduplication: skips if an identical notification was already sent within the last 2 days (prevents double-firing if the CLI runs more than once per day)
- Wires up `send-deadline-reminders` CLI command in `cli.py`, matching the existing `send-weekly-digest` pattern
- 16 unit tests covering: milestone triggers, non-milestone skips, deduplication, singular/plural title, message content, empty journey list

## Test plan

- [x] All 16 unit tests pass (`pytest tests/services/test_deadline_service.py`)
- [x] Pre-commit hooks pass (ruff, biome, format)
- [ ] CI passes on PR