### PR TITLE
feat(journey): add mortgage guidance and partner referral cards

### DIFF
--- a/frontend/src/components/Journey/StepContent/MortgageComparison.tsx
+++ b/frontend/src/components/Journey/StepContent/MortgageComparison.tsx
@@ -1,0 +1,74 @@
+/**
+ * Mortgage Comparison Step Content
+ * Guidance for comparing mortgage offers from multiple lenders
+ */
+
+import {
+  ArrowDownUp,
+  Calculator,
+  CalendarClock,
+  FileSearch,
+  Repeat2,
+} from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function MortgageComparison(_props: Readonly<IProps>) {
+  return (
+    <GuidanceCard
+      title="Compare Mortgage Offers"
+      description="Once you have offers from multiple lenders, compare them carefully before committing. The best headline rate is rarely the best overall deal."
+      items={[
+        {
+          icon: Calculator,
+          label: "Effektivzins — the Only Fair Comparison Metric",
+          detail:
+            "Always compare the Effektivzins (APRC), not the Sollzins. The APRC includes all mandatory fees and gives a true cost-per-year figure. German banks must disclose it by law.",
+        },
+        {
+          icon: CalendarClock,
+          label: "Zinsbindungsfrist (Fixed-Rate Period)",
+          detail:
+            "German mortgages typically fix the rate for 5–20 years. Longer fixes (15–20 yrs) provide stability but cost more. Shorter periods (10 yrs) work if you expect rates to fall or plan to sell.",
+        },
+        {
+          icon: ArrowDownUp,
+          label: "Tilgungsrate (Repayment Rate)",
+          detail:
+            "The minimum is often 1%, but 2–3% is recommended. Higher initial repayment means less total interest and faster equity build-up — use the amortisation calculator to model this.",
+        },
+        {
+          icon: Repeat2,
+          label: "Sondertilgung & Anschlussfinanzierung",
+          detail:
+            "Check: annual overpayment allowance (target 5–10%), costs to exit early, and whether the bank offers a follow-on rate (Anschlussfinanzierung) for when the fixed period ends.",
+        },
+        {
+          icon: FileSearch,
+          label: "ESIS — European Standard Information Sheet",
+          detail:
+            "Every lender must provide a standardised ESIS document. Request it from all lenders and use it for a like-for-like comparison before signing any offer.",
+        },
+      ]}
+      tip="Run the Mortgage Amortisation Calculator with each offer's rate and repayment to see the exact total cost over time. Small differences compound significantly over 20+ years."
+      ctaLabel="Open Amortisation Calculator"
+      ctaHref="/calculators"
+      ctaSearch={{ tab: "amortisation" }}
+    />
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { MortgageComparison }

--- a/frontend/src/components/Journey/StepContent/MortgagePreapproval.tsx
+++ b/frontend/src/components/Journey/StepContent/MortgagePreapproval.tsx
@@ -1,0 +1,78 @@
+/**
+ * Mortgage Preapproval Step Content
+ * Guidance for getting a mortgage pre-approval in Germany
+ */
+
+import { BadgeCheck, Building2, FileText, Scale, Wallet } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+import { PartnerReferralBanner } from "./PartnerReferralBanner"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function MortgagePreapproval(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-3">
+      <GuidanceCard
+        title="Get Mortgage Pre-Approval"
+        description="A Finanzierungszusage (pre-approval) from a bank shows sellers you are a serious buyer and lets you move quickly when you find the right property."
+        items={[
+          {
+            icon: FileText,
+            label: "Prepare Your Documents",
+            detail:
+              "Banks require: last 3 salary slips, 2 years of tax returns, 3 months of bank statements, employment contract, passport, and proof of equity (savings account statement).",
+          },
+          {
+            icon: Scale,
+            label: "Understand Key Loan Terms",
+            detail:
+              "Sollzins is the nominal interest rate; Effektivzins (APRC) includes all fees and is the fair comparison metric. Tilgungsrate (repayment rate) — aim for at least 2% initially.",
+          },
+          {
+            icon: Building2,
+            label: "Approach Multiple Lenders",
+            detail:
+              "Compare at least 3–4 offers: local Sparkasse, Volksbank, and online brokers. Submit all applications within 14 days — SCHUFA treats clustered queries as a single inquiry.",
+          },
+          {
+            icon: BadgeCheck,
+            label: "Sondertilgungsrecht (Overpayment Right)",
+            detail:
+              "Negotiate the right to repay 5–10% of the original loan annually without penalty. This significantly reduces your total interest cost over the loan term.",
+          },
+          {
+            icon: Wallet,
+            label: "Non-Citizen Considerations",
+            detail:
+              "Without a German employment history, you may need a larger deposit (30–40%) and be required to provide an Aufenthaltstitel (residence permit). Some online brokers specialise in expat cases.",
+          },
+        ]}
+        tip="Pre-approval is not a binding commitment — you can still negotiate with multiple banks simultaneously. Use the Mortgage Calculator to model different repayment scenarios first."
+        ctaLabel="Open Mortgage Calculator"
+        ctaHref="/calculators"
+        ctaSearch={{ tab: "mortgage" }}
+      />
+
+      <PartnerReferralBanner
+        partnerName="Hypofriend"
+        description="Hypofriend specialises in mortgage pre-approval for expats and foreign buyers in Germany — available in English with dedicated advisors."
+        ctaLabel="Visit Hypofriend"
+        href="https://www.hypofriend.de"
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { MortgagePreapproval }

--- a/frontend/src/components/Journey/StepContent/OwnershipManagement.tsx
+++ b/frontend/src/components/Journey/StepContent/OwnershipManagement.tsx
@@ -14,6 +14,7 @@ import {
 
 import type { JourneyStep } from "@/models/journey"
 import { GuidanceCard } from "./GuidanceCard"
+import { PartnerReferralBanner } from "./PartnerReferralBanner"
 
 interface IProps {
   step: JourneyStep
@@ -74,6 +75,13 @@ function OwnershipManagement(_props: Readonly<IProps>) {
               "Schedule an annual Heizungswartung (heating system maintenance). It's legally required for gas systems and keeps your system efficient.",
           },
         ]}
+      />
+
+      <PartnerReferralBanner
+        partnerName="Myhammer"
+        description="Find English-speaking, vetted tradespeople across Germany on Myhammer — post your job, get quotes, and read verified reviews from other homeowners."
+        ctaLabel="Find a Handwerker"
+        href="https://www.myhammer.de"
       />
     </div>
   )

--- a/frontend/src/components/Journey/StepContent/PartnerReferralBanner.tsx
+++ b/frontend/src/components/Journey/StepContent/PartnerReferralBanner.tsx
@@ -1,0 +1,49 @@
+/**
+ * Partner Referral Banner
+ * Reusable inline referral card for contextual partner recommendations
+ */
+
+import { ExternalLink } from "lucide-react"
+
+interface IProps {
+  partnerName: string
+  description: string
+  ctaLabel: string
+  href: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Inline blue banner that contextually recommends a partner service. */
+function PartnerReferralBanner({
+  partnerName,
+  description,
+  ctaLabel,
+  href,
+}: Readonly<IProps>) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-800/40 dark:bg-blue-950/20">
+      <p className="text-sm text-blue-800 dark:text-blue-300">
+        <span className="font-medium">Partner tip:</span> {description}
+      </p>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Visit ${partnerName} (opens in new tab)`}
+        className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-blue-700 hover:underline dark:text-blue-400"
+      >
+        {ctaLabel}
+        <ExternalLink className="h-3 w-3" />
+      </a>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { PartnerReferralBanner }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -19,6 +19,8 @@ import { ProgressBar } from "../ProgressBar"
 import { TaskCheckbox } from "../TaskCheckbox"
 import { FinanceCheck } from "./FinanceCheck"
 import { MarketInsights } from "./MarketInsights"
+import { MortgageComparison } from "./MortgageComparison"
+import { MortgagePreapproval } from "./MortgagePreapproval"
 import { OwnershipInsurance } from "./OwnershipInsurance"
 import { OwnershipManagement } from "./OwnershipManagement"
 import { OwnershipRegistration } from "./OwnershipRegistration"
@@ -61,6 +63,8 @@ const STEP_CONTENT_REGISTRY: Record<
   (props: IStepContentProps) => ReactNode
 > = {
   finance_check: (p) => <FinanceCheck step={p.step} />,
+  mortgage_preapproval: (p) => <MortgagePreapproval step={p.step} />,
+  mortgage_comparison: (p) => <MortgageComparison step={p.step} />,
   research_goals: (p) => (
     <PropertyGoalsForm
       journeyId={p.journeyId}


### PR DESCRIPTION
## Summary
- Add `MortgagePreapproval.tsx` step content for `mortgage_preapproval` journey step — 5-item guidance card covering document prep, loan terms, lender comparison, Sondertilgungsrecht, and non-citizen considerations; includes a Hypofriend partner referral for expat-friendly pre-approval
- Add `MortgageComparison.tsx` step content for `mortgage_comparison` journey step — covers Effektivzins, Zinsbindungsfrist, Tilgungsrate, Sondertilgung, and ESIS document comparison
- Register both new components in `StepBody` content registry
- Add Myhammer partner referral card to `OwnershipManagement` step — helps buyers find English-speaking vetted tradespeople post-purchase

## Test plan
- [ ] Open a journey with mortgage financing — step 7 (Get Mortgage Pre-Approval) now renders the guidance card with Hypofriend referral
- [ ] Step 8 (Compare Mortgage Offers) renders the comparison guidance card
- [ ] Ownership management step shows Myhammer referral card at the bottom
- [ ] All three external links open in new tab with `noopener noreferrer`
- [ ] Internal CTA links navigate correctly within the app
- [ ] Dark mode styling matches blue referral banner pattern