### PR TITLE
feat(email): add resend as preferred transactional email backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,10 @@ SMTP_TLS=True
 SMTP_SSL=False
 SMTP_PORT=587
 
-# SendGrid (preferred over SMTP when configured)
+# Resend (preferred when configured — resend.com, free tier 3k/month)
+RESEND_API_KEY=
+
+# SendGrid (used when Resend is not configured)
 SENDGRID_API_KEY=
 
 # Postgres

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -108,7 +108,10 @@ class Settings(BaseSettings):
             self.EMAILS_FROM_NAME = self.PROJECT_NAME
         return self
 
-    # SendGrid (preferred over SMTP when configured)
+    # Resend (preferred when configured — resend.com, free tier 3k/month)
+    RESEND_API_KEY: str | None = None
+
+    # SendGrid (used when Resend is not configured)
     SENDGRID_API_KEY: str | None = None
 
     EMAIL_RESET_TOKEN_EXPIRE_HOURS: int = 1
@@ -117,8 +120,14 @@ class Settings(BaseSettings):
     @property
     def emails_enabled(self) -> bool:
         return bool(
-            (self.SMTP_HOST or self.SENDGRID_API_KEY) and self.EMAILS_FROM_EMAIL
+            (self.RESEND_API_KEY or self.SMTP_HOST or self.SENDGRID_API_KEY)
+            and self.EMAILS_FROM_EMAIL
         )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def resend_enabled(self) -> bool:
+        return bool(self.RESEND_API_KEY)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -44,7 +44,14 @@ def send_email(
 ) -> None:
     assert settings.emails_enabled, "no provided configuration for email variables"
 
