### PR TITLE
feat(middleware): add request logging and content size limit middleware

### DIFF
--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -1,0 +1,112 @@
+"""ASGI middleware for request logging and body size limiting.
+
+Two middlewares:
+- RequestLoggingMiddleware  — attaches a UUID request-id to every request,
+  logs start/completion with elapsed_ms, and echoes the id in the response
+  header ``X-Request-ID``.
+- ContentSizeLimitMiddleware — rejects ``application/json`` requests whose
+  ``Content-Length`` header exceeds ``settings.MAX_JSON_BODY_SIZE_BYTES``.
+  Multipart requests and requests without a body are never blocked.
+"""
+
+import logging
+import time
+import uuid
+
+from starlette.datastructures import MutableHeaders, State
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.core.config import settings
+
+_logger = logging.getLogger(__name__)
+
+
+class RequestLoggingMiddleware:
+    """Log every HTTP request with its UUID request-id and elapsed time."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = str(uuid.uuid4())
+        if "state" not in scope or not isinstance(scope["state"], State):
+            scope["state"] = State()
+        scope["state"].request_id = request_id
+
+        path = scope.get("path", "")
+        method = scope.get("method", "")
+        _logger.info("request started method=%s path=%s request_id=%s", method, path, request_id)
+        start = time.perf_counter()
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers.append("X-Request-ID", request_id)
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            _logger.info(
+                "request completed method=%s path=%s request_id=%s elapsed_ms=%.1f",
+                method,
+                path,
+                request_id,
+                elapsed_ms,
+            )
+
+
+class ContentSizeLimitMiddleware:
+    """Reject application/json requests exceeding MAX_JSON_BODY_SIZE_BYTES.
+
+    Reads the ``Content-Length`` header only — does not buffer the body.
+    Multipart requests and requests without a content-type are ignored.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        content_type = headers.get(b"content-type", b"").decode("latin1").lower()
+        content_length_raw = headers.get(b"content-length", b"")
+
+        if "application/json" in content_type and content_length_raw:
+            try:
+                content_length = int(content_length_raw)
+            except ValueError:
+                content_length = 0
+
+            if content_length > settings.MAX_JSON_BODY_SIZE_BYTES:
+                _logger.warning(
+                    "Request body too large: %d bytes (limit %d)",
+                    content_length,
+                    settings.MAX_JSON_BODY_SIZE_BYTES,
+                )
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 413,
+                        "headers": [
+                            (b"content-type", b"application/json"),
+                        ],
+                    }
+                )
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": b'{"detail":"Request body too large"}',
+                    }
+                )
+                return
+
+        await self.app(scope, receive, send)

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -33,13 +33,15 @@ class RequestLoggingMiddleware:
             return
 
         request_id = str(uuid.uuid4())
-        if "state" not in scope or not isinstance(scope["state"], State):
+        if not isinstance(scope.get("state"), State):
             scope["state"] = State()
         scope["state"].request_id = request_id
 
         path = scope.get("path", "")
         method = scope.get("method", "")
-        _logger.info("request started method=%s path=%s request_id=%s", method, path, request_id)
+        _logger.info(
+            "request started method=%s path=%s request_id=%s", method, path, request_id
+        )
         start = time.perf_counter()
 
         async def send_with_request_id(message: Message) -> None:

