### PR TITLE
fix: replace proxy middleware to prevent X-Forwarded-For spoofing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,6 @@ STACK_NAME=heimpath
 BACKEND_CORS_ORIGINS="http://localhost,http://localhost:5173,https://localhost,https://localhost:5173"
 # Required — no default. Generate with: openssl rand -hex 32
 SECRET_KEY=changethis
-# Comma-separated trusted proxy IPs for X-Forwarded-* headers.
-# In production, set to the Azure Container Apps load balancer CIDR (e.g. "10.0.0.0/8").
-# Leave as "*" only if the container is protected by platform-level network ingress controls.
-TRUSTED_PROXY_IPS=*
 FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=changethis
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -47,8 +47,7 @@ jobs:
             az containerapp update \
               --name heimpath-backend-prod \
               --resource-group rg-heimpath-prod \
-              --image ${{ steps.meta.outputs.prefix }}/backend:${{ inputs.image_tag }} \
-              --set-env-vars "TRUSTED_PROXY_IPS=*"
+              --image ${{ steps.meta.outputs.prefix }}/backend:${{ inputs.image_tag }}
 
       - name: Deploy frontend
         uses: azure/cli@v2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -77,7 +77,6 @@ jobs:
               --name heimpath-backend-staging \
               --resource-group rg-heimpath-staging \
               --image ${{ steps.meta.outputs.prefix }}/backend:${{ steps.meta.outputs.tag }} \
-              --set-env-vars "TRUSTED_PROXY_IPS=*" \
               --min-replicas 1
 
       - name: Deploy frontend

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,11 +38,6 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     # Redis (token blacklist + rate limiting)
     REDIS_URL: str = "redis://localhost:6379"
-    # Comma-separated list of trusted proxy IPs for X-Forwarded-* headers.
-    # In production, scope this to the Azure load balancer CIDR (e.g. "10.0.0.0/8").
-    # "*" trusts all sources and should only be used when the container is not
-    # directly reachable from the internet (e.g. protected by Azure Container Apps ingress).
-    TRUSTED_PROXY_IPS: str = "*"
     FRONTEND_HOST: str = "http://localhost:5173"
     ENVIRONMENT: Literal["local", "staging", "production"] = "local"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,6 @@
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
 
 import sentry_sdk
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -35,24 +34,32 @@ class _ContainerAppsProxyMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] in ("http", "websocket"):
-            headers = dict(scope["headers"])
+            headers: list[tuple[bytes, bytes]] = scope["headers"]
 
-            if b"x-forwarded-for" in headers:
-                xff = headers[b"x-forwarded-for"].decode("latin1")
-                real_ip = xff.split(",")[-1].strip()
+            xff_values = [
+                v.decode("latin1") for k, v in headers if k == b"x-forwarded-for"
+            ]
+            if xff_values:
+                # CAE Envoy appends the real client IP at the end of the XFF chain.
+                # Take the rightmost entry to prevent spoofing via injected XFF values.
+                real_ip = ", ".join(xff_values).split(",")[-1].strip()
+                # Only overwrite when non-empty; scope["client"] may be None on
+                # Unix-socket connections where the server has no peer address.
                 if real_ip:
                     scope["client"] = (real_ip, 0)
 
-            if b"x-forwarded-proto" in headers:
-                proto = (
-                    headers[b"x-forwarded-proto"].decode("latin1").split(",")[0].strip()
-                )
+            proto_values = [
+                v.decode("latin1") for k, v in headers if k == b"x-forwarded-proto"
+            ]
+            if proto_values:
+                # Take the leftmost proto — set by the client; CAE does not override it.
+                proto = proto_values[0].split(",")[0].strip()
                 if proto in {"http", "https", "ws", "wss"}:
                     scope["scheme"] = proto
 
-        return await self.app(scope, receive, send)
+        await self.app(scope, receive, send)
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 import sentry_sdk
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -8,7 +9,7 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from sqlmodel import Session
 from starlette.middleware.cors import CORSMiddleware
-from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.api.main import api_router
 from app.core.config import settings
@@ -16,6 +17,42 @@ from app.core.db import engine
 from app.services.portfolio_service import generate_recurring_transactions
 
 logger = logging.getLogger(__name__)
