### PR TITLE
chore: add pybreaker circuit breaker library dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "python-multipart<1.0.0,>=0.0.26",
     "email-validator<3.0.0.0,>=2.1.0.post1",
     "tenacity<9.0.0,>=8.2.3",
+    "pybreaker<2.0.0,>=1.2.0",
     "pydantic>2.0",
     "emails<1.0,>=0.6",
     "jinja2<4.0.0,>=3.1.4",

--- a/uv.lock
+++ b/uv.lock
@@ -243,6 +243,7 @@ dependencies = [
     { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pwdlib", extra = ["argon2", "bcrypt"] },
+    { name = "pybreaker" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -286,6 +287,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1.13,<4.0.0" },
     { name = "pwdlib", extras = ["argon2", "bcrypt"], specifier = ">=0.3.0" },
+    { name = "pybreaker", specifier = ">=1.2.0,<2.0.0" },
     { name = "pydantic", specifier = ">2.0" },
     { name = "pydantic-settings", specifier = ">=2.2.1,<3.0.0" },
     { name = "pyjwt", specifier = ">=2.12.0,<3.0.0" },
@@ -2523,6 +2525,15 @@ argon2 = [
 ]
 bcrypt = [
     { name = "bcrypt" },
+]
+
+[[package]]
+name = "pybreaker"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `pybreaker>=1.2.0,<2.0.0` to `backend/pyproject.toml` dependencies
- Runs `uv sync` from workspace root to update `uv.lock` (pybreaker==1.4.1 resolved)
- Enables circuit breakers for Stripe, Azure Translator, and Anthropic integrations (implemented in follow-up tasks 233–234)

## Test plan

- [ ] `python -c "import pybreaker; pybreaker.CircuitBreaker(fail_max=5, reset_timeout=60)"` succeeds in backend container
- [ ] All pre-commit hooks pass (ruff, biome, toml check)
- [ ] CI backend tests pass (no new import errors introduced)