### PR TITLE
fix(nav): add dashboard link for logged-in users and fix admin error

### DIFF
--- a/frontend/src/components/Landing/LandingHeader.tsx
+++ b/frontend/src/components/Landing/LandingHeader.tsx
@@ -22,7 +22,12 @@ function LandingHeader() {
         <div className="flex items-center gap-2">
           <Appearance />
           {authenticated ? (
-            <NavUserMenu />
+            <>
+              <Button variant="outline" size="sm" asChild>
+                <Link to="/dashboard">Go to Dashboard</Link>
+              </Button>
+              <NavUserMenu />
+            </>
           ) : (
             <>
               <Button variant="ghost" size="sm" asChild>

--- a/frontend/src/routes/_layout/admin.tsx
+++ b/frontend/src/routes/_layout/admin.tsx
@@ -21,14 +21,29 @@ function getUsersQueryOptions() {
   }
 }
 
+function AdminErrorFallback() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 gap-3">
+      <p className="text-lg font-semibold">Failed to load admin panel</p>
+      <p className="text-sm text-muted-foreground">
+        Please refresh the page. If the problem persists, contact support.
+      </p>
+    </div>
+  )
+}
+
 export const Route = createFileRoute("/_layout/admin")({
   component: Admin,
+  errorComponent: AdminErrorFallback,
   beforeLoad: async () => {
-    const user = await UsersService.readUserMe()
+    let user: UserPublic
+    try {
+      user = await UsersService.readUserMe()
+    } catch {
+      throw redirect({ to: "/dashboard" })
+    }
     if (!user.is_superuser) {
-      throw redirect({
-        to: "/dashboard",
-      })
+      throw redirect({ to: "/dashboard" })
     }
   },
   head: () => ({


### PR DESCRIPTION
## Summary

- **Landing page:** Adds a "Go to Dashboard" outline button in the header when a user is already authenticated, so they can navigate directly to the app without going through the user menu
- **Admin page — `beforeLoad` error:** The `readUserMe()` call was unhandled; any API or network failure would throw to the root `ErrorComponent` ("Something went wrong"). Wrapped in try-catch: failures now redirect to `/dashboard` gracefully
- **Admin page — render error:** Added a route-level `errorComponent` (`AdminErrorFallback`) so errors during rendering (e.g. `useSuspenseQuery` failures in `UsersTableContent`) display a friendly inline message within the layout instead of the full-page error screen

## Test plan

- [ ] Visit landing page while logged in — header shows "Go to Dashboard" button that navigates to `/dashboard`
- [ ] Visit landing page while logged out — header shows "Log In" and "Get Started" as before
- [ ] Navigate to `/admin` as a superuser — admin panel loads correctly
- [ ] Navigate to `/admin` as a non-superuser — redirected to `/dashboard`
- [ ] Simulate API error in `readUserMe()` while navigating to `/admin` — redirected to `/dashboard` instead of showing error page