### PR TITLE
feat(models): add audit_log model and reliability columns to document_translation

### DIFF
--- a/backend/app/alembic/versions/r8e9l1i2a3b4_add_audit_log_and_reliability_columns.py
+++ b/backend/app/alembic/versions/r8e9l1i2a3b4_add_audit_log_and_reliability_columns.py
@@ -1,0 +1,78 @@
+"""Add audit_log table and reliability columns to document_translation
+
+Revision ID: r8e9l1i2a3b4
+Revises: s1t2u3v4w5x6
+Create Date: 2026-05-06 14:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic
+revision = "r8e9l1i2a3b4"
+down_revision = "s1t2u3v4w5x6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── audit_log table ───────────────────────────────────────────────────────
+    op.create_table(
+        "audit_log",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("action", sa.String(100), nullable=False),
+        sa.Column("resource_type", sa.String(50), nullable=True),
+        sa.Column("resource_id", sa.String(100), nullable=True),
+        sa.Column("ip_address", sa.String(45), nullable=True),
+        sa.Column("request_id", sa.String(36), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default="success"),
+        sa.Column("extra_data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.create_index("ix_audit_log_user_id", "audit_log", ["user_id"])
+    op.create_index("ix_audit_log_action", "audit_log", ["action"])
+    op.create_index("ix_audit_log_resource_type", "audit_log", ["resource_type"])
+    op.create_index("ix_audit_log_created_at", "audit_log", ["created_at"])
+
+    # ── document_translation: reliability columns ─────────────────────────────
+    op.add_column(
+        "document_translation",
+        sa.Column(
+            "requires_manual_review",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "document_translation",
+        sa.Column("translation_confidence_score", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("document_translation", "translation_confidence_score")
+    op.drop_column("document_translation", "requires_manual_review")
+
+    op.drop_index("ix_audit_log_created_at", "audit_log")
+    op.drop_index("ix_audit_log_resource_type", "audit_log")
+    op.drop_index("ix_audit_log_action", "audit_log")
+    op.drop_index("ix_audit_log_user_id", "audit_log")
+    op.drop_table("audit_log")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -36,6 +36,7 @@ from app.models.article import (
     ArticleStatus,
     DifficultyLevel,
 )
+from app.models.audit_log import AuditLog
 from app.models.base import Base
 from app.models.calculator import HiddenCostCalculation
 from app.models.contract import ContractAnalysis
@@ -110,6 +111,7 @@ __all__ = [
     "UserUpdateMe",
     # New SQLAlchemy models
     "Article",
+    "AuditLog",
     "ArticleCategory",
     "ArticleRating",
     "ArticleStatus",

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -1,0 +1,42 @@
+"""AuditLog database model for tracking security-relevant actions."""
+
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class AuditLog(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Immutable audit trail for user and system actions.
+
+    Records are written fire-and-forget by audit_service.log_action().
+    Rows survive user deletion via SET NULL on user_id (regulatory
+    requirement — audit history must not be destroyed when an account
+    is removed).
+    """
+
+    __tablename__ = "audit_log"
+
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Action name — e.g. "document.upload", "payment.checkout_created"
+    action = Column(String(100), nullable=False, index=True)
+
+    # Optional resource context
+    resource_type = Column(String(50), nullable=True, index=True)
+    resource_id = Column(String(100), nullable=True)
+
+    # Request metadata
+    ip_address = Column(String(45), nullable=True)  # IPv6 max 45 chars
+    request_id = Column(String(36), nullable=True)
+
+    # Outcome — "success" | "failure"
+    status = Column(String(20), nullable=False, default="success")
+
+    # Arbitrary extra payload (userAgent, tier, etc.)
+    extra_data = Column(JSONB, nullable=True)

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -3,8 +3,10 @@
 from enum import Enum as PyEnum
 
 from sqlalchemy import (
+    Boolean,
     Column,
     DateTime,
+    Float,
     ForeignKey,
     Integer,
     String,
@@ -162,6 +164,15 @@ class DocumentTranslation(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     # Linked glossary terms (populated at processing time)
     glossary_links = Column(MutableList.as_mutable(JSONB), nullable=True, default=None)
+
+    # Confidence gating — set during processing when avg confidence < threshold
+    requires_manual_review = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+    )
+    translation_confidence_score = Column(Float, nullable=True)
 
     # Timing
     processing_started_at = Column(DateTime(timezone=True), nullable=True)


### PR DESCRIPTION
## Summary

- Adds `AuditLog` SQLAlchemy model with user_id (SET NULL FK), action, resource_type, resource_id, ip_address, request_id, status, and extra_data (JSONB) columns — audit rows survive user deletion per regulatory requirement
- Adds `requires_manual_review` (Boolean, server_default=false) and `translation_confidence_score` (Float, nullable) to `DocumentTranslation` for confidence gating
- Manual Alembic migration `r8e9l1i2a3b4` creates the audit_log table with indexes on user_id, action, resource_type, created_at, and adds both new columns to document_translation with backwards-compatible server defaults

## Test plan

- [ ] `python -m alembic upgrade head` applies cleanly (no errors)
- [ ] `python -m alembic downgrade -1` rolls back cleanly
- [ ] `pre-commit run --all-files` clean
- [ ] Backend test suite: no regressions vs main (1527 pass)