### PR TITLE
feat(notifications): add full notification history page at /notifications

### DIFF
--- a/frontend/src/components/Notifications/NotificationBell.tsx
+++ b/frontend/src/components/Notifications/NotificationBell.tsx
@@ -1,17 +1,5 @@
 import { useNavigate } from "@tanstack/react-router"
-import {
-  AlertTriangle,
-  Bell,
-  Bookmark,
-  Calculator,
-  CheckCircle,
-  ChevronRight,
-  Clock,
-  CreditCard,
-  FileText,
-  Info,
-  XCircle,
-} from "lucide-react"
+import { Bell, ChevronRight } from "lucide-react"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
@@ -28,24 +16,8 @@ import {
   useMarkNotificationRead,
 } from "@/hooks/mutations/useNotificationMutations"
 import { useNotifications } from "@/hooks/queries/useNotificationQueries"
-import type { Notification, NotificationType } from "@/models/notification"
-
-// ***************************************************************************
-//                              Constants
-// ***************************************************************************
-
-const NOTIFICATION_ICONS: Record<NotificationType, typeof Bell> = {
-  step_completed: CheckCircle,
-  document_translated: FileText,
-  translation_failed: XCircle,
-  calculation_saved: Calculator,
-  law_bookmarked: Bookmark,
-  journey_deadline: Clock,
-  payment_reminder: CreditCard,
-  subscription_expiring: AlertTriangle,
-  system_announcement: Info,
-  weekly_digest: Bell,
-}
+import type { Notification } from "@/models/notification"
+import { getRelativeTime, NOTIFICATION_ICONS } from "./notificationUtils"
 
 // ***************************************************************************
 //                              Components
@@ -90,28 +62,6 @@ function NotificationItem({
       )}
     </DropdownMenuItem>
   )
-}
-
-// ***************************************************************************
-//                              Functions
-// ***************************************************************************
-
-function getRelativeTime(dateString: string): string {
-  const now = new Date()
-  const date = new Date(dateString)
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-
-  if (diffMins < 1) return "Just now"
-  if (diffMins < 60) return `${diffMins}m ago`
-
-  const diffHours = Math.floor(diffMins / 60)
-  if (diffHours < 24) return `${diffHours}h ago`
-
-  const diffDays = Math.floor(diffHours / 24)
-  if (diffDays < 7) return `${diffDays}d ago`
-
-  return date.toLocaleDateString()
 }
 
 // ***************************************************************************
@@ -193,6 +143,21 @@ function NotificationBell() {
             )}
           </div>
         </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <div className="p-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-center gap-1 text-xs text-muted-foreground"
