### PR TITLE
feat(reliability): add circuit breaker singletons for external services

### DIFF
--- a/backend/app/core/circuit_breakers.py
+++ b/backend/app/core/circuit_breakers.py
@@ -1,0 +1,80 @@
+"""Module-level pybreaker circuit breaker singletons.
+
+Each breaker protects one external integration:
+- stripe_breaker     — Stripe API (sync calls)
+- translator_breaker — Azure Translator API (async calls)
+- anthropic_breaker  — Anthropic Claude API (async calls)
+
+Usage at call sites::
+
+    from app.core.circuit_breakers import stripe_breaker
+
+    # sync
+    result = stripe_breaker.call(stripe.checkout.Session.create, **params)
+
+    # async
+    result = await translator_breaker.call_async(my_async_fn, *args)
+
+This module intentionally imports ONLY pybreaker and logging to prevent
+circular imports — services must not be imported here.
+"""
+
+import logging
+
+import pybreaker
+
+_logger = logging.getLogger(__name__)
+
+
+class _LoggingListener(pybreaker.CircuitBreakerListener):
+    """Log circuit state transitions and individual call failures."""
+
+    def state_change(
+        self,
+        cb: pybreaker.CircuitBreaker,
+        old_state: object,
+        new_state: object,
+    ) -> None:
+        _logger.warning(
+            "Circuit breaker '%s' changed state: %s -> %s",
+            cb.name,
+            old_state,
+            new_state,
+        )
+
+    def failure(
+        self,
+        cb: pybreaker.CircuitBreaker,
+        exc: BaseException,
+    ) -> None:
+        _logger.error(
+            "Circuit breaker '%s' recorded failure (%s/%s): %s",
+            cb.name,
+            cb.fail_counter,
+            cb.fail_max,
+            exc,
+        )
+
+
+_listener = _LoggingListener()
+
+stripe_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,
+    reset_timeout=60,
+    name="stripe",
+    listeners=[_listener],
+)
+
+translator_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,
+    reset_timeout=60,
+    name="translator",
+    listeners=[_listener],
+)
+
+anthropic_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,
+    reset_timeout=60,
+    name="anthropic",
+    listeners=[_listener],
+)

