### PR TITLE
fix(admin): hide secondary columns on mobile to prevent table overflow

### DIFF
--- a/frontend/src/components/Admin/ArticlesAdmin.tsx
+++ b/frontend/src/components/Admin/ArticlesAdmin.tsx
@@ -300,8 +300,12 @@ function ArticlesAdmin() {
           <thead className="border-b bg-muted/50">
             <tr>
               <th className="px-4 py-3 text-left font-medium">Title</th>
-              <th className="px-4 py-3 text-left font-medium">Category</th>
-              <th className="px-4 py-3 text-left font-medium">Difficulty</th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Category
+              </th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Difficulty
+              </th>
               <th className="px-4 py-3 text-left font-medium">Author</th>
               <th className="px-4 py-3 text-right font-medium">Actions</th>
             </tr>
@@ -325,10 +329,10 @@ function ArticlesAdmin() {
                   <td className="px-4 py-3 max-w-xs truncate font-medium">
                     {article.title}
                   </td>
-                  <td className="px-4 py-3 text-xs capitalize">
+                  <td className="hidden px-4 py-3 text-xs capitalize sm:table-cell">
                     {article.category.replace(/_/g, " ")}
                   </td>
-                  <td className="px-4 py-3">
+                  <td className="hidden px-4 py-3 sm:table-cell">
                     <Badge
                       variant={
                         DIFFICULTY_VARIANT[article.difficultyLevel] ?? "outline"

--- a/frontend/src/components/Admin/GlossaryAdmin.tsx
+++ b/frontend/src/components/Admin/GlossaryAdmin.tsx
@@ -242,8 +242,12 @@ function GlossaryAdmin() {
             <tr>
               <th className="px-4 py-3 text-left font-medium">Term (DE)</th>
               <th className="px-4 py-3 text-left font-medium">Term (EN)</th>
-              <th className="px-4 py-3 text-left font-medium">Slug</th>
-              <th className="px-4 py-3 text-left font-medium">Category</th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Slug
+              </th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Category
+              </th>
               <th className="px-4 py-3 text-right font-medium">Actions</th>
             </tr>
           </thead>
@@ -265,10 +269,10 @@ function GlossaryAdmin() {
                 >
                   <td className="px-4 py-3 font-medium">{term.termDe}</td>
                   <td className="px-4 py-3">{term.termEn}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                  <td className="hidden px-4 py-3 font-mono text-xs text-muted-foreground sm:table-cell">
                     {term.slug}
                   </td>
-                  <td className="px-4 py-3 text-xs capitalize">
+                  <td className="hidden px-4 py-3 text-xs capitalize sm:table-cell">
                     {term.category.replace(/_/g, " ")}
                   </td>
                   <td className="px-4 py-3 text-right">

--- a/frontend/src/components/Admin/LawsAdmin.tsx
+++ b/frontend/src/components/Admin/LawsAdmin.tsx
@@ -273,8 +273,12 @@ function LawsAdmin() {
             <tr>
               <th className="px-4 py-3 text-left font-medium">Citation</th>
               <th className="px-4 py-3 text-left font-medium">Title (EN)</th>
-              <th className="px-4 py-3 text-left font-medium">Category</th>
-              <th className="px-4 py-3 text-left font-medium">Type</th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Category
+              </th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Type
+              </th>
               <th className="px-4 py-3 text-right font-medium">Actions</th>
             </tr>
           </thead>
@@ -298,10 +302,10 @@ function LawsAdmin() {
                     {law.citation}
                   </td>
                   <td className="px-4 py-3 max-w-xs truncate">{law.titleEn}</td>
-                  <td className="px-4 py-3 text-xs capitalize">
+                  <td className="hidden px-4 py-3 text-xs capitalize sm:table-cell">
                     {law.category.replace(/_/g, " ")}
                   </td>
-                  <td className="px-4 py-3 text-xs capitalize">
+                  <td className="hidden px-4 py-3 text-xs capitalize sm:table-cell">
                     {law.propertyType}
                   </td>
                   <td className="px-4 py-3 text-right">

--- a/frontend/src/components/Admin/ProfessionalsAdmin.tsx
+++ b/frontend/src/components/Admin/ProfessionalsAdmin.tsx
@@ -267,8 +267,12 @@ function ProfessionalsAdmin() {
             <tr>
               <th className="px-4 py-3 text-left font-medium">Name</th>
               <th className="px-4 py-3 text-left font-medium">Type</th>
-              <th className="px-4 py-3 text-left font-medium">City</th>
-              <th className="px-4 py-3 text-left font-medium">Verified</th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                City
+              </th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Verified
+              </th>
               <th className="px-4 py-3 text-right font-medium">Actions</th>
             </tr>
           </thead>
@@ -292,8 +296,8 @@ function ProfessionalsAdmin() {
                   <td className="px-4 py-3 text-xs capitalize">
                     {p.type.replace(/_/g, " ")}
                   </td>
-                  <td className="px-4 py-3">{p.city}</td>
-                  <td className="px-4 py-3">
+                  <td className="hidden px-4 py-3 sm:table-cell">{p.city}</td>
+                  <td className="hidden px-4 py-3 sm:table-cell">
                     {p.isVerified ? (
                       <Badge variant="default" className="text-xs">
                         Verified

--- a/frontend/src/components/Admin/columns.tsx
+++ b/frontend/src/components/Admin/columns.tsx
@@ -34,6 +34,7 @@ export const columns: ColumnDef<UserTableData>[] = [
   {
     accessorKey: "email",
     header: "Email",
+    meta: { className: "hidden sm:table-cell" },
     cell: ({ row }) => (
       <span className="text-muted-foreground">{row.original.email}</span>
     ),

--- a/frontend/src/components/Common/DataTable.tsx
+++ b/frontend/src/components/Common/DataTable.tsx
@@ -54,7 +54,16 @@ export function DataTable<TData, TValue>({
               <TableRow key={headerGroup.id} className="hover:bg-transparent">
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id}>
+                    <TableHead
+                      key={header.id}
+                      className={
+                        (
+                          header.column.columnDef.meta as
+                            | { className?: string }
+                            | undefined
+                        )?.className
+                      }
+                    >
                       {header.isPlaceholder
                         ? null
                         : flexRender(
@@ -72,7 +81,16 @@ export function DataTable<TData, TValue>({
               table.getRowModel().rows.map((row) => (
                 <TableRow key={row.id}>
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell
+                      key={cell.id}
+                      className={
+                        (
+                          cell.column.columnDef.meta as
+                            | { className?: string }
+                            | undefined
+                        )?.className
+                      }
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),


### PR DESCRIPTION
## Summary
- Hides non-essential table columns below the `sm` breakpoint (640px) across all 5 admin tabs to eliminate the 171-element mobile overflow detected in the QA audit
- Users table: hides Email column (via new `meta.className` support in DataTable)
- Laws table: hides Category and Type columns
- Articles table: hides Category and Difficulty columns
- Glossary table: hides Slug and Category columns
- Professionals table: hides City and Verified columns
- Each table retains its most identifying columns (name/title) and the Actions column on mobile

## Test plan
- [ ] Open `/admin` on a 375×812 viewport — confirm no horizontal overflow on any tab
- [ ] Verify hidden columns reappear at ≥640px viewport width
- [ ] Confirm all 5 tabs (Users, Laws, Glossary, Articles, Professionals) render correctly on desktop