+            onClick={() => {
+              setOpen(false)
+              navigate({ to: "/notifications" })
+            }}
+          >
+            View all notifications
+            <ChevronRight className="size-3" />
+          </Button>
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/frontend/src/components/Notifications/NotificationCenter.tsx
+++ b/frontend/src/components/Notifications/NotificationCenter.tsx
@@ -1,0 +1,254 @@
+/**
+ * Notification Center
+ * Full paginated notification history with filter tabs and bulk actions
+ */
+
+import { useNavigate } from "@tanstack/react-router"
+import { Bell, ChevronRight, Trash2 } from "lucide-react"
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  useDeleteNotification,
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+} from "@/hooks/mutations/useNotificationMutations"
+import { useNotifications } from "@/hooks/queries/useNotificationQueries"
+import type { Notification } from "@/models/notification"
+import { getRelativeTime, NOTIFICATION_ICONS } from "./notificationUtils"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const PAGE_SIZE = 20
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+interface INotificationRowProps {
+  notification: Notification
+}
+
+/** Single notification row with click-through, read indicator, and delete. */
+function NotificationRow({ notification }: INotificationRowProps) {
+  const navigate = useNavigate()
+  const markRead = useMarkNotificationRead()
+  const deleteNotification = useDeleteNotification()
+
+  const Icon = NOTIFICATION_ICONS[notification.type] ?? Bell
+
+  function handleClick() {
+    if (!notification.isRead) {
+      markRead.mutate(notification.id)
+    }
+    if (notification.actionUrl) {
+      navigate({ to: notification.actionUrl })
+    }
+  }
+
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation()
+    deleteNotification.mutate(notification.id)
+  }
+
+  const innerContent = (
+    <>
+      {!notification.isRead && (
+        <span className="absolute left-1.5 top-1/2 size-1.5 -translate-y-1/2 rounded-full bg-primary" />
+      )}
+      <Icon
+        className={`mt-0.5 size-5 shrink-0 ${
+          notification.isRead ? "text-muted-foreground" : "text-primary"
+        }`}
+      />
+      <div className="min-w-0 flex-1">
+        <p
+          className={`text-sm leading-snug ${
+            notification.isRead ? "text-muted-foreground" : "font-medium"
+          }`}
+        >
+          {notification.title}
+        </p>
+        <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+          {notification.message}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground/60">
+          {getRelativeTime(notification.createdAt)}
+        </p>
+      </div>
+      <div className="ml-2 flex shrink-0 items-center gap-1">
+        {notification.actionUrl && (
+          <ChevronRight className="size-4 text-muted-foreground/40 opacity-0 transition-opacity group-hover:opacity-100" />
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7 text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+          title="Delete notification"
+          aria-label="Delete notification"
+          onClick={handleDelete}
+        >
+          <Trash2 className="size-3.5" />
+        </Button>
+      </div>
+    </>
+  )
+
+  if (notification.actionUrl) {
+    return (
+      <button
+        type="button"
+        className="group relative flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+        onClick={handleClick}
+      >
+        {innerContent}
+      </button>
+    )
+  }
+
+  return (
+    <div className="group relative flex items-start gap-3 px-4 py-3 transition-colors hover:bg-muted/30">
+      {innerContent}
+    </div>
+  )
+}
+
+/** Default component. Paginated notification history with filter tabs. */
+function NotificationCenter() {
+  const [unreadOnly, setUnreadOnly] = useState(false)
+  const [page, setPage] = useState(0)
+
+  const offset = page * PAGE_SIZE
+  const { data, isLoading, isError } = useNotifications(
+    PAGE_SIZE,
+    offset,
+    unreadOnly,
+  )
+  const markAllRead = useMarkAllNotificationsRead()
+
+  const notifications = data?.data ?? []
+  const totalCount = data?.count ?? 0
+  const unreadCount = data?.unreadCount ?? 0
+  const hasNextPage = offset + PAGE_SIZE < totalCount
+  const hasPrevPage = page > 0
+
+  function handleTabChange(value: string) {
+    setUnreadOnly(value === "unread")
+    setPage(0)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-1">
+        {["sk-1", "sk-2", "sk-3", "sk-4", "sk-5"].map((id) => (
+          <div key={id} className="flex items-start gap-3 px-4 py-3">
+            <Skeleton className="mt-0.5 size-5 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-center">
+        <p className="text-sm text-destructive">
+          Failed to load notifications. Please try again later.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Tabs defaultValue="all" onValueChange={handleTabChange}>
+          <TabsList>
+            <TabsTrigger value="all">All</TabsTrigger>
+            <TabsTrigger value="unread">
+              Unread
+              {unreadCount > 0 && (
+                <span className="ml-1.5 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-bold text-primary-foreground">
+                  {unreadCount}
+                </span>
+              )}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {unreadCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs"
+            onClick={() => markAllRead.mutate()}
+          >
+            Mark all read
+          </Button>
+        )}
+      </div>
+
+      {notifications.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed py-16 text-center">
+          <Bell className="size-10 text-muted-foreground/40" />
+          <div>
+            <p className="font-medium text-muted-foreground">
+              {unreadOnly ? "No unread notifications" : "No notifications yet"}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground/70">
+              {unreadOnly
+                ? "You're all caught up!"
+                : "Notifications will appear here as you use HeimPath."}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="divide-y rounded-lg border">
+          {notifications.map((notification) => (
+            <NotificationRow
+              key={notification.id}
+              notification={notification}
+            />
+          ))}
+        </div>
+      )}
+
+      {(hasPrevPage || hasNextPage) && (
+        <div className="flex items-center justify-between pt-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasPrevPage}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            Previous
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            {offset + 1}–{Math.min(offset + PAGE_SIZE, totalCount)} of{" "}
+            {totalCount}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasNextPage}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { NotificationCenter }

--- a/frontend/src/components/Notifications/notificationUtils.ts
+++ b/frontend/src/components/Notifications/notificationUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared utilities for notification components
+ */
+
+import {
+  AlertTriangle,
+  Bell,
+  Bookmark,
+  Calculator,
+  CheckCircle,
+  Clock,
+  CreditCard,
+  FileText,
+  Info,
+  XCircle,
+} from "lucide-react"
+import type { NotificationType } from "@/models/notification"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+export const NOTIFICATION_ICONS: Record<NotificationType, typeof Bell> = {
+  step_completed: CheckCircle,
+  document_translated: FileText,
+  translation_failed: XCircle,
+  calculation_saved: Calculator,
+  law_bookmarked: Bookmark,
+  journey_deadline: Clock,
+  payment_reminder: CreditCard,
+  subscription_expiring: AlertTriangle,
+  system_announcement: Info,
+  weekly_digest: Bell,
+}
+
+/******************************************************************************
+                              Functions
+******************************************************************************/
+
+export function getRelativeTime(dateString: string): string {
+  const now = new Date()
+  const date = new Date(dateString)
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+
+  if (diffMins < 1) return "Just now"
+  if (diffMins < 60) return `${diffMins}m ago`
+
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 7) return `${diffDays}d ago`
+
+  return date.toLocaleDateString()
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as ToolsPropertyCostCalculatorRouteImport } from './routes/tools/
 import { Route as ToolsMortgageCalculatorRouteImport } from './routes/tools/mortgage-calculator'
 import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutSearchRouteImport } from './routes/_layout/search'
+import { Route as LayoutNotificationsRouteImport } from './routes/_layout/notifications'
 import { Route as LayoutDashboardRouteImport } from './routes/_layout/dashboard'
 import { Route as LayoutContractExplainerRouteImport } from './routes/_layout/contract-explainer'
 import { Route as LayoutCalculatorsRouteImport } from './routes/_layout/calculators'
@@ -139,6 +140,11 @@ const LayoutSettingsRoute = LayoutSettingsRouteImport.update({
 const LayoutSearchRoute = LayoutSearchRouteImport.update({
   id: '/search',
   path: '/search',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutNotificationsRoute = LayoutNotificationsRouteImport.update({
+  id: '/notifications',
+  path: '/notifications',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutDashboardRoute = LayoutDashboardRouteImport.update({
@@ -279,6 +285,7 @@ export interface FileRoutesByFullPath {
   '/calculators': typeof LayoutCalculatorsRoute
   '/contract-explainer': typeof LayoutContractExplainerRoute
   '/dashboard': typeof LayoutDashboardRoute
+  '/notifications': typeof LayoutNotificationsRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
   '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
@@ -320,6 +327,7 @@ export interface FileRoutesByTo {
   '/calculators': typeof LayoutCalculatorsRoute
   '/contract-explainer': typeof LayoutContractExplainerRoute
   '/dashboard': typeof LayoutDashboardRoute
+  '/notifications': typeof LayoutNotificationsRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
   '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
@@ -363,6 +371,7 @@ export interface FileRoutesById {
   '/_layout/calculators': typeof LayoutCalculatorsRoute
   '/_layout/contract-explainer': typeof LayoutContractExplainerRoute
   '/_layout/dashboard': typeof LayoutDashboardRoute
+  '/_layout/notifications': typeof LayoutNotificationsRoute
   '/_layout/search': typeof LayoutSearchRoute
   '/_layout/settings': typeof LayoutSettingsRoute
   '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
@@ -407,6 +416,7 @@ export interface FileRouteTypes {
     | '/calculators'
     | '/contract-explainer'
     | '/dashboard'
+    | '/notifications'
     | '/search'
     | '/settings'
     | '/tools/mortgage-calculator'
@@ -448,6 +458,7 @@ export interface FileRouteTypes {
     | '/calculators'
     | '/contract-explainer'
     | '/dashboard'
+    | '/notifications'
     | '/search'
     | '/settings'
     | '/tools/mortgage-calculator'
@@ -490,6 +501,7 @@ export interface FileRouteTypes {
     | '/_layout/calculators'
     | '/_layout/contract-explainer'
     | '/_layout/dashboard'
+    | '/_layout/notifications'
     | '/_layout/search'
     | '/_layout/settings'
     | '/tools/mortgage-calculator'
@@ -659,6 +671,13 @@ declare module '@tanstack/react-router' {
       path: '/search'
       fullPath: '/search'
       preLoaderRoute: typeof LayoutSearchRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/notifications': {
+      id: '/_layout/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
+      preLoaderRoute: typeof LayoutNotificationsRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/dashboard': {
@@ -847,6 +866,7 @@ interface LayoutRouteChildren {
   LayoutCalculatorsRoute: typeof LayoutCalculatorsRoute
   LayoutContractExplainerRoute: typeof LayoutContractExplainerRoute
   LayoutDashboardRoute: typeof LayoutDashboardRoute
+  LayoutNotificationsRoute: typeof LayoutNotificationsRoute
   LayoutSearchRoute: typeof LayoutSearchRoute
   LayoutSettingsRoute: typeof LayoutSettingsRoute
   LayoutArticlesSlugRoute: typeof LayoutArticlesSlugRoute
@@ -872,6 +892,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutCalculatorsRoute: LayoutCalculatorsRoute,
   LayoutContractExplainerRoute: LayoutContractExplainerRoute,
   LayoutDashboardRoute: LayoutDashboardRoute,
+  LayoutNotificationsRoute: LayoutNotificationsRoute,
   LayoutSearchRoute: LayoutSearchRoute,
   LayoutSettingsRoute: LayoutSettingsRoute,
   LayoutArticlesSlugRoute: LayoutArticlesSlugRoute,

--- a/frontend/src/routes/_layout/notifications.tsx
+++ b/frontend/src/routes/_layout/notifications.tsx
@@ -1,0 +1,58 @@
+/**
+ * Notifications Page
+ * Full notification history at /notifications
+ */
+
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Settings } from "lucide-react"
+import { NotificationCenter } from "@/components/Notifications/NotificationCenter"
+import { Button } from "@/components/ui/button"
+
+/******************************************************************************
+                              Route
+******************************************************************************/
+
+export const Route = createFileRoute("/_layout/notifications")({
+  component: NotificationsPage,
+  head: () => ({
+    meta: [{ title: "Notifications - HeimPath" }],
+  }),
+})
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Notifications history page. */
+function NotificationsPage() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Notifications</h1>
+          <p className="text-sm text-muted-foreground">
+            Your full notification history
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          asChild
+          title="Notification settings"
+        >
+          <Link to="/settings">
+            <Settings className="size-5" />
+          </Link>
+        </Button>
+      </div>
+
+      <NotificationCenter />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default NotificationsPage


### PR DESCRIPTION
## Summary
- Add `NotificationCenter` component with paginated notification list, All/Unread tabs, bulk mark-all-read, and per-item delete
- Add `/notifications` route rendering the full history with a settings gear link
- Add "View all notifications" link to the `NotificationBell` dropdown footer

## Test plan
- [ ] Bell dropdown shows "View all notifications" button at the bottom
- [ ] Clicking it closes the dropdown and navigates to `/notifications`
- [ ] `/notifications` page renders with All/Unread tabs
- [ ] Unread tab shows only unread items; badge count matches
- [ ] Clicking a row with `actionUrl` marks it read and navigates
- [ ] Clicking a row without `actionUrl` does nothing (no cursor-pointer)
- [ ] Delete button (hover-reveal) removes the notification
- [ ] "Mark all read" button clears all unread badges
- [ ] Pagination Previous/Next works; page range label is correct
- [ ] Empty state shown when no notifications match current filter
- [ ] Loading skeletons shown on initial fetch
- [ ] Error state shown when API is unreachable