--- a/backend/tests/core/test_middleware.py
+++ b/backend/tests/core/test_middleware.py
@@ -1,0 +1,207 @@
+"""Tests for app.core.middleware — RequestLoggingMiddleware and ContentSizeLimitMiddleware."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from app.core.middleware import ContentSizeLimitMiddleware, RequestLoggingMiddleware
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _ok_app():
+    """Minimal Starlette app that handles GET and POST at '/'."""
+
+    async def homepage(request: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok"})
+
+    return Starlette(routes=[Route("/", homepage, methods=["GET", "POST"])])
+
+
+def _state_app():
+    """App that echoes scope state request_id back in the response body."""
+
+    async def homepage(request: Request) -> JSONResponse:
+        return JSONResponse({"request_id": getattr(request.state, "request_id", None)})
+
+    return Starlette(routes=[Route("/", homepage)])
+
+
+# ── RequestLoggingMiddleware ──────────────────────────────────────────────────
+
+
+class TestRequestLoggingMiddleware:
+    """Response must carry X-Request-ID; consecutive requests must have distinct IDs."""
+
+    def test_response_has_x_request_id_header(self) -> None:
+        app = RequestLoggingMiddleware(_ok_app())
+        client = TestClient(app)
+        response = client.get("/")
+        assert "x-request-id" in response.headers
+
+    def test_x_request_id_is_a_valid_uuid(self) -> None:
+        import uuid as _uuid
+
+        app = RequestLoggingMiddleware(_ok_app())
+        client = TestClient(app)
+        response = client.get("/")
+        _uuid.UUID(response.headers["x-request-id"])
+
+    def test_consecutive_requests_have_distinct_ids(self) -> None:
+        app = RequestLoggingMiddleware(_ok_app())
+        client = TestClient(app)
+        r1 = client.get("/")
+        r2 = client.get("/")
+        assert r1.headers["x-request-id"] != r2.headers["x-request-id"]
+
+    def test_request_id_set_in_scope_state(self) -> None:
+        app = RequestLoggingMiddleware(_state_app())
+        client = TestClient(app)
+        response = client.get("/")
+        body = response.json()
+        assert body["request_id"] == response.headers["x-request-id"]
+
+    def test_non_http_scope_passes_through(self) -> None:
+        """Non-HTTP scopes (e.g. lifespan) must be forwarded unchanged."""
+        called = []
+
+        async def raw_app(scope, receive, send):
+            called.append(scope["type"])
+
+        mw = RequestLoggingMiddleware(raw_app)
+
+        async def run():
+            await mw({"type": "lifespan"}, None, None)
+
+        asyncio.run(run())
+        assert called == ["lifespan"]
+
+    def test_logs_request_started(self) -> None:
+        with patch("app.core.middleware._logger") as mock_logger:
+            app = RequestLoggingMiddleware(_ok_app())
+            client = TestClient(app)
+            client.get("/")
+        assert mock_logger.info.called
+        first_call_msg = mock_logger.info.call_args_list[0].args[0]
+        assert "request started" in first_call_msg
+
+    def test_logs_request_completed(self) -> None:
+        with patch("app.core.middleware._logger") as mock_logger:
+            app = RequestLoggingMiddleware(_ok_app())
+            client = TestClient(app)
+            client.get("/")
+        assert mock_logger.info.call_count >= 2
+        last_call_msg = mock_logger.info.call_args_list[-1].args[0]
+        assert "request completed" in last_call_msg
+
+
+# ── ContentSizeLimitMiddleware ────────────────────────────────────────────────
+
+
+class TestContentSizeLimitMiddleware:
+    """Small JSON must pass; oversized JSON must get 413; multipart is never blocked."""
+
+    def test_small_json_body_returns_200(self) -> None:
+        inner = _ok_app()
+        app = ContentSizeLimitMiddleware(inner)
+        with patch("app.core.middleware.settings") as mock_settings:
+            mock_settings.MAX_JSON_BODY_SIZE_BYTES = 1_048_576
+            client = TestClient(app)
+            response = client.post(
+                "/",
+                content=b'{"key":"value"}',
+                headers={"Content-Type": "application/json"},
+            )
+        assert response.status_code == 200
+
+    def test_oversized_json_body_returns_413(self) -> None:
+        inner = _ok_app()
+        app = ContentSizeLimitMiddleware(inner)
+        two_mb = 2 * 1024 * 1024
+        with patch("app.core.middleware.settings") as mock_settings:
+            mock_settings.MAX_JSON_BODY_SIZE_BYTES = 1024  # 1 KB limit
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/",
+                content=b"x" * two_mb,
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(two_mb),
+                },
+            )
+        assert response.status_code == 413
+
+    def test_413_response_has_json_detail(self) -> None:
+        inner = _ok_app()
+        app = ContentSizeLimitMiddleware(inner)
+        two_mb = 2 * 1024 * 1024
+        with patch("app.core.middleware.settings") as mock_settings:
+            mock_settings.MAX_JSON_BODY_SIZE_BYTES = 1024
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/",
+                content=b"x" * two_mb,
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(two_mb),
+                },
+            )
+        assert "detail" in response.json()
+
+    def test_multipart_request_is_not_blocked(self) -> None:
+        inner = _ok_app()
+        app = ContentSizeLimitMiddleware(inner)
+        with patch("app.core.middleware.settings") as mock_settings:
+            mock_settings.MAX_JSON_BODY_SIZE_BYTES = 1  # tiny limit
+            client = TestClient(app)
+            response = client.post(
+                "/",
+                files={"file": ("f.txt", b"a" * 1000, "text/plain")},
+            )
+        assert response.status_code == 200
+
+    def test_get_request_without_body_passes(self) -> None:
+        inner = _ok_app()
+        app = ContentSizeLimitMiddleware(inner)
+        with patch("app.core.middleware.settings") as mock_settings:
+            mock_settings.MAX_JSON_BODY_SIZE_BYTES = 1
+            client = TestClient(app)
+            response = client.get("/")
+        assert response.status_code == 200
+
+    def test_non_http_scope_passes_through(self) -> None:
+        called = []
+
+        async def raw_app(scope, receive, send):
+            called.append(scope["type"])
+
+        mw = ContentSizeLimitMiddleware(raw_app)
+
+        async def run():
+            await mw({"type": "lifespan"}, None, None)
+
+        asyncio.run(run())
+        assert called == ["lifespan"]
+
+    def test_invalid_content_length_header_does_not_raise(self) -> None:
+        inner = _ok_app()
+        app = ContentSizeLimitMiddleware(inner)
+        with patch("app.core.middleware.settings") as mock_settings:
+            mock_settings.MAX_JSON_BODY_SIZE_BYTES = 1024
+            client = TestClient(app)
+            response = client.post(
+                "/",
+                content=b'{"key":"value"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": "not-a-number",
+                },
+            )
+        assert response.status_code == 200

--- a/backend/tests/core/test_middleware.py
+++ b/backend/tests/core/test_middleware.py
@@ -3,7 +3,6 @@
 import asyncio
 from unittest.mock import patch
 
-import pytest
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -12,14 +11,13 @@ from starlette.testclient import TestClient
 
 from app.core.middleware import ContentSizeLimitMiddleware, RequestLoggingMiddleware
 
-
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
 def _ok_app():
     """Minimal Starlette app that handles GET and POST at '/'."""
 
-    async def homepage(request: Request) -> JSONResponse:
+    async def homepage(_request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok"})
 
     return Starlette(routes=[Route("/", homepage, methods=["GET", "POST"])])
@@ -72,7 +70,7 @@ class TestRequestLoggingMiddleware:
         """Non-HTTP scopes (e.g. lifespan) must be forwarded unchanged."""
         called = []
 
-        async def raw_app(scope, receive, send):
+        async def raw_app(scope, _receive, _send):
             called.append(scope["type"])
 
         mw = RequestLoggingMiddleware(raw_app)
@@ -179,7 +177,7 @@ class TestContentSizeLimitMiddleware:
     def test_non_http_scope_passes_through(self) -> None:
         called = []
 
-        async def raw_app(scope, receive, send):
+        async def raw_app(scope, _receive, _send):
             called.append(scope["type"])
 
         mw = ContentSizeLimitMiddleware(raw_app)


### PR DESCRIPTION
## Summary

- Adds `RequestLoggingMiddleware`: attaches a UUID request-id to each HTTP request via `scope["state"].request_id`, logs `request started` and `request completed` with elapsed_ms, and appends `X-Request-ID` response header
- Adds `ContentSizeLimitMiddleware`: rejects `application/json` requests whose `Content-Length` exceeds `settings.MAX_JSON_BODY_SIZE_BYTES` (returns 413); multipart and headerless requests are never blocked
- Uses Starlette `State` object for scope state so `request.state.request_id` works correctly at call sites
- 14 tests covering header presence, UUID validity, distinct IDs per request, scope state propagation, logging, size enforcement, multipart bypass, and invalid header resilience

## Test plan

- [ ] All 14 tests in `tests/core/test_middleware.py` pass
- [ ] `pre-commit run --all-files` clean
- [ ] SonarCloud quality gate passes (new code coverage ≥ 80%)