### PR TITLE
infra: provision azure cache for redis and wire REDIS_URL

### DIFF
--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -30,6 +30,10 @@ output "staging_frontend_url" {
   value = "https://${azurerm_container_app.staging_frontend.ingress[0].fqdn}"
 }
 
+output "staging_redis_hostname" {
+  value = azurerm_redis_cache.staging.hostname
+}
+
 # ──────────────────────────────────────────────
 # Production outputs
 # ──────────────────────────────────────────────
@@ -52,4 +56,8 @@ output "prod_backend_url" {
 
 output "prod_frontend_url" {
   value = "https://${azurerm_container_app.prod_frontend.ingress[0].fqdn}"
+}
+
+output "prod_redis_hostname" {
+  value = azurerm_redis_cache.prod.hostname
 }

--- a/infra/terraform/prod.tf
+++ b/infra/terraform/prod.tf
@@ -16,6 +16,30 @@ resource "azurerm_resource_group" "prod" {
   }
 }
 
+# ── Redis ─────────────────────────────────────
+
+resource "azurerm_redis_cache" "prod" {
+  name                 = "heimpath-redis-prod"
+  location             = azurerm_resource_group.prod.location
+  resource_group_name  = azurerm_resource_group.prod.name
+  capacity             = 0
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = false
+  minimum_tls_version  = "1.2"
+
+  redis_configuration {}
+
+  tags = {
+    project     = "heimpath"
+    environment = "prod"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 # ── Backend ──────────────────────────────────
 
 resource "azurerm_container_app" "prod_backend" {
@@ -48,6 +72,11 @@ resource "azurerm_container_app" "prod_backend" {
   secret {
     name  = "first-superuser-password"
     value = var.prod_first_superuser_password
+  }
+
+  secret {
+    name  = "redis-url"
+    value = "rediss://:${azurerm_redis_cache.prod.primary_access_key}@${azurerm_redis_cache.prod.hostname}:${azurerm_redis_cache.prod.ssl_port}/0"
   }
 
   dynamic "secret" {
@@ -155,6 +184,11 @@ resource "azurerm_container_app" "prod_backend" {
       env {
         name  = "WEB_CONCURRENCY"
         value = "1"
+      }
+
+      env {
+        name        = "REDIS_URL"
+        secret_name = "redis-url"
       }
 
       dynamic "env" {

--- a/infra/terraform/staging.tf
+++ b/infra/terraform/staging.tf
@@ -12,6 +12,26 @@ resource "azurerm_resource_group" "staging" {
   }
 }
 
+# ── Redis ─────────────────────────────────────
+
+resource "azurerm_redis_cache" "staging" {
+  name                 = "heimpath-redis-staging"
+  location             = azurerm_resource_group.staging.location
+  resource_group_name  = azurerm_resource_group.staging.name
+  capacity             = 0
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = false
+  minimum_tls_version  = "1.2"
+
+  redis_configuration {}
+
+  tags = {
+    project     = "heimpath"
+    environment = "staging"
+  }
+}
+
 # ── Backend ──────────────────────────────────
 
 resource "azurerm_container_app" "staging_backend" {
@@ -44,6 +64,11 @@ resource "azurerm_container_app" "staging_backend" {
   secret {
     name  = "first-superuser-password"
     value = var.staging_first_superuser_password
+  }
+
+  secret {
+    name  = "redis-url"
+    value = "rediss://:${azurerm_redis_cache.staging.primary_access_key}@${azurerm_redis_cache.staging.hostname}:${azurerm_redis_cache.staging.ssl_port}/0"
   }
 
   dynamic "secret" {
@@ -151,6 +176,11 @@ resource "azurerm_container_app" "staging_backend" {
       env {
         name  = "WEB_CONCURRENCY"
         value = "1"
+      }
+
+      env {
+        name        = "REDIS_URL"
+        secret_name = "redis-url"
       }
 
       dynamic "env" {

--- a/infra/terraform/terraform.tfvars
+++ b/infra/terraform/terraform.tfvars
@@ -7,11 +7,11 @@ subscription_id = "8b21f152-e36b-4d53-9b88-70fc38d906bc"
 ghcr_username   = "sojisoyoye"
 
 # Staging database (Neon branch)
-staging_postgres_server  = "ep-shy-paper-a9bzjdvq-pooler.gwc.azure.neon.tech"
-staging_postgres_user    = "neondb_owner"
-staging_first_superuser  = "admin@heimpath.com"
+staging_postgres_server = "ep-shy-paper-a9bzjdvq-pooler.gwc.azure.neon.tech"
+staging_postgres_user   = "neondb_owner"
+staging_first_superuser = "admin@heimpath.com"
 
 # Production database (Neon branch)
-prod_postgres_server  = "ep-long-bread-a9mlfg8t-pooler.gwc.azure.neon.tech"
-prod_postgres_user    = "neondb_owner"
-prod_first_superuser  = "admin@heimpath.com"
+prod_postgres_server = "ep-long-bread-a9mlfg8t-pooler.gwc.azure.neon.tech"
+prod_postgres_user   = "neondb_owner"
+prod_first_superuser = "admin@heimpath.com"


### PR DESCRIPTION
## Summary

- Adds `azurerm_redis_cache` (Basic C0, 250MB) for both staging and prod environments in Germany West Central
- Stores the TLS connection string (`rediss://`) as a Container App secret (`redis-url`)
- Injects `REDIS_URL` env var into the backend container from that secret
- Adds `staging_redis_hostname` and `prod_redis_hostname` outputs

## Why

Production rate limiting was silently falling back to `fakeredis` (in-memory) because no Redis was provisioned. Rate limit counters reset on every container restart and don't propagate across replicas. After this change + `terraform apply`, the sliding-window rate limiter for login, registration, and password reset will be fully operational.

## Test plan

- [ ] `terraform plan` reviewed — 2 new resources (redis_cache × 2), 2 updated container apps
- [ ] `terraform apply` run after merge
- [ ] Backend startup logs show Redis connection success (not fakeredis fallback warning)
- [ ] POST /api/v1/login/access-token with wrong credentials 6 times → 6th returns 429

## Notes

- Basic C0 has no SLA and is intentionally chosen for cost — upgrade to Standard C1 if higher availability needed
- Non-SSL port is disabled by default in the Azure provider (only TLS port 6380 is active)
- The `terraform validate` pre-existing error on `heimpath-deadline-reminders-staging` (name > 32 chars) is unrelated to this PR — resource is already deployed and functioning