### PR TITLE
fix(email): block registration spam and add notification email flag

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -68,6 +68,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 )
 async def register(
     request: RegisterRequest,
+    http_request: Request,
     session: Session = Depends(get_db),
 ) -> User:
     """
@@ -78,11 +79,22 @@ async def register(
     - At least 1 uppercase letter
     - At least 1 number
 
-    Rate limiting: 3 attempts per hour.
+    Rate limiting: 3 attempts per hour per email, 5 per hour per IP.
 
     Returns the created user (without password).
     """
-    # Check rate limit before processing
+    client_ip = http_request.client.host if http_request.client else None
+
+    # Check IP-based registration rate limit first (prevents mass-registration
+    # with different emails from the same source, which exhausts email quotas).
+    if client_ip and rate_limit_service.is_ip_register_locked(client_ip):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many registration attempts. Please try again later.",
+            headers={"Retry-After": "3600"},
+        )
+
+    # Check per-email rate limit
     if rate_limit_service.is_register_locked(request.email):
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -122,6 +134,12 @@ async def register(
         rate_limit_service.record_register_attempt(request.email)
     except Exception:
         logger.warning("Failed to record register rate-limit for %s", request.email)
+
+    try:
+        if client_ip:
+            rate_limit_service.record_ip_register(client_ip)
+    except Exception:
+        logger.warning("Failed to record IP register rate-limit for %s", client_ip)
 
     try:
         token_data = generate_verification_token(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -181,6 +181,12 @@ class Settings(BaseSettings):
     MAX_JSON_BODY_SIZE_BYTES: int = 1_048_576  # 1 MB
     DB_STATEMENT_TIMEOUT_MS: int = 10_000  # 10 seconds
 
+    # Email settings
+    # Set NOTIFICATION_EMAILS_ENABLED=false to suppress all non-essential emails
+    # (notifications, weekly digest).  Forgot-password and email verification
+    # emails are always sent regardless of this flag.
+    NOTIFICATION_EMAILS_ENABLED: bool = True
+
     # Domain used to construct absolute backend URLs (e.g. avatar serving)
     DOMAIN: str = "localhost"
 

--- a/backend/app/services/digest_service.py
+++ b/backend/app/services/digest_service.py
@@ -33,6 +33,10 @@ def send_weekly_digest(session: Session) -> int:
     Returns:
         Number of digest emails successfully sent.
     """
+    if not settings.NOTIFICATION_EMAILS_ENABLED:
+        logger.info("Notification emails disabled — skipping weekly digest")
+        return 0
+
     from app.models import User
 
     one_week_ago = datetime.now(timezone.utc) - timedelta(days=7)

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -288,6 +288,8 @@ def _send_notification_email(
     try:
         if not settings.emails_enabled:
             return
+        if not settings.NOTIFICATION_EMAILS_ENABLED:
+            return
 
         from app.models import User
 

--- a/backend/app/services/rate_limit_service.py
+++ b/backend/app/services/rate_limit_service.py
@@ -57,6 +57,16 @@ IP_FAILED_LOCKOUT_SECONDS: int = 3600  # 1 hour
 _IP_FAILED_ATTEMPTS_PREFIX = "auth:ratelimit:ip:attempts:"
 _IP_FAILED_LOCKOUT_PREFIX = "auth:ratelimit:ip:lockout:"
 
+# IP-based registration rate limit constants
+# Prevents a single source from mass-registering accounts with different emails
+# (which would exhaust transactional email API daily quotas).
+IP_REGISTER_MAX: int = 5
+IP_REGISTER_WINDOW_SECONDS: int = 3600  # 1 hour
+IP_REGISTER_LOCKOUT_SECONDS: int = 3600  # 1 hour
+
+_IP_REGISTER_ATTEMPTS_PREFIX = "auth:ratelimit:ip_register:attempts:"
+_IP_REGISTER_LOCKOUT_PREFIX = "auth:ratelimit:ip_register:lockout:"
+
 # ── Professional click rate limiting ─────────────────────────────────────────
 # Professional click rate limit constants
 CLICK_MAX_ATTEMPTS: int = 20
@@ -299,4 +309,24 @@ def record_ip_failed(ip: str) -> RateLimitInfo:
         IP_FAILED_MAX,
         IP_FAILED_WINDOW_SECONDS,
         IP_FAILED_LOCKOUT_SECONDS,
+    )
+
+
+# ── IP-based registration rate limiting ───────────────────────────────────────
+
+
+def is_ip_register_locked(ip: str) -> bool:
+    """Return *True* if the IP is locked for new account registrations."""
+    return _redis().ttl(f"{_IP_REGISTER_LOCKOUT_PREFIX}{ip}") > 0
+
+
+def record_ip_register(ip: str) -> RateLimitInfo:
+    """Record a registration from an IP and return the updated status."""
+    return _record_attempt(
+        ip,
+        _IP_REGISTER_ATTEMPTS_PREFIX,
+        _IP_REGISTER_LOCKOUT_PREFIX,
+        IP_REGISTER_MAX,
+        IP_REGISTER_WINDOW_SECONDS,
+        IP_REGISTER_LOCKOUT_SECONDS,
     )

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -190,7 +190,7 @@ export class AuthService {
      * - At least 1 uppercase letter
      * - At least 1 number
      *
-     * Rate limiting: 3 attempts per hour.
+     * Rate limiting: 3 attempts per hour per email, 5 per hour per IP.
      *
      * Returns the created user (without password).
      * @param data The data for the request.


### PR DESCRIPTION
## Summary

- **IP-based registration rate limiting**: Limits new account registrations to 5 per IP per hour. Previously, rate limiting only tracked per email address, so spammers using a different email each time could create unlimited accounts and exhaust the Resend daily email quota.
- **`NOTIFICATION_EMAILS_ENABLED` flag**: New config setting (default `true`). Set `NOTIFICATION_EMAILS_ENABLED=false` in the environment to immediately suppress all notification emails (in-app event notifications, weekly digests) while keeping forgot-password and email verification emails active.

## Test plan

- [ ] Verify existing auth tests still pass (`pytest tests/api/routes/test_auth.py`)
- [ ] Verify rate limit tests still pass (`pytest tests/services/test_rate_limit_service.py`)
- [ ] Set `NOTIFICATION_EMAILS_ENABLED=false` and confirm no notification/digest emails are sent
- [ ] Confirm forgot-password and email verification emails still send when flag is `false`
- [ ] Attempt 6 registrations from the same IP within an hour — 6th should receive 429