### PR TITLE
feat(reliability): add tenacity retry decorators for external services

### DIFF
--- a/backend/app/core/reliability.py
+++ b/backend/app/core/reliability.py
@@ -1,0 +1,118 @@
+"""Tenacity retry decorator instances for external service calls.
+
+Three named retry strategies protect the three external integrations:
+- stripe_retry       — Stripe API (sync, 3 attempts)
+- translator_retry   — Azure Translator API (async, 3 attempts)
+- anthropic_retry    — Anthropic Claude API (async, 2 attempts)
+
+Usage::
+
+    from app.core.reliability import stripe_retry
+
+    @stripe_retry
+    def create_checkout(...):
+        return stripe.checkout.Session.create(...)
+
+All decorators set ``reraise=True`` so the original exception propagates
+to the caller once retries are exhausted — callers are responsible for
+handling the final error.
+
+Predicate functions use lazy imports where needed to avoid circular
+dependencies with service modules.
+"""
+
+import logging
+
+import stripe
+import anthropic
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+# ── Transient-error predicates ────────────────────────────────────────────────
+
+
+def _is_transient_stripe_error(exc: BaseException) -> bool:
+    """Return True for Stripe errors that are safe to retry.
+
+    stripe-python 7.x removed APITimeoutError — timeouts now surface as
+    APIConnectionError, so both connection issues and timeouts are covered
+    by that single class.
+    """
+    return isinstance(
+        exc,
+        (
+            stripe.APIConnectionError,
+            stripe.RateLimitError,
+        ),
+    )
+
+
+def _is_transient_translator_error(exc: BaseException) -> bool:
+    """Return True for Azure Translator errors that are safe to retry.
+
+    Uses a lazy import of TranslationError to avoid a circular dependency
+    with translation_service.
+    """
+    import aiohttp  # noqa: PLC0415 — intentional lazy import
+
+    if isinstance(exc, aiohttp.ClientConnectionError):
+        return True
+
+    # Lazy import to avoid circular dependency
+    try:
+        from app.services.translation_service import TranslationError  # noqa: PLC0415
+    except ImportError:
+        return False
+
+    if isinstance(exc, TranslationError):
+        msg = str(exc)
+        return any(code in msg for code in ("429", "503", "504"))
+
+    return False
+
+
+def _is_transient_anthropic_error(exc: BaseException) -> bool:
+    """Return True for Anthropic errors that are safe to retry."""
+    return isinstance(
+        exc,
+        (
+            anthropic.APIConnectionError,
+            anthropic.APITimeoutError,
+            anthropic.RateLimitError,
+        ),
+    )
+
+
+# ── Retry decorators ──────────────────────────────────────────────────────────
+
+stripe_retry = retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential_jitter(initial=1, max=10),
+    retry=retry_if_exception(_is_transient_stripe_error),
+    reraise=True,
+    before_sleep=before_sleep_log(_logger, logging.WARNING),
+)
+
+translator_retry = retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential_jitter(initial=1, max=15),
+    retry=retry_if_exception(_is_transient_translator_error),
+    reraise=True,
+    before_sleep=before_sleep_log(_logger, logging.WARNING),
+)
+
+anthropic_retry = retry(
+    stop=stop_after_attempt(2),
+    wait=wait_exponential_jitter(initial=2, max=20),
+    retry=retry_if_exception(_is_transient_anthropic_error),
+    reraise=True,
+    before_sleep=before_sleep_log(_logger, logging.WARNING),
+)

--- a/backend/app/core/reliability.py
+++ b/backend/app/core/reliability.py
@@ -2,8 +2,8 @@
 
 Three named retry strategies protect the three external integrations:
 - stripe_retry       — Stripe API (sync, 3 attempts)
-- translator_retry   — Azure Translator API (async, 3 attempts)
-- anthropic_retry    — Anthropic Claude API (async, 2 attempts)
+- translator_retry   — Azure Translator API (sync/async, 3 attempts)
+- anthropic_retry    — Anthropic Claude API (sync/async, 2 attempts)
 
 Usage::
 
@@ -23,8 +23,8 @@ dependencies with service modules.
 
 import logging
 
-import stripe
 import anthropic
