### PR TITLE
fix(admin): make admin page mobile responsive

### DIFF
--- a/frontend/src/components/Admin/ArticlesAdmin.tsx
+++ b/frontend/src/components/Admin/ArticlesAdmin.tsx
@@ -137,7 +137,7 @@ function ArticleFormDialog({
             <Label>Title *</Label>
             <Input {...register("title", { required: true })} />
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label>Slug *</Label>
               <Input
@@ -150,7 +150,7 @@ function ArticleFormDialog({
               <Input {...register("authorName", { required: true })} />
             </div>
           </div>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <div className="space-y-1">
               <Label>Category *</Label>
               <Select
@@ -295,7 +295,7 @@ function ArticlesAdmin() {
           Add Article
         </Button>
       </div>
-      <div className="rounded-md border">
+      <div className="overflow-x-auto rounded-md border">
         <table className="w-full text-sm">
           <thead className="border-b bg-muted/50">
             <tr>

--- a/frontend/src/components/Admin/GlossaryAdmin.tsx
+++ b/frontend/src/components/Admin/GlossaryAdmin.tsx
@@ -112,7 +112,7 @@ function GlossaryFormDialog({
           <DialogTitle>{editTerm ? "Edit Term" : "Add Term"}</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4 py-2">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label>Term (German) *</Label>
               <Input
@@ -128,7 +128,7 @@ function GlossaryFormDialog({
               />
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label>Slug *</Label>
               <Input
@@ -236,7 +236,7 @@ function GlossaryAdmin() {
           Add Term
         </Button>
       </div>
-      <div className="rounded-md border">
+      <div className="overflow-x-auto rounded-md border">
         <table className="w-full text-sm">
           <thead className="border-b bg-muted/50">
             <tr>

--- a/frontend/src/components/Admin/LawsAdmin.tsx
+++ b/frontend/src/components/Admin/LawsAdmin.tsx
@@ -120,7 +120,7 @@ function LawFormDialog({
           <DialogTitle>{editLaw ? "Edit Law" : "Add Law"}</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4 py-2">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label>Citation *</Label>
               <Input
@@ -267,7 +267,7 @@ function LawsAdmin() {
           Add Law
         </Button>
       </div>
-      <div className="rounded-md border">
+      <div className="overflow-x-auto rounded-md border">
         <table className="w-full text-sm">
           <thead className="border-b bg-muted/50">
             <tr>

--- a/frontend/src/components/Admin/ProfessionalsAdmin.tsx
+++ b/frontend/src/components/Admin/ProfessionalsAdmin.tsx
@@ -128,7 +128,7 @@ function ProfessionalFormDialog({
             <Label>Name *</Label>
             <Input {...register("name", { required: true })} />
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label>Type *</Label>
               <Select
@@ -168,7 +168,7 @@ function ProfessionalFormDialog({
             <Label>Description</Label>
             <Textarea rows={3} {...register("description")} />
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="space-y-1">
               <Label>Email</Label>
               <Input type="email" {...register("email")} />
@@ -261,7 +261,7 @@ function ProfessionalsAdmin() {
           Add Professional
         </Button>
       </div>
-      <div className="rounded-md border">
+      <div className="overflow-x-auto rounded-md border">
         <table className="w-full text-sm">
           <thead className="border-b bg-muted/50">
             <tr>

--- a/frontend/src/components/Common/DataTable.tsx
+++ b/frontend/src/components/Common/DataTable.tsx
@@ -47,48 +47,53 @@ export function DataTable<TData, TValue>({
 
   return (
     <div className="flex flex-col gap-4">
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id} className="hover:bg-transparent">
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                )
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows.length ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id} className="hover:bg-transparent">
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  )
+                })}
               </TableRow>
-            ))
-          ) : (
-            <TableRow className="hover:bg-transparent">
-              <TableCell
-                colSpan={columns.length}
-                className="h-32 text-center text-muted-foreground"
-              >
-                No results found.
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow className="hover:bg-transparent">
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-32 text-center text-muted-foreground"
+                >
+                  No results found.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
 
       {table.getPageCount() > 1 && (
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 border-t bg-muted/20">

--- a/frontend/src/routes/_layout/admin.tsx
+++ b/frontend/src/routes/_layout/admin.tsx
@@ -83,13 +83,15 @@ function Admin() {
         <p className="text-muted-foreground">Manage users and content</p>
       </div>
       <Tabs defaultValue="users">
-        <TabsList>
-          <TabsTrigger value="users">Users</TabsTrigger>
-          <TabsTrigger value="laws">Laws</TabsTrigger>
-          <TabsTrigger value="glossary">Glossary</TabsTrigger>
-          <TabsTrigger value="articles">Articles</TabsTrigger>
-          <TabsTrigger value="professionals">Professionals</TabsTrigger>
-        </TabsList>
+        <div className="overflow-x-auto">
+          <TabsList className="w-max">
+            <TabsTrigger value="users">Users</TabsTrigger>
+            <TabsTrigger value="laws">Laws</TabsTrigger>
+            <TabsTrigger value="glossary">Glossary</TabsTrigger>
+            <TabsTrigger value="articles">Articles</TabsTrigger>
+            <TabsTrigger value="professionals">Professionals</TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="users" className="mt-6">
           <div className="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary

- **Tabs overflow** (`admin.tsx`): wrapped `TabsList` in `overflow-x-auto` so the 5 admin tabs scroll horizontally on narrow viewports instead of breaking the layout
- **Users table** (`DataTable.tsx`): wrapped `<Table>` in `overflow-x-auto` so the users data table scrolls horizontally on mobile
- **Content tables** (`LawsAdmin`, `GlossaryAdmin`, `ArticlesAdmin`, `ProfessionalsAdmin`): added `overflow-x-auto` to all four `<table>` container divs
- **Form dialog grids** (all four admin components): changed fixed `grid-cols-2`/`grid-cols-3` to `grid-cols-1` on mobile with `sm:grid-cols-2`/`sm:grid-cols-3` breakpoints so form fields stack vertically on small screens

## Test plan

- [ ] Open admin page on a mobile viewport (375px) — tabs row scrolls horizontally, all 5 tabs accessible
- [ ] Users tab — table scrolls horizontally if content is wider than viewport
- [ ] Laws / Glossary / Articles / Professionals tabs — tables scroll horizontally on mobile
- [ ] Open any "Add/Edit" dialog on mobile — form fields stack in a single column
- [ ] Desktop layout unchanged — all grids revert to 2/3 columns at sm breakpoint