+
+
+class _ContainerAppsProxyMiddleware:
+    """Proxy header middleware for Azure Container Apps.
+
+    Container Apps' Envoy ingress appends the real downstream client IP to the
+    X-Forwarded-For chain.  Reading the rightmost entry gives the IP added by
+    the trusted CAE ingress, which cannot be spoofed: even if a client injects
+    values earlier in the chain, CAE always appends the real IP at the end.
+
+    Replaces uvicorn's ProxyHeadersMiddleware (which reads the leftmost value
+    and is therefore vulnerable to X-Forwarded-For spoofing when all hosts are
+    trusted).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
+        if scope["type"] in ("http", "websocket"):
+            headers = dict(scope["headers"])
+
+            if b"x-forwarded-for" in headers:
+                xff = headers[b"x-forwarded-for"].decode("latin1")
+                real_ip = xff.split(",")[-1].strip()
+                if real_ip:
+                    scope["client"] = (real_ip, 0)
+
+            if b"x-forwarded-proto" in headers:
+                proto = (
+                    headers[b"x-forwarded-proto"].decode("latin1").split(",")[0].strip()
+                )
+                if proto in {"http", "https", "ws", "wss"}:
+                    scope["scheme"] = proto
+
+        return await self.app(scope, receive, send)
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -71,13 +108,8 @@ if settings.all_cors_origins:
         allow_headers=["Authorization", "Content-Type", "X-Requested-With"],
     )
 
-# Trust proxy headers (X-Forwarded-Proto, X-Forwarded-For) from Azure Container Apps.
-# trusted_hosts is controlled by TRUSTED_PROXY_IPS in config; set it to the load
-# balancer CIDR in production rather than leaving it as "*".
+# Extract real client IP from X-Forwarded-For set by Azure Container Apps ingress.
 if settings.ENVIRONMENT != "local":
-    app.add_middleware(
-        ProxyHeadersMiddleware,
-        trusted_hosts=settings.TRUSTED_PROXY_IPS.split(","),
-    )
+    app.add_middleware(_ContainerAppsProxyMiddleware)
 
 app.include_router(api_router, prefix=settings.API_V1_STR)

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -20,50 +20,6 @@ def _base_settings_kwargs() -> dict:
     }
 
 
-def test_trusted_proxy_ips_wildcard_allowed_in_staging() -> None:
-    """TRUSTED_PROXY_IPS='*' is permitted in staging (app is behind ACA ingress)."""
-    s = Settings(
-        **_base_settings_kwargs(),
-        ENVIRONMENT="staging",
-        TRUSTED_PROXY_IPS="*",
-        _env_file=None,
-    )
-    assert s.TRUSTED_PROXY_IPS == "*"
-
-
-def test_trusted_proxy_ips_wildcard_allowed_in_production() -> None:
-    """TRUSTED_PROXY_IPS='*' is permitted in production (app is behind ACA ingress)."""
-    s = Settings(
-        **_base_settings_kwargs(),
-        ENVIRONMENT="production",
-        TRUSTED_PROXY_IPS="*",
-        _env_file=None,
-    )
-    assert s.TRUSTED_PROXY_IPS == "*"
-
-
-def test_trusted_proxy_ips_wildcard_allowed_in_local() -> None:
-    """TRUSTED_PROXY_IPS='*' is permitted in local environment."""
-    s = Settings(
-        **_base_settings_kwargs(),
-        ENVIRONMENT="local",
-        TRUSTED_PROXY_IPS="*",
-        _env_file=None,
-    )
-    assert s.TRUSTED_PROXY_IPS == "*"
-
-
-def test_trusted_proxy_ips_cidr_allowed_in_production() -> None:
-    """A specific CIDR range is accepted in production."""
-    s = Settings(
-        **_base_settings_kwargs(),
-        ENVIRONMENT="production",
-        TRUSTED_PROXY_IPS="10.0.0.0/8",
-        _env_file=None,
-    )
-    assert s.TRUSTED_PROXY_IPS == "10.0.0.0/8"
-
-
 # ── SECRET_KEY validation ──────────────────────────────────────────────────
 
 
@@ -74,7 +30,6 @@ def test_secret_key_changethis_raises_in_production() -> None:
         Settings(
             **kwargs,
             ENVIRONMENT="production",
-            TRUSTED_PROXY_IPS="10.0.0.0/8",
             _env_file=None,
         )
 
@@ -93,7 +48,6 @@ def test_postgres_password_empty_raises_in_production() -> None:
         Settings(
             **kwargs,
             ENVIRONMENT="production",
-            TRUSTED_PROXY_IPS="10.0.0.0/8",
             _env_file=None,
         )
 

--- a/backend/tests/core/test_proxy_middleware.py
+++ b/backend/tests/core/test_proxy_middleware.py
@@ -1,0 +1,70 @@
+"""Tests for _ContainerAppsProxyMiddleware."""
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from app.main import _ContainerAppsProxyMiddleware
+
+
+def _make_app() -> Starlette:
+    """Minimal Starlette app that echoes the resolved client IP and scheme."""
+
+    async def echo(request: Request) -> PlainTextResponse:
+        host = request.client.host if request.client else "none"
+        return PlainTextResponse(f"{host} {request.url.scheme}")
+
+    app = Starlette(routes=[Route("/", echo)])
+    app.add_middleware(_ContainerAppsProxyMiddleware)
+    return app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(_make_app(), raise_server_exceptions=True)
+
+
+class TestXForwardedFor:
+    def test_single_entry_uses_it_as_client_ip(self, client: TestClient) -> None:
+        resp = client.get("/", headers={"X-Forwarded-For": "1.2.3.4"})
+        assert resp.text.startswith("1.2.3.4")
+
+    def test_rightmost_entry_is_used(self, client: TestClient) -> None:
+        """Spoofed IPs in earlier positions must be ignored."""
+        resp = client.get("/", headers={"X-Forwarded-For": "9.9.9.9, 1.2.3.4"})
+        assert resp.text.startswith("1.2.3.4")
+
+    def test_rightmost_entry_with_whitespace(self, client: TestClient) -> None:
+        resp = client.get("/", headers={"X-Forwarded-For": "9.9.9.9,  1.2.3.4  "})
+        assert resp.text.startswith("1.2.3.4")
+
+    def test_empty_xff_does_not_overwrite_client(self, client: TestClient) -> None:
+        """An empty XFF value must not corrupt scope['client']."""
+        # TestClient sets client to 127.0.0.1 by default.
+        resp = client.get("/", headers={"X-Forwarded-For": ""})
+        assert resp.text.startswith("testclient")
+
+    def test_no_xff_header_leaves_client_unchanged(self, client: TestClient) -> None:
+        resp = client.get("/")
+        assert resp.text.startswith("testclient")
+
+
+class TestXForwardedProto:
+    def test_https_proto_is_applied(self, client: TestClient) -> None:
+        resp = client.get("/", headers={"X-Forwarded-Proto": "https"})
+        assert resp.text.endswith("https")
+
+    def test_leftmost_proto_is_used(self, client: TestClient) -> None:
+        resp = client.get("/", headers={"X-Forwarded-Proto": "https, http"})
+        assert resp.text.endswith("https")
+
+    def test_invalid_proto_is_ignored(self, client: TestClient) -> None:
+        resp = client.get("/", headers={"X-Forwarded-Proto": "ftp"})
+        assert resp.text.endswith("http")
+
+    def test_no_proto_header_leaves_scheme_unchanged(self, client: TestClient) -> None:
+        resp = client.get("/")
+        assert resp.text.endswith("http")

--- a/backend/tests/core/test_proxy_middleware.py
+++ b/backend/tests/core/test_proxy_middleware.py
@@ -51,6 +51,17 @@ class TestXForwardedFor:
         resp = client.get("/")
         assert resp.text.startswith("testclient")
 
+    def test_duplicate_xff_headers_uses_rightmost(self, client: TestClient) -> None:
+        """Two separate XFF header lines must be joined; rightmost value wins."""
+        resp = client.get(
+            "/",
+            headers=[
+                ("x-forwarded-for", "9.9.9.9"),
+                ("x-forwarded-for", "1.2.3.4"),
+            ],
+        )
+        assert resp.text.startswith("1.2.3.4")
+
 
 class TestXForwardedProto:
     def test_https_proto_is_applied(self, client: TestClient) -> None:

--- a/infra/terraform/prod.tf
+++ b/infra/terraform/prod.tf
@@ -177,11 +177,6 @@ resource "azurerm_container_app" "prod_backend" {
       }
 
       env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
-      }
-
-      env {
         name  = "WEB_CONCURRENCY"
         value = "1"
       }
@@ -390,11 +385,6 @@ resource "azurerm_container_app_job" "prod_migration" {
         name        = "FIRST_SUPERUSER_PASSWORD"
         secret_name = "first-superuser-password"
       }
-
-      env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
-      }
     }
   }
 
@@ -500,11 +490,6 @@ resource "azurerm_container_app_job" "prod_weekly_digest" {
       env {
         name  = "FRONTEND_HOST"
         value = var.prod_frontend_url
-      }
-
-      env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
       }
 
       dynamic "env" {
@@ -641,11 +626,6 @@ resource "azurerm_container_app_job" "prod_deadline_reminders" {
       env {
         name  = "FRONTEND_HOST"
         value = var.prod_frontend_url
-      }
-
-      env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
       }
 
       dynamic "env" {

--- a/infra/terraform/staging.tf
+++ b/infra/terraform/staging.tf
@@ -169,11 +169,6 @@ resource "azurerm_container_app" "staging_backend" {
       }
 
       env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
-      }
-
-      env {
         name  = "WEB_CONCURRENCY"
         value = "1"
       }
@@ -382,11 +377,6 @@ resource "azurerm_container_app_job" "staging_migration" {
         name        = "FIRST_SUPERUSER_PASSWORD"
         secret_name = "first-superuser-password"
       }
-
-      env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
-      }
     }
   }
 
@@ -492,11 +482,6 @@ resource "azurerm_container_app_job" "staging_weekly_digest" {
       env {
         name  = "FRONTEND_HOST"
         value = var.staging_frontend_url
-      }
-
-      env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
       }
 
       dynamic "env" {
@@ -633,11 +618,6 @@ resource "azurerm_container_app_job" "staging_deadline_reminders" {
       env {
         name  = "FRONTEND_HOST"
         value = var.staging_frontend_url
-      }
-
-      env {
-        name  = "TRUSTED_PROXY_IPS"
-        value = "*"
       }
 
       dynamic "env" {


### PR DESCRIPTION
## Summary

- Replaces `ProxyHeadersMiddleware` (uvicorn built-in) with a custom `_ContainerAppsProxyMiddleware` that reads the **rightmost** `X-Forwarded-For` value
- Removes `TRUSTED_PROXY_IPS` config field entirely — no longer needed
- Removes `TRUSTED_PROXY_IPS=*` from `staging.tf` and `prod.tf` (backend + all scheduled jobs)
- Removes `--set-env-vars "TRUSTED_PROXY_IPS=*"` from both deploy workflows (the override that would have survived the Terraform fix)

## Why

Azure Container Apps Envoy **appends** the real client IP to `X-Forwarded-For`. The old middleware with `trusted_hosts="*"` reads the **leftmost** (first) value, which an attacker can spoof:

1. Attacker sends `X-Forwarded-For: victim-ip`
2. Container Apps appends real IP: `X-Forwarded-For: victim-ip, attacker-real-ip`
3. Old middleware reads `victim-ip` → rate limiter thinks attacker is `victim-ip`

The new middleware reads the **rightmost** value (the one CAE added), so spoofed entries earlier in the chain are ignored.

## Verification

Confirmed the spoofing attack worked before this fix:
- `curl -H "X-Forwarded-For: 9.9.9.9" https://api.staging.heimpath.com/...` → backend logged `9.9.9.9` (spoofed)
- After this fix, the rightmost (real) IP will be used instead

## Test plan

- [ ] CI green
- [ ] Deploy to staging — verify `terraform apply` removes `TRUSTED_PROXY_IPS` env var from containers
- [ ] `curl -H "X-Forwarded-For: 9.9.9.9" https://api.staging.heimpath.com/api/v1/utils/health-check/` → backend logs real IP, not `9.9.9.9`