--- a/backend/tests/core/test_circuit_breakers.py
+++ b/backend/tests/core/test_circuit_breakers.py
@@ -1,0 +1,143 @@
+"""Tests for app.core.circuit_breakers."""
+
+from unittest.mock import patch
+
+import pybreaker
+
+from app.core.circuit_breakers import (
+    _LoggingListener,
+    anthropic_breaker,
+    stripe_breaker,
+    translator_breaker,
+)
+
+
+class TestCircuitBreakerConfiguration:
+    """Each singleton must be configured per spec: fail_max=5, reset_timeout=60."""
+
+    def test_stripe_breaker_fail_max(self) -> None:
+        assert stripe_breaker.fail_max == 5
+
+    def test_stripe_breaker_reset_timeout(self) -> None:
+        assert stripe_breaker.reset_timeout == 60
+
+    def test_stripe_breaker_name(self) -> None:
+        assert stripe_breaker.name == "stripe"
+
+    def test_translator_breaker_fail_max(self) -> None:
+        assert translator_breaker.fail_max == 5
+
+    def test_translator_breaker_reset_timeout(self) -> None:
+        assert translator_breaker.reset_timeout == 60
+
+    def test_translator_breaker_name(self) -> None:
+        assert translator_breaker.name == "translator"
+
+    def test_anthropic_breaker_fail_max(self) -> None:
+        assert anthropic_breaker.fail_max == 5
+
+    def test_anthropic_breaker_reset_timeout(self) -> None:
+        assert anthropic_breaker.reset_timeout == 60
+
+    def test_anthropic_breaker_name(self) -> None:
+        assert anthropic_breaker.name == "anthropic"
+
+    def test_all_breakers_start_closed(self) -> None:
+        for breaker in (stripe_breaker, translator_breaker, anthropic_breaker):
+            assert breaker.current_state == "closed"
+
+
+class TestCircuitBreakerSingletons:
+    """Singletons must be distinct objects sharing the same listener."""
+
+    def test_breakers_are_distinct_instances(self) -> None:
+        assert stripe_breaker is not translator_breaker
+        assert translator_breaker is not anthropic_breaker
+        assert stripe_breaker is not anthropic_breaker
+
+    def test_each_breaker_has_listener(self) -> None:
+        for breaker in (stripe_breaker, translator_breaker, anthropic_breaker):
+            assert len(breaker.listeners) == 1
+            assert isinstance(breaker.listeners[0], _LoggingListener)
+
+    def test_all_breakers_share_same_listener_instance(self) -> None:
+        listener_ids = {
+            id(b.listeners[0])
+            for b in (stripe_breaker, translator_breaker, anthropic_breaker)
+        }
+        assert len(listener_ids) == 1, (
+            "All breakers should share the same _LoggingListener"
+        )
+
+
+class TestLoggingListener:
+    """_LoggingListener must log state changes and failures at the correct level."""
+
+    def test_failure_logs_at_error_level(self) -> None:
+        listener = _LoggingListener()
+        cb = pybreaker.CircuitBreaker(fail_max=5, reset_timeout=60, name="test-failure")
+
+        with patch("app.core.circuit_breakers._logger") as mock_logger:
+            listener.failure(cb, RuntimeError("connection refused"))
+
+        mock_logger.error.assert_called_once()
+
+    def test_failure_log_includes_breaker_name(self) -> None:
+        listener = _LoggingListener()
+        cb = pybreaker.CircuitBreaker(fail_max=5, reset_timeout=60, name="test-counter")
+
+        with patch("app.core.circuit_breakers._logger") as mock_logger:
+            listener.failure(cb, ValueError("timeout"))
+
+        call_args = mock_logger.error.call_args
+        # Second positional arg is the breaker name
+        assert call_args.args[1] == "test-counter"
+
+    def test_failure_log_includes_fail_counter_and_max(self) -> None:
+        listener = _LoggingListener()
+        cb = pybreaker.CircuitBreaker(fail_max=5, reset_timeout=60, name="test-counts")
+
+        with patch("app.core.circuit_breakers._logger") as mock_logger:
+            listener.failure(cb, ValueError("timeout"))
+
+        call_args = mock_logger.error.call_args
+        # args[2] = fail_counter, args[3] = fail_max
+        assert call_args.args[3] == 5
+
+    def test_state_change_logs_at_warning_level(self) -> None:
+        listener = _LoggingListener()
+        cb = pybreaker.CircuitBreaker(fail_max=2, reset_timeout=60, name="test-state")
+
+        with patch("app.core.circuit_breakers._logger") as mock_logger:
+            listener.state_change(cb, "closed", "open")
+
+        mock_logger.warning.assert_called_once()
+
+    def test_state_change_log_includes_breaker_name(self) -> None:
+        listener = _LoggingListener()
+        cb = pybreaker.CircuitBreaker(fail_max=2, reset_timeout=60, name="test-names")
+
+        with patch("app.core.circuit_breakers._logger") as mock_logger:
+            listener.state_change(cb, "closed", "open")
+
+        call_args = mock_logger.warning.call_args
+        assert call_args.args[1] == "test-names"
+
+    def test_state_change_log_includes_old_and_new_state(self) -> None:
+        listener = _LoggingListener()
+        cb = pybreaker.CircuitBreaker(fail_max=2, reset_timeout=60, name="test-states")
+
+        with patch("app.core.circuit_breakers._logger") as mock_logger:
+            listener.state_change(cb, "closed", "open")
+
+        call_args = mock_logger.warning.call_args
+        assert call_args.args[2] == "closed"
+        assert call_args.args[3] == "open"
+
+    def test_listener_is_subclass_of_circuit_breaker_listener(self) -> None:
+        assert issubclass(_LoggingListener, pybreaker.CircuitBreakerListener)
+
+    def test_listener_instance_is_logging_listener(self) -> None:
+        listener = _LoggingListener()
+        assert isinstance(listener, _LoggingListener)
+        assert isinstance(listener, pybreaker.CircuitBreakerListener)


### PR DESCRIPTION
## Summary

Creates `backend/app/core/circuit_breakers.py` with three module-level `pybreaker.CircuitBreaker` singletons:

| Breaker | Protects | Usage |
|---------|----------|-------|
| `stripe_breaker` | Stripe API | `stripe_breaker.call(fn, *args)` |
| `translator_breaker` | Azure Translator | `await translator_breaker.call_async(fn, *args)` |
| `anthropic_breaker` | Anthropic Claude | `await anthropic_breaker.call_async(fn, *args)` |

Each is configured with `fail_max=5` and `reset_timeout=60` seconds. A shared `_LoggingListener` emits:
- `WARNING` on state transitions (e.g. `closed -> open`)
- `ERROR` on individual call failures (with fail counter context)

The module intentionally imports only `pybreaker` and `logging` — no service imports — to prevent circular dependency issues.

Unblocks tasks 242 (translation hardening) and 243 (payment hardening).

## Test plan

- [ ] `from app.core.circuit_breakers import stripe_breaker, translator_breaker, anthropic_breaker` succeeds with no import errors
- [ ] Each breaker starts in `closed` state with `fail_max=5`, `reset_timeout=60`
- [ ] CI backend tests pass