### PR TITLE
fix(nav): correct broken calculator tab deep-links

### DIFF
--- a/frontend/src/components/Journey/StepContent/MortgageComparison.tsx
+++ b/frontend/src/components/Journey/StepContent/MortgageComparison.tsx
@@ -62,7 +62,7 @@ function MortgageComparison(_props: Readonly<IProps>) {
       tip="Run the Mortgage Amortisation Calculator with each offer's rate and repayment to see the exact total cost over time. Small differences compound significantly over 20+ years."
       ctaLabel="Open Amortisation Calculator"
       ctaHref="/calculators"
-      ctaSearch={{ tab: "amortisation" }}
+      ctaSearch={{ tab: "mortgage" }}
     />
   )
 }

--- a/frontend/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/frontend/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -53,7 +53,7 @@ const CHECKLIST_ITEMS: ReadonlyArray<ChecklistItem> = [
     label: "Calculate hidden costs",
     icon: Calculator,
     to: "/calculators",
-    search: { tab: "hidden-costs" },
+    search: { tab: "costs" },
   },
   {
     id: "document",

--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -118,7 +118,7 @@ const PRIORITY_CONFIG: Record<
 > = {
   understand_costs: {
     route: "/calculators",
-    search: { tab: "hidden-costs" },
+    search: { tab: "costs" },
     cta: "Calculate Hidden Costs",
     detail:
       "Use our Hidden Costs Calculator to see the real total cost of buying property in any German state — including taxes, notary fees, and agent commissions.",

--- a/frontend/src/routes/_layout/calculators.tsx
+++ b/frontend/src/routes/_layout/calculators.tsx
@@ -384,6 +384,8 @@ const TAB_ALIASES: Record<string, string> = {
   financing: "eligibility",
   "rent-estimate": "rent-analyser",
   "rent-ceiling": "rent-analyser",
+  "hidden-costs": "costs",
+  amortisation: "mortgage",
 }
 
 /** Default component. Calculators page with grouped card grid navigation. */


### PR DESCRIPTION
## Summary

- `MortgageComparison`: CTA was using `tab: "amortisation"` which is not a valid tab key — corrected to `"mortgage"`
- `OnboardingWizard`: priority config was using `tab: "hidden-costs"` which is not a valid tab key — corrected to `"costs"`
- `GettingStartedChecklist`: same `"hidden-costs"` bug — corrected to `"costs"`
- `calculators.tsx` `TAB_ALIASES`: added `"hidden-costs" → "costs"` and `"amortisation" → "mortgage"` as backward-compatible fallbacks so any existing shared links still resolve correctly

## Test plan

- [ ] Navigate to the journey `mortgage_comparison` step — "Open Amortisation Calculator" CTA opens the Mortgage Amortisation calculator directly
- [ ] Complete onboarding wizard with "Understand Costs" priority — lands on the Hidden Costs calculator (`/calculators?tab=costs`)
- [ ] Dashboard "Getting Started" checklist — "Calculate hidden costs" item links correctly to `/calculators?tab=costs`
- [ ] Deep-link `/calculators?tab=hidden-costs` still resolves to the Hidden Costs calculator via the alias
- [ ] Deep-link `/calculators?tab=amortisation` still resolves to the Mortgage calculator via the alias