### PR TITLE
security: add CSP, HSTS, and Permissions-Policy headers to nginx

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -5,6 +5,9 @@ server {
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-XSS-Protection "1; mode=block" always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+  add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=()" always;
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://*.sentry.io https://api.cognitive.microsofttranslator.com https://heimpath-translator.cognitiveservices.azure.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none';" always;
 
   # Proxy /api/ to the backend so the browser sees one origin and cookies
   # (logged_in, access_token) are set on the frontend domain — making them

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,12 @@ import { defineConfig } from "vite"
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    // Disable Vite's inline modulepreload polyfill so it doesn't violate
+    // the `script-src 'self'` CSP directive (the polyfill is only needed
+    // for browsers that are >3 years old and no longer in our support matrix).
+    modulePreload: { polyfill: false },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- Adds `Content-Security-Policy` header restricting scripts, styles, images, and connect sources to self + Sentry and Azure Translator endpoints
- Adds `Strict-Transport-Security` (HSTS) with 1-year max-age and includeSubDomains to enforce HTTPS
- Adds `Permissions-Policy` to disable unused browser APIs (camera, microphone, geolocation, payment, USB)

Closes tasks #186 and #190 from the QA security audit (April 2026).

## CSP policy breakdown
| Directive | Value | Rationale |
|-----------|-------|-----------|
| `default-src` | `'self'` | Base fallback — only self allowed |
| `script-src` | `'self'` | Vite bundle served from self; no inline scripts |
| `style-src` | `'self' 'unsafe-inline'` | Tailwind + Radix UI use inline styles |
| `img-src` | `'self' data:` | Avatars via API proxy; data: for base64 |
| `font-src` | `'self'` | No external font CDN |
| `connect-src` | `'self' https://*.sentry.io https://api.cognitive.microsofttranslator.com https://heimpath-translator.cognitiveservices.azure.com` | API + Sentry telemetry + Azure Translator |
| `frame-ancestors` | `'self'` | Consistent with X-Frame-Options: SAMEORIGIN |
| `base-uri` | `'self'` | Prevent base tag injection |
| `form-action` | `'self'` | Forms only submit to self |
| `object-src` | `'none'` | No plugins |

## Test plan
- [ ] Deploy to staging and run `curl -I https://staging.heimpath.com | grep -i content-security-policy`
- [ ] Verify all app pages still load without CSP violations in browser console
- [ ] Verify `Strict-Transport-Security` header is present
- [ ] Verify `Permissions-Policy` header is present