+import stripe
 from tenacity import (
     before_sleep_log,
     retry,

--- a/backend/tests/core/test_reliability.py
+++ b/backend/tests/core/test_reliability.py
@@ -1,0 +1,195 @@
+"""Tests for app.core.reliability — retry predicates and decorator instances."""
+
+from unittest.mock import MagicMock, patch
+
+import anthropic
+import pytest
+import stripe
+
+from app.core.reliability import (
+    _is_transient_anthropic_error,
+    _is_transient_stripe_error,
+    _is_transient_translator_error,
+    anthropic_retry,
+    stripe_retry,
+    translator_retry,
+)
+
+
+class TestIsTransientStripeError:
+    """Predicate must accept retryable Stripe errors, reject everything else.
+
+    stripe-python 7.x removed APITimeoutError — timeouts surface as
+    APIConnectionError instead.
+    """
+
+    def test_api_connection_error_is_transient(self) -> None:
+        assert _is_transient_stripe_error(stripe.APIConnectionError("connection failed"))
+
+    def test_rate_limit_error_is_transient(self) -> None:
+        # stripe 7.x RateLimitError constructor takes only a message
+        err = stripe.RateLimitError("rate limit exceeded")
+        assert _is_transient_stripe_error(err)
+
+    def test_authentication_error_is_not_transient(self) -> None:
+        err = stripe.AuthenticationError("invalid api key")
+        assert not _is_transient_stripe_error(err)
+
+    def test_value_error_is_not_transient(self) -> None:
+        assert not _is_transient_stripe_error(ValueError("bad value"))
+
+    def test_runtime_error_is_not_transient(self) -> None:
+        assert not _is_transient_stripe_error(RuntimeError("crash"))
+
+
+class TestIsTransientTranslatorError:
+    """Predicate must handle aiohttp connection errors and status-coded TranslationErrors."""
+
+    def test_aiohttp_client_connection_error_is_transient(self) -> None:
+        import aiohttp
+
+        assert _is_transient_translator_error(aiohttp.ClientConnectionError())
+
+    def test_translation_error_429_is_transient(self) -> None:
+        # Simulate TranslationError being importable
+        with patch.dict("sys.modules", {}):
+            from app.services.translation_service import TranslationError
+
+            err = TranslationError("API error 429: Too Many Requests")
+            assert _is_transient_translator_error(err)
+
+    def test_translation_error_503_is_transient(self) -> None:
+        from app.services.translation_service import TranslationError
+
+        err = TranslationError("API error 503: Service Unavailable")
+        assert _is_transient_translator_error(err)
+
+    def test_translation_error_504_is_transient(self) -> None:
+        from app.services.translation_service import TranslationError
+
+        err = TranslationError("API error 504: Gateway Timeout")
+        assert _is_transient_translator_error(err)
+
+    def test_translation_error_400_is_not_transient(self) -> None:
+        from app.services.translation_service import TranslationError
+
+        err = TranslationError("API error 400: Bad Request")
+        assert not _is_transient_translator_error(err)
+
+    def test_value_error_is_not_transient(self) -> None:
+        assert not _is_transient_translator_error(ValueError("bad value"))
+
+    def test_import_error_returns_false(self) -> None:
+        """If TranslationError cannot be imported, non-aiohttp errors return False."""
+        import sys
+
+        with patch.dict(
+            sys.modules,
+            {"app.services.translation_service": None},  # type: ignore[dict-item]
+        ):
+            # Non-aiohttp error with no TranslationError available
+            result = _is_transient_translator_error(RuntimeError("boom"))
+        assert result is False
+
+
+class TestIsTransientAnthropicError:
+    """Predicate must accept retryable Anthropic errors, reject everything else."""
+
+    def test_api_connection_error_is_transient(self) -> None:
+        err = anthropic.APIConnectionError(request=MagicMock())
+        assert _is_transient_anthropic_error(err)
+
+    def test_api_timeout_error_is_transient(self) -> None:
+        err = anthropic.APITimeoutError(request=MagicMock())
+        assert _is_transient_anthropic_error(err)
+
+    def test_rate_limit_error_is_transient(self) -> None:
+        err = anthropic.RateLimitError(
+            message="rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+        assert _is_transient_anthropic_error(err)
+
+    def test_authentication_error_is_not_transient(self) -> None:
+        err = anthropic.AuthenticationError(
+            message="invalid api key",
+            response=MagicMock(status_code=401, headers={}),
+            body=None,
+        )
+        assert not _is_transient_anthropic_error(err)
+
+    def test_value_error_is_not_transient(self) -> None:
+        assert not _is_transient_anthropic_error(ValueError("bad value"))
+
+    def test_runtime_error_is_not_transient(self) -> None:
+        assert not _is_transient_anthropic_error(RuntimeError("crash"))
+
+
+class TestRetryDecorators:
+    """Decorators must be callables that wrap functions correctly."""
+
+    def test_stripe_retry_is_callable(self) -> None:
+        assert callable(stripe_retry)
+
+    def test_translator_retry_is_callable(self) -> None:
+        assert callable(translator_retry)
+
+    def test_anthropic_retry_is_callable(self) -> None:
+        assert callable(anthropic_retry)
+
+    def test_stripe_retry_wraps_function(self) -> None:
+        call_count = 0
+
+        @stripe_retry
+        def always_succeeds() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        result = always_succeeds()
+        assert result == "ok"
+        assert call_count == 1
+
+    def test_translator_retry_wraps_function(self) -> None:
+        @translator_retry
+        def always_succeeds() -> int:
+            return 42
+
+        assert always_succeeds() == 42
+
+    def test_anthropic_retry_wraps_function(self) -> None:
+        @anthropic_retry
+        def always_succeeds() -> bool:
+            return True
+
+        assert always_succeeds() is True
+
+    def test_stripe_retry_reraises_non_transient_error(self) -> None:
+        """Non-transient errors must propagate immediately without retrying."""
+        call_count = 0
+
+        @stripe_retry
+        def raises_value_error() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("bad input")
+
+        with pytest.raises(ValueError, match="bad input"):
+            raises_value_error()
+
+        assert call_count == 1  # no retries for non-transient errors
+
+    def test_anthropic_retry_reraises_non_transient_error(self) -> None:
+        call_count = 0
+
+        @anthropic_retry
+        def raises_type_error() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise TypeError("wrong type")
+
+        with pytest.raises(TypeError):
+            raises_type_error()
+
+        assert call_count == 1

--- a/backend/tests/core/test_reliability.py
+++ b/backend/tests/core/test_reliability.py
@@ -24,7 +24,9 @@ class TestIsTransientStripeError:
     """
 
     def test_api_connection_error_is_transient(self) -> None:
-        assert _is_transient_stripe_error(stripe.APIConnectionError("connection failed"))
+        assert _is_transient_stripe_error(
+            stripe.APIConnectionError("connection failed")
+        )
 
     def test_rate_limit_error_is_transient(self) -> None:
         # stripe 7.x RateLimitError constructor takes only a message
@@ -51,12 +53,10 @@ class TestIsTransientTranslatorError:
         assert _is_transient_translator_error(aiohttp.ClientConnectionError())
 
     def test_translation_error_429_is_transient(self) -> None:
-        # Simulate TranslationError being importable
-        with patch.dict("sys.modules", {}):
-            from app.services.translation_service import TranslationError
+        from app.services.translation_service import TranslationError
 
-            err = TranslationError("API error 429: Too Many Requests")
-            assert _is_transient_translator_error(err)
+        err = TranslationError("API error 429: Too Many Requests")
+        assert _is_transient_translator_error(err)
 
     def test_translation_error_503_is_transient(self) -> None:
         from app.services.translation_service import TranslationError


### PR DESCRIPTION
## Summary

- Adds `_is_transient_stripe_error`, `_is_transient_translator_error`, and `_is_transient_anthropic_error` predicates covering retryable error classes for each integration
- Adds `stripe_retry` (3 attempts, 1–10s jitter), `translator_retry` (3 attempts, 1–15s jitter), and `anthropic_retry` (2 attempts, 2–20s jitter) tenacity decorators with `reraise=True` and `before_sleep` logging
- Notes stripe-python 7.x behavior: `APITimeoutError` was removed; timeouts surface as `APIConnectionError`
- Uses lazy imports in `_is_transient_translator_error` to avoid circular dependency with `translation_service`
- 26 tests covering all predicates and decorator wrapping/reraise behavior

## Test plan

- [ ] All 26 tests in `tests/core/test_reliability.py` pass
- [ ] `pre-commit run --all-files` clean
- [ ] SonarCloud quality gate passes (new code coverage ≥ 80%)