### PR TITLE
fix(admin): hide role, status, author columns on mobile viewports

### DIFF
--- a/frontend/src/components/Admin/ArticlesAdmin.tsx
+++ b/frontend/src/components/Admin/ArticlesAdmin.tsx
@@ -306,7 +306,9 @@ function ArticlesAdmin() {
               <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
                 Difficulty
               </th>
-              <th className="px-4 py-3 text-left font-medium">Author</th>
+              <th className="hidden px-4 py-3 text-left font-medium sm:table-cell">
+                Author
+              </th>
               <th className="px-4 py-3 text-right font-medium">Actions</th>
             </tr>
           </thead>
@@ -342,7 +344,7 @@ function ArticlesAdmin() {
                       {article.difficultyLevel}
                     </Badge>
                   </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">
+                  <td className="hidden px-4 py-3 text-sm text-muted-foreground sm:table-cell">
                     {article.authorName}
                   </td>
                   <td className="px-4 py-3 text-right">

--- a/frontend/src/components/Admin/columns.tsx
+++ b/frontend/src/components/Admin/columns.tsx
@@ -42,6 +42,7 @@ export const columns: ColumnDef<UserTableData>[] = [
   {
     accessorKey: "is_superuser",
     header: "Role",
+    meta: { className: "hidden sm:table-cell" },
     cell: ({ row }) => (
       <Badge variant={row.original.is_superuser ? "default" : "secondary"}>
         {row.original.is_superuser ? "Superuser" : "User"}
@@ -51,6 +52,7 @@ export const columns: ColumnDef<UserTableData>[] = [
   {
     accessorKey: "is_active",
     header: "Status",
+    meta: { className: "hidden sm:table-cell" },
     cell: ({ row }) => (
       <div className="flex items-center gap-2">
         <span


### PR DESCRIPTION
## Summary
- Hide Role and Status columns in Users DataTable on mobile (< sm breakpoint) — only Full Name and Actions visible at 375px
- Hide Author column in Articles admin table on mobile — only Title and Actions visible
- All other admin tables (Laws, Glossary, Professionals) already had `hidden sm:table-cell` applied

## Test plan
- [ ] Open /admin at 375px viewport width — Users tab shows only Full Name + Actions columns
- [ ] Articles tab at 375px shows only Title + Actions columns
- [ ] All 5 admin tabs render without horizontal overflow on mobile
- [ ] At sm+ breakpoints, all columns are visible as before