### PR TITLE
fix(auth): add IP rate limiting to forgot-password and resend-verification

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -468,6 +468,7 @@ async def verify_email(
 @router.post("/resend-verification", response_model=VerifyEmailResponse)
 async def resend_verification(
     request: ResendVerificationRequest,
+    http_request: Request,
     session: Session = Depends(get_db),
 ) -> VerifyEmailResponse:
     """
@@ -476,11 +477,20 @@ async def resend_verification(
     Generates a new verification token and sends it to the user's email.
     Any previous token for the user is invalidated.
 
-    Rate limiting: 3 attempts per hour.
+    Rate limiting: 3 attempts per hour per email, 10 per hour per IP.
 
     Note: Always returns success to prevent email enumeration attacks.
     """
-    # Check rate limit before processing
+    client_ip = http_request.client.host if http_request.client else None
+
+    if client_ip and rate_limit_service.is_ip_resend_verification_locked(client_ip):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many verification email requests. Please try again later.",
+            headers={"Retry-After": "3600"},
+        )
+
+    # Check per-email rate limit before processing
     if rate_limit_service.is_resend_verification_locked(request.email):
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -490,6 +500,14 @@ async def resend_verification(
 
     # Record attempt regardless of outcome (prevents email enumeration via timing)
     rate_limit_service.record_resend_verification_attempt(request.email)
+
+    try:
+        if client_ip:
+            rate_limit_service.record_ip_resend_verification(client_ip)
+    except Exception:
+        logger.warning(
+            "Failed to record IP resend-verification rate-limit for %s", client_ip
+        )
 
     # Find user by email
     statement = select(User).where(User.email == request.email)
@@ -538,6 +556,7 @@ async def resend_verification(
 @router.post("/forgot-password", response_model=ForgotPasswordResponse)
 async def forgot_password(
     request: ForgotPasswordRequest,
+    http_request: Request,
     session: Session = Depends(get_db),
 ) -> ForgotPasswordResponse:
     """
@@ -546,11 +565,20 @@ async def forgot_password(
     Generates a reset token and sends it to the user's email.
     Tokens expire after 1 hour.
 
-    Rate limiting: 3 attempts per hour.
+    Rate limiting: 3 attempts per hour per email, 10 per hour per IP.
 
     Note: Always returns success to prevent email enumeration attacks.
     """
-    # Check rate limit before processing
+    client_ip = http_request.client.host if http_request.client else None
+
+    if client_ip and rate_limit_service.is_ip_password_reset_locked(client_ip):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many password reset attempts. Please try again later.",
+            headers={"Retry-After": "3600"},
+        )
+
+    # Check per-email rate limit before processing
     if rate_limit_service.is_password_reset_locked(request.email):
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -564,6 +592,14 @@ async def forgot_password(
 
     # Record attempt regardless of outcome (prevents email enumeration via timing)
     rate_limit_service.record_password_reset_attempt(request.email)
+
+    try:
+        if client_ip:
+            rate_limit_service.record_ip_password_reset(client_ip)
+    except Exception:
+        logger.warning(
+            "Failed to record IP password-reset rate-limit for %s", client_ip
+        )
 
     statement = select(User).where(User.email == request.email)
     user = session.exec(statement).first()

--- a/backend/app/services/rate_limit_service.py
+++ b/backend/app/services/rate_limit_service.py
@@ -67,6 +67,28 @@ IP_REGISTER_LOCKOUT_SECONDS: int = 3600  # 1 hour
 _IP_REGISTER_ATTEMPTS_PREFIX = "auth:ratelimit:ip_register:attempts:"
 _IP_REGISTER_LOCKOUT_PREFIX = "auth:ratelimit:ip_register:lockout:"
 
+# IP-based password reset rate limit constants
+# Prevents a bot from triggering password reset emails for many different
+# addresses from a single source.
+IP_PASSWORD_RESET_MAX: int = 10
+IP_PASSWORD_RESET_WINDOW_SECONDS: int = 3600  # 1 hour
+IP_PASSWORD_RESET_LOCKOUT_SECONDS: int = 3600  # 1 hour
+
+_IP_PASSWORD_RESET_ATTEMPTS_PREFIX = "auth:ratelimit:ip_password_reset:attempts:"
+_IP_PASSWORD_RESET_LOCKOUT_PREFIX = "auth:ratelimit:ip_password_reset:lockout:"
+
+# IP-based resend-verification rate limit constants
+IP_RESEND_VERIFICATION_MAX: int = 10
+IP_RESEND_VERIFICATION_WINDOW_SECONDS: int = 3600  # 1 hour
+IP_RESEND_VERIFICATION_LOCKOUT_SECONDS: int = 3600  # 1 hour
+
+_IP_RESEND_VERIFICATION_ATTEMPTS_PREFIX = (
+    "auth:ratelimit:ip_resend_verification:attempts:"
+)
+_IP_RESEND_VERIFICATION_LOCKOUT_PREFIX = (
+    "auth:ratelimit:ip_resend_verification:lockout:"
+)
+
 # ── Professional click rate limiting ─────────────────────────────────────────
 # Professional click rate limit constants
 CLICK_MAX_ATTEMPTS: int = 20
@@ -329,4 +351,44 @@ def record_ip_register(ip: str) -> RateLimitInfo:
         IP_REGISTER_MAX,
         IP_REGISTER_WINDOW_SECONDS,
         IP_REGISTER_LOCKOUT_SECONDS,
+    )
+
+
+# ── IP-based password reset rate limiting ─────────────────────────────────────
+
+
+def is_ip_password_reset_locked(ip: str) -> bool:
+    """Return *True* if the IP is locked for password reset requests."""
+    return _redis().ttl(f"{_IP_PASSWORD_RESET_LOCKOUT_PREFIX}{ip}") > 0
+
+
+def record_ip_password_reset(ip: str) -> RateLimitInfo:
+    """Record a password reset request from an IP and return the updated status."""
+    return _record_attempt(
+        ip,
+        _IP_PASSWORD_RESET_ATTEMPTS_PREFIX,
+        _IP_PASSWORD_RESET_LOCKOUT_PREFIX,
+        IP_PASSWORD_RESET_MAX,
+        IP_PASSWORD_RESET_WINDOW_SECONDS,
+        IP_PASSWORD_RESET_LOCKOUT_SECONDS,
+    )
+
+
+# ── IP-based resend-verification rate limiting ────────────────────────────────
+
+
+def is_ip_resend_verification_locked(ip: str) -> bool:
+    """Return *True* if the IP is locked for resend-verification requests."""
+    return _redis().ttl(f"{_IP_RESEND_VERIFICATION_LOCKOUT_PREFIX}{ip}") > 0
+
+
+def record_ip_resend_verification(ip: str) -> RateLimitInfo:
+    """Record a resend-verification request from an IP and return the updated status."""
+    return _record_attempt(
+        ip,
+        _IP_RESEND_VERIFICATION_ATTEMPTS_PREFIX,
+        _IP_RESEND_VERIFICATION_LOCKOUT_PREFIX,
+        IP_RESEND_VERIFICATION_MAX,
+        IP_RESEND_VERIFICATION_WINDOW_SECONDS,
+        IP_RESEND_VERIFICATION_LOCKOUT_SECONDS,
     )

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -316,7 +316,7 @@ export class AuthService {
      * Generates a new verification token and sends it to the user's email.
      * Any previous token for the user is invalidated.
      *
-     * Rate limiting: 3 attempts per hour.
+     * Rate limiting: 3 attempts per hour per email, 10 per hour per IP.
      *
      * Note: Always returns success to prevent email enumeration attacks.
      * @param data The data for the request.
@@ -343,7 +343,7 @@ export class AuthService {
      * Generates a reset token and sends it to the user's email.
      * Tokens expire after 1 hour.
      *
-     * Rate limiting: 3 attempts per hour.
+     * Rate limiting: 3 attempts per hour per email, 10 per hour per IP.
      *
      * Note: Always returns success to prevent email enumeration attacks.
      * @param data The data for the request.


### PR DESCRIPTION
## Summary

Closes the same bot attack vector that allowed email quota exhaustion via the `/forgot-password` and `/resend-verification` endpoints.

Previously, both endpoints only enforced per-email rate limits (3/hour). A bot cycling through different email addresses could bypass this entirely and trigger unlimited transactional emails.

- `/forgot-password`: 10 requests/hour per IP, then 1-hour lockout
- `/resend-verification`: 10 requests/hour per IP, then 1-hour lockout

Both limits are higher than registration (5/hour) to account for legitimate users who may switch devices or share IPs (e.g. office NAT).

## Test plan

- [ ] `pytest tests/api/routes/test_auth.py tests/services/test_rate_limit_service.py` — all pass
- [ ] 11th forgot-password request from same IP within an hour → 429
- [ ] 11th resend-verification request from same IP within an hour → 429
- [ ] Legitimate user (different IP) is unaffected