### PR TITLE
infra: add scheduled cron jobs for weekly digest and deadline reminders

### DIFF
--- a/frontend/src/components/UserSettings/NotificationPreferences.tsx
+++ b/frontend/src/components/UserSettings/NotificationPreferences.tsx
@@ -39,7 +39,10 @@ const NOTIFICATION_CATEGORIES: CategoryGroup[] = [
   },
   {
     label: "Documents",
-    types: [{ type: "document_translated", label: "Document Translated" }],
+    types: [
+      { type: "document_translated", label: "Document Translated" },
+      { type: "translation_failed", label: "Translation Failed" },
+    ],
   },
   {
     label: "Calculators",

--- a/infra/terraform/prod.tf
+++ b/infra/terraform/prod.tf
@@ -370,6 +370,290 @@ resource "azurerm_container_app_job" "prod_migration" {
   }
 }
 
+# ── Scheduled Jobs ───────────────────────────
+
+resource "azurerm_container_app_job" "prod_weekly_digest" {
+  name                         = "heimpath-weekly-digest-prod"
+  location                     = azurerm_resource_group.prod.location
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  replica_timeout_in_seconds   = 600
+  replica_retry_limit          = 1
+
+  schedule_trigger_config {
+    cron_expression          = "0 7 * * 1" # Mondays 07:00 UTC
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  registry {
+    server               = "ghcr.io"
+    username             = var.ghcr_username
+    password_secret_name = "ghcr-password"
+  }
+
+  secret {
+    name  = "ghcr-password"
+    value = var.ghcr_password
+  }
+
+  secret {
+    name  = "postgres-password"
+    value = var.prod_postgres_password
+  }
+
+  secret {
+    name  = "secret-key"
+    value = var.prod_secret_key
+  }
+
+  dynamic "secret" {
+    for_each = var.prod_smtp_password != "" ? [1] : []
+    content {
+      name  = "smtp-password"
+      value = var.prod_smtp_password
+    }
+  }
+
+  template {
+    container {
+      name    = "weekly-digest"
+      image   = var.prod_backend_image
+      cpu     = 0.25
+      memory  = "0.5Gi"
+      command = ["python", "-m", "app.cli", "send-weekly-digest"]
+
+      env {
+        name  = "ENVIRONMENT"
+        value = "production"
+      }
+
+      env {
+        name  = "PROJECT_NAME"
+        value = var.project_name
+      }
+
+      env {
+        name  = "POSTGRES_SERVER"
+        value = var.prod_postgres_server
+      }
+
+      env {
+        name  = "POSTGRES_PORT"
+        value = tostring(var.prod_postgres_port)
+      }
+
+      env {
+        name  = "POSTGRES_USER"
+        value = var.prod_postgres_user
+      }
+
+      env {
+        name        = "POSTGRES_PASSWORD"
+        secret_name = "postgres-password"
+      }
+
+      env {
+        name  = "POSTGRES_DB"
+        value = var.prod_postgres_db
+      }
+
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+
+      env {
+        name  = "FRONTEND_HOST"
+        value = var.prod_frontend_url
+      }
+
+      env {
+        name  = "TRUSTED_PROXY_IPS"
+        value = "*"
+      }
+
+      dynamic "env" {
+        for_each = var.prod_smtp_host != "" ? [1] : []
+        content {
+          name  = "SMTP_HOST"
+          value = var.prod_smtp_host
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_smtp_user != "" ? [1] : []
+        content {
+          name  = "SMTP_USER"
+          value = var.prod_smtp_user
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_smtp_password != "" ? [1] : []
+        content {
+          name        = "SMTP_PASSWORD"
+          secret_name = "smtp-password"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_emails_from_email != "" ? [1] : []
+        content {
+          name  = "EMAILS_FROM_EMAIL"
+          value = var.prod_emails_from_email
+        }
+      }
+    }
+  }
+
+  tags = {
+    project     = "heimpath"
+    environment = "prod"
+  }
+}
+
+resource "azurerm_container_app_job" "prod_deadline_reminders" {
+  name                         = "heimpath-deadline-reminders-prod"
+  location                     = azurerm_resource_group.prod.location
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.prod.name
+  replica_timeout_in_seconds   = 600
+  replica_retry_limit          = 1
+
+  schedule_trigger_config {
+    cron_expression          = "0 8 * * *" # Daily 08:00 UTC
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  registry {
+    server               = "ghcr.io"
+    username             = var.ghcr_username
+    password_secret_name = "ghcr-password"
+  }
+
+  secret {
+    name  = "ghcr-password"
+    value = var.ghcr_password
+  }
+
+  secret {
+    name  = "postgres-password"
+    value = var.prod_postgres_password
+  }
+
+  secret {
+    name  = "secret-key"
+    value = var.prod_secret_key
+  }
+
+  dynamic "secret" {
+    for_each = var.prod_smtp_password != "" ? [1] : []
+    content {
+      name  = "smtp-password"
+      value = var.prod_smtp_password
+    }
+  }
+
+  template {
+    container {
+      name    = "deadline-reminders"
+      image   = var.prod_backend_image
+      cpu     = 0.25
+      memory  = "0.5Gi"
+      command = ["python", "-m", "app.cli", "send-deadline-reminders"]
+
+      env {
+        name  = "ENVIRONMENT"
+        value = "production"
+      }
+
+      env {
+        name  = "PROJECT_NAME"
+        value = var.project_name
+      }
+
+      env {
+        name  = "POSTGRES_SERVER"
+        value = var.prod_postgres_server
+      }
+
+      env {
+        name  = "POSTGRES_PORT"
+        value = tostring(var.prod_postgres_port)
+      }
+
+      env {
+        name  = "POSTGRES_USER"
+        value = var.prod_postgres_user
+      }
+
+      env {
+        name        = "POSTGRES_PASSWORD"
+        secret_name = "postgres-password"
+      }
+
+      env {
+        name  = "POSTGRES_DB"
+        value = var.prod_postgres_db
+      }
+
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+
+      env {
+        name  = "FRONTEND_HOST"
+        value = var.prod_frontend_url
+      }
+
+      env {
+        name  = "TRUSTED_PROXY_IPS"
+        value = "*"
+      }
+
+      dynamic "env" {
+        for_each = var.prod_smtp_host != "" ? [1] : []
+        content {
+          name  = "SMTP_HOST"
+          value = var.prod_smtp_host
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_smtp_user != "" ? [1] : []
+        content {
+          name  = "SMTP_USER"
+          value = var.prod_smtp_user
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_smtp_password != "" ? [1] : []
+        content {
+          name        = "SMTP_PASSWORD"
+          secret_name = "smtp-password"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_emails_from_email != "" ? [1] : []
+        content {
+          name  = "EMAILS_FROM_EMAIL"
+          value = var.prod_emails_from_email
+        }
+      }
+    }
+  }
+
+  tags = {
+    project     = "heimpath"
+    environment = "prod"
+  }
+}
+
 # ── Custom Domains ───────────────────────────
 
 resource "azurerm_container_app_custom_domain" "prod_frontend" {

--- a/infra/terraform/prod.tf
+++ b/infra/terraform/prod.tf
@@ -377,11 +377,11 @@ resource "azurerm_container_app_job" "prod_weekly_digest" {
   location                     = azurerm_resource_group.prod.location
   container_app_environment_id = azurerm_container_app_environment.main.id
   resource_group_name          = azurerm_resource_group.prod.name
-  replica_timeout_in_seconds   = 600
+  replica_timeout_in_seconds   = 1800
   replica_retry_limit          = 1
 
   schedule_trigger_config {
-    cron_expression          = "0 7 * * 1" # Mondays 07:00 UTC
+    cron_expression          = "0 6 * * 1" # Mondays 06:00 UTC
     parallelism              = 1
     replica_completion_count = 1
   }

--- a/infra/terraform/staging.tf
+++ b/infra/terraform/staging.tf
@@ -373,11 +373,11 @@ resource "azurerm_container_app_job" "staging_weekly_digest" {
   location                     = azurerm_resource_group.staging.location
   container_app_environment_id = azurerm_container_app_environment.main.id
   resource_group_name          = azurerm_resource_group.staging.name
-  replica_timeout_in_seconds   = 600
+  replica_timeout_in_seconds   = 1800
   replica_retry_limit          = 1
 
   schedule_trigger_config {
-    cron_expression          = "0 7 * * 1" # Mondays 07:00 UTC
+    cron_expression          = "0 6 * * 1" # Mondays 06:00 UTC
     parallelism              = 1
     replica_completion_count = 1
   }

--- a/infra/terraform/staging.tf
+++ b/infra/terraform/staging.tf
@@ -366,6 +366,290 @@ resource "azurerm_container_app_job" "staging_migration" {
   }
 }
 
+# ── Scheduled Jobs ───────────────────────────
+
+resource "azurerm_container_app_job" "staging_weekly_digest" {
+  name                         = "heimpath-weekly-digest-staging"
+  location                     = azurerm_resource_group.staging.location
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.staging.name
+  replica_timeout_in_seconds   = 600
+  replica_retry_limit          = 1
+
+  schedule_trigger_config {
+    cron_expression          = "0 7 * * 1" # Mondays 07:00 UTC
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  registry {
+    server               = "ghcr.io"
+    username             = var.ghcr_username
+    password_secret_name = "ghcr-password"
+  }
+
+  secret {
+    name  = "ghcr-password"
+    value = var.ghcr_password
+  }
+
+  secret {
+    name  = "postgres-password"
+    value = var.staging_postgres_password
+  }
+
+  secret {
+    name  = "secret-key"
+    value = var.staging_secret_key
+  }
+
+  dynamic "secret" {
+    for_each = var.staging_smtp_password != "" ? [1] : []
+    content {
+      name  = "smtp-password"
+      value = var.staging_smtp_password
+    }
+  }
+
+  template {
+    container {
+      name    = "weekly-digest"
+      image   = var.staging_backend_image
+      cpu     = 0.25
+      memory  = "0.5Gi"
+      command = ["python", "-m", "app.cli", "send-weekly-digest"]
+
+      env {
+        name  = "ENVIRONMENT"
+        value = "staging"
+      }
+
+      env {
+        name  = "PROJECT_NAME"
+        value = var.project_name
+      }
+
+      env {
+        name  = "POSTGRES_SERVER"
+        value = var.staging_postgres_server
+      }
+
+      env {
+        name  = "POSTGRES_PORT"
+        value = tostring(var.staging_postgres_port)
+      }
+
+      env {
+        name  = "POSTGRES_USER"
+        value = var.staging_postgres_user
+      }
+
+      env {
+        name        = "POSTGRES_PASSWORD"
+        secret_name = "postgres-password"
+      }
+
+      env {
+        name  = "POSTGRES_DB"
+        value = var.staging_postgres_db
+      }
+
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+
+      env {
+        name  = "FRONTEND_HOST"
+        value = var.staging_frontend_url
+      }
+
+      env {
+        name  = "TRUSTED_PROXY_IPS"
+        value = "*"
+      }
+
+      dynamic "env" {
+        for_each = var.staging_smtp_host != "" ? [1] : []
+        content {
+          name  = "SMTP_HOST"
+          value = var.staging_smtp_host
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_smtp_user != "" ? [1] : []
+        content {
+          name  = "SMTP_USER"
+          value = var.staging_smtp_user
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_smtp_password != "" ? [1] : []
+        content {
+          name        = "SMTP_PASSWORD"
+          secret_name = "smtp-password"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_emails_from_email != "" ? [1] : []
+        content {
+          name  = "EMAILS_FROM_EMAIL"
+          value = var.staging_emails_from_email
+        }
+      }
+    }
+  }
+
+  tags = {
+    project     = "heimpath"
+    environment = "staging"
+  }
+}
+
+resource "azurerm_container_app_job" "staging_deadline_reminders" {
+  name                         = "heimpath-deadline-reminders-staging"
+  location                     = azurerm_resource_group.staging.location
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.staging.name
+  replica_timeout_in_seconds   = 600
+  replica_retry_limit          = 1
+
+  schedule_trigger_config {
+    cron_expression          = "0 8 * * *" # Daily 08:00 UTC
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  registry {
+    server               = "ghcr.io"
+    username             = var.ghcr_username
+    password_secret_name = "ghcr-password"
+  }
+
+  secret {
+    name  = "ghcr-password"
+    value = var.ghcr_password
+  }
+
+  secret {
+    name  = "postgres-password"
+    value = var.staging_postgres_password
+  }
+
+  secret {
+    name  = "secret-key"
+    value = var.staging_secret_key
+  }
+
+  dynamic "secret" {
+    for_each = var.staging_smtp_password != "" ? [1] : []
+    content {
+      name  = "smtp-password"
+      value = var.staging_smtp_password
+    }
+  }
+
+  template {
+    container {
+      name    = "deadline-reminders"
+      image   = var.staging_backend_image
+      cpu     = 0.25
+      memory  = "0.5Gi"
+      command = ["python", "-m", "app.cli", "send-deadline-reminders"]
+
+      env {
+        name  = "ENVIRONMENT"
+        value = "staging"
+      }
+
+      env {
+        name  = "PROJECT_NAME"
+        value = var.project_name
+      }
+
+      env {
+        name  = "POSTGRES_SERVER"
+        value = var.staging_postgres_server
+      }
+
+      env {
+        name  = "POSTGRES_PORT"
+        value = tostring(var.staging_postgres_port)
+      }
+
+      env {
+        name  = "POSTGRES_USER"
+        value = var.staging_postgres_user
+      }
+
+      env {
+        name        = "POSTGRES_PASSWORD"
+        secret_name = "postgres-password"
+      }
+
+      env {
+        name  = "POSTGRES_DB"
+        value = var.staging_postgres_db
+      }
+
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+
+      env {
+        name  = "FRONTEND_HOST"
+        value = var.staging_frontend_url
+      }
+
+      env {
+        name  = "TRUSTED_PROXY_IPS"
+        value = "*"
+      }
+
+      dynamic "env" {
+        for_each = var.staging_smtp_host != "" ? [1] : []
+        content {
+          name  = "SMTP_HOST"
+          value = var.staging_smtp_host
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_smtp_user != "" ? [1] : []
+        content {
+          name  = "SMTP_USER"
+          value = var.staging_smtp_user
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_smtp_password != "" ? [1] : []
+        content {
+          name        = "SMTP_PASSWORD"
+          secret_name = "smtp-password"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_emails_from_email != "" ? [1] : []
+        content {
+          name  = "EMAILS_FROM_EMAIL"
+          value = var.staging_emails_from_email
+        }
+      }
+    }
+  }
+
+  tags = {
+    project     = "heimpath"
+    environment = "staging"
+  }
+}
+
 # ── Custom Domains ───────────────────────────
 
 resource "azurerm_container_app_custom_domain" "staging_frontend" {


### PR DESCRIPTION
## Summary

- Adds Azure Container App Jobs with cron triggers for the two CLI commands that were implemented but never executed in production
- Weekly digest job fires every Monday at 07:00 UTC (`send-weekly-digest`)
- Deadline reminders job fires daily at 08:00 UTC (`send-deadline-reminders`)
- Both jobs added to prod and staging environments following the existing migration job pattern
- Each job receives the full set of env vars needed: DB connection, SMTP config, and FRONTEND_HOST (for email unsubscribe links)
- Also fixes `translation_failed` missing from the Documents category in NotificationPreferences settings UI

## Test plan

- [ ] `terraform plan` shows 4 new resources: 2 scheduled jobs in prod, 2 in staging
- [ ] No existing resources are modified by the plan
- [ ] Frontend: Settings → Notifications shows "Translation Failed" row under Documents with in-app and email toggles
- [ ] TypeScript compiles clean (`bunx tsc --noEmit`)
- [ ] Pre-commit passes