-    if settings.sendgrid_enabled:
+    if settings.resend_enabled:
+        _send_email_resend(
+            email_to=email_to,
+            subject=subject,
+            html_content=html_content,
+            unsubscribe_url=unsubscribe_url,
+        )
+    elif settings.sendgrid_enabled:
         _send_email_sendgrid(
             email_to=email_to,
             subject=subject,
@@ -57,6 +64,37 @@ def send_email(
             subject=subject,
             html_content=html_content,
         )
+
+
+def _send_email_resend(
+    *,
+    email_to: str,
+    subject: str,
+    html_content: str,
+    unsubscribe_url: str | None = None,
+) -> None:
+    """Send email via Resend API (preferred — resend.com, free tier 3k/month)."""
+    import resend
+
+    resend.api_key = settings.RESEND_API_KEY
+    from_address = (
+        f"{settings.EMAILS_FROM_NAME} <{settings.EMAILS_FROM_EMAIL}>"
+        if settings.EMAILS_FROM_NAME
+        else str(settings.EMAILS_FROM_EMAIL)
+    )
+    params: resend.Emails.SendParams = {
+        "from": from_address,
+        "to": [email_to],
+        "subject": subject,
+        "html": html_content,
+    }
+    if unsubscribe_url:
+        params["headers"] = {
+            "List-Unsubscribe": f"<{unsubscribe_url}>",
+            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        }
+    email = resend.Emails.send(params)
+    logger.info("Resend email id: %s", email.get("id"))
 
 
 def _send_email_sendgrid(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "starlette>=0.47.2",
     "redis>=5.0.0",
     "fakeredis>=2.0.0",
+    "resend>=2.0.0",
     "sendgrid>=6.11.0",
     "anthropic>=0.49.0",
     "python-dateutil>=2.8.0",

--- a/backend/tests/test_email_utils.py
+++ b/backend/tests/test_email_utils.py
@@ -1,4 +1,4 @@
-"""Tests for email utility functions (SendGrid dispatch, send_email routing)."""
+"""Tests for email utility functions (send_email routing, Resend/SendGrid/SMTP backends)."""
 
 import sys
 from unittest.mock import MagicMock, patch
@@ -7,10 +7,29 @@ import pytest
 
 
 class TestSendEmail:
+    @patch("app.utils._send_email_resend")
+    @patch("app.utils.settings")
+    def test_prefers_resend_when_enabled(self, mock_settings, mock_resend) -> None:
+        mock_settings.emails_enabled = True
+        mock_settings.resend_enabled = True
+
+        from app.utils import send_email
+
+        send_email(
+            email_to="a@b.com",
+            subject="Hi",
+            html_content="<p>test</p>",
+        )
+
+        mock_resend.assert_called_once()
+
     @patch("app.utils._send_email_sendgrid")
     @patch("app.utils.settings")
-    def test_prefers_sendgrid_when_enabled(self, mock_settings, mock_sg) -> None:
+    def test_prefers_sendgrid_when_resend_disabled(
+        self, mock_settings, mock_sg
+    ) -> None:
         mock_settings.emails_enabled = True
+        mock_settings.resend_enabled = False
         mock_settings.sendgrid_enabled = True
 
         from app.utils import send_email
@@ -27,6 +46,7 @@ class TestSendEmail:
     @patch("app.utils.settings")
     def test_falls_back_to_smtp(self, mock_settings, mock_smtp) -> None:
         mock_settings.emails_enabled = True
+        mock_settings.resend_enabled = False
         mock_settings.sendgrid_enabled = False
 
         from app.utils import send_email
@@ -47,6 +67,114 @@ class TestSendEmail:
 
         with pytest.raises(AssertionError):
             send_email(email_to="a@b.com", subject="Hi", html_content="<p>test</p>")
+
+    @patch("app.utils._send_email_resend")
+    @patch("app.utils._send_email_sendgrid")
+    @patch("app.utils.settings")
+    def test_resend_takes_priority_over_sendgrid(
+        self, mock_settings, mock_sg, mock_resend
+    ) -> None:
+        mock_settings.emails_enabled = True
+        mock_settings.resend_enabled = True
+        mock_settings.sendgrid_enabled = True
+
+        from app.utils import send_email
+
+        send_email(email_to="a@b.com", subject="Hi", html_content="<p>test</p>")
+
+        mock_resend.assert_called_once()
+        mock_sg.assert_not_called()
+
+
+class TestSendEmailResend:
+    @patch("app.utils.settings")
+    def test_sends_basic_email(self, mock_settings) -> None:
+        mock_settings.RESEND_API_KEY = "re_test_key"
+        mock_settings.EMAILS_FROM_EMAIL = "from@test.com"
+        mock_settings.EMAILS_FROM_NAME = "Test Sender"
+
+        mock_resend_module = MagicMock()
+        mock_resend_module.Emails.send.return_value = {"id": "abc123"}
+
+        with patch.dict(sys.modules, {"resend": mock_resend_module}):
+            from app.utils import _send_email_resend
+
+            _send_email_resend(
+                email_to="to@test.com",
+                subject="Test subject",
+                html_content="<p>Hello</p>",
+            )
+
+        mock_resend_module.Emails.send.assert_called_once()
+        call_params = mock_resend_module.Emails.send.call_args[0][0]
+        assert call_params["to"] == ["to@test.com"]
+        assert call_params["subject"] == "Test subject"
+        assert "headers" not in call_params
+
+    @patch("app.utils.settings")
+    def test_sends_with_unsubscribe_headers(self, mock_settings) -> None:
+        mock_settings.RESEND_API_KEY = "re_test_key"
+        mock_settings.EMAILS_FROM_EMAIL = "from@test.com"
+        mock_settings.EMAILS_FROM_NAME = "Test Sender"
+
+        mock_resend_module = MagicMock()
+        mock_resend_module.Emails.send.return_value = {"id": "abc123"}
+
+        with patch.dict(sys.modules, {"resend": mock_resend_module}):
+            from app.utils import _send_email_resend
+
+            _send_email_resend(
+                email_to="to@test.com",
+                subject="Test",
+                html_content="<p>Hello</p>",
+                unsubscribe_url="https://example.com/unsub",
+            )
+
+        call_params = mock_resend_module.Emails.send.call_args[0][0]
+        assert "headers" in call_params
+        assert "List-Unsubscribe" in call_params["headers"]
+
+    @patch("app.utils.settings")
+    def test_from_address_format_with_name(self, mock_settings) -> None:
+        mock_settings.RESEND_API_KEY = "re_test_key"
+        mock_settings.EMAILS_FROM_EMAIL = "no-reply@heimpath.com"
+        mock_settings.EMAILS_FROM_NAME = "HeimPath"
+
+        mock_resend_module = MagicMock()
+        mock_resend_module.Emails.send.return_value = {"id": "abc123"}
+
+        with patch.dict(sys.modules, {"resend": mock_resend_module}):
+            from app.utils import _send_email_resend
+
+            _send_email_resend(
+                email_to="user@example.com",
+                subject="Welcome",
+                html_content="<p>Hi</p>",
+            )
+
+        call_params = mock_resend_module.Emails.send.call_args[0][0]
+        assert call_params["from"] == "HeimPath <no-reply@heimpath.com>"
+
+    @patch("app.utils.settings")
+    def test_from_address_format_without_name(self, mock_settings) -> None:
+        mock_settings.RESEND_API_KEY = "re_test_key"
+        mock_settings.EMAILS_FROM_EMAIL = "no-reply@heimpath.com"
+        mock_settings.EMAILS_FROM_NAME = None
+
+        mock_resend_module = MagicMock()
+        mock_resend_module.Emails.send.return_value = {"id": "abc123"}
+
+        with patch.dict(sys.modules, {"resend": mock_resend_module}):
+            from app.utils import _send_email_resend
+
+            _send_email_resend(
+                email_to="user@example.com",
+                subject="Welcome",
+                html_content="<p>Hi</p>",
+            )
+
+        call_params = mock_resend_module.Emails.send.call_args[0][0]
+        assert call_params["from"] == "no-reply@heimpath.com"
 
 
 class TestSendEmailSendgrid:

--- a/uv.lock
+++ b/uv.lock
@@ -250,6 +250,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "python-multipart" },
     { name = "redis" },
+    { name = "resend" },
     { name = "sendgrid" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -294,6 +295,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "python-multipart", specifier = ">=0.0.26,<1.0.0" },
     { name = "redis", specifier = ">=5.0.0" },
+    { name = "resend", specifier = ">=2.0.0" },
     { name = "sendgrid", specifier = ">=6.11.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=1.40.6" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
@@ -2920,6 +2922,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "resend"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b5/dffc1acd852c708c48626d064a54c83acf0f6c8f097efc14e3b5c3a3ad99/resend-2.30.0.tar.gz", hash = "sha256:4c3c634316ad1a1fe7c5453afdd560c7d318ba18960149a8159f3bed334eb386", size = 43201, upload-time = "2026-05-04T16:23:43.203Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/05/c1114a7d29e0543d815cb9b5ac0f00b6ea7bb65507d952f2896d61acdc2b/resend-2.30.0-py2.py3-none-any.whl", hash = "sha256:a8993ad6be911b039f86d5853bb2b478cc2aa66c82f1829f0b1b2e0753cf09c4", size = 68388, upload-time = "2026-05-04T16:23:42.172Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `resend>=2.0.0` as the preferred transactional email backend (free tier: 3k emails/month)
- `send_email()` dispatch order: Resend → SendGrid → SMTP
- When `RESEND_API_KEY` is set, all outbound email (verification, password reset, test) uses the Resend API
- SendGrid and SMTP remain as fallbacks with no behavior changes
- `List-Unsubscribe` headers are forwarded to Resend when `unsubscribe_url` is provided

## Test plan

- [x] 11 unit tests pass (`test_email_utils.py`)
- [x] Resend priority over SendGrid and SMTP verified
- [x] `from` address formatted as `"Name <email>"` when `EMAILS_FROM_NAME` is set
- [x] Unsubscribe headers passed through correctly
- [x] pre-commit clean (ruff, biome, format)