### PR TITLE
feat(frontend): add react error boundary to prevent white-screen crashes

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "fastapi[standard]>=0.116.0,<1.0.0",
-    "python-multipart<1.0.0,>=0.0.26",
+    "python-multipart<1.0.0,>=0.0.27",
     "email-validator<3.0.0.0,>=2.1.0.post1",
     "tenacity<9.0.0,>=8.2.3",
     "pybreaker<2.0.0,>=1.2.0",

--- a/frontend/src/components/Common/ErrorBoundary/index.tsx
+++ b/frontend/src/components/Common/ErrorBoundary/index.tsx
@@ -1,0 +1,101 @@
+import * as Sentry from "@sentry/react"
+import { Component, type ErrorInfo, type ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const FALLBACK_TITLE = "Something went wrong"
+const FALLBACK_MESSAGE =
+  "An unexpected error occurred. You can try reloading the page or returning to the dashboard."
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IProps {
+  children: ReactNode
+  /** Optional custom fallback. If omitted the default fallback UI is shown. */
+  fallback?: ReactNode
+}
+
+interface IState {
+  hasError: boolean
+  eventId: string | null
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/**
+ * Global React Error Boundary.
+ *
+ * Catches render-time exceptions that would otherwise produce a white screen.
+ * Captures the error to Sentry (when configured) and renders a fallback UI
+ * with recovery actions.
+ *
+ * Error Boundaries must be class components — this is a React requirement.
+ */
+class ErrorBoundary extends Component<Readonly<IProps>, IState> {
+  constructor(props: Readonly<IProps>) {
+    super(props)
+    this.state = { hasError: false, eventId: null }
+  }
+
+  static getDerivedStateFromError(_error: Error): IState {
+    return { hasError: true, eventId: null }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    const eventId = Sentry.captureException(error, {
+      extra: { componentStack: info.componentStack },
+    })
+    this.setState({ eventId: eventId ?? null })
+  }
+
+  render(): ReactNode {
+    const { hasError, eventId } = this.state
+    const { children, fallback } = this.props
+
+    if (!hasError) {
+      return children
+    }
+
+    if (fallback) {
+      return fallback
+    }
+
+    return (
+      <div
+        className="flex min-h-[400px] flex-col items-center justify-center gap-4 p-8 text-center"
+        data-testid="error-boundary-fallback"
+      >
+        <div className="flex flex-col items-center gap-2">
+          <span className="text-4xl font-bold">{FALLBACK_TITLE}</span>
+          <p className="max-w-md text-muted-foreground">{FALLBACK_MESSAGE}</p>
+          {eventId && (
+            <p className="text-xs text-muted-foreground">
+              Reference: <span className="font-mono">{eventId}</span>
+            </p>
+          )}
+        </div>
+        <div className="flex gap-3">
+          <Button variant="outline" onClick={() => window.location.reload()}>
+            Reload page
+          </Button>
+          <Button asChild>
+            <a href="/dashboard">Go to dashboard</a>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default ErrorBoundary

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { createRootRoute, HeadContent, Outlet } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
+import ErrorBoundary from "@/components/Common/ErrorBoundary"
 import ErrorComponent from "@/components/Common/ErrorComponent"
 import NotFound from "@/components/Common/NotFound"
 
@@ -8,7 +9,9 @@ export const Route = createRootRoute({
   component: () => (
     <>
       <HeadContent />
-      <Outlet />
+      <ErrorBoundary>
+        <Outlet />
+      </ErrorBoundary>
       <TanStackRouterDevtools position="bottom-right" />
       <ReactQueryDevtools initialIsOpen={false} />
     </>

--- a/frontend/src/routes/_layout/documents/$documentId.tsx
+++ b/frontend/src/routes/_layout/documents/$documentId.tsx
@@ -6,6 +6,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { ArrowLeft, FileText, Share2, Trash2 } from "lucide-react"
 import { useCallback, useState } from "react"
+import ErrorBoundary from "@/components/Common/ErrorBoundary"
 import {
   ClauseAnalysis,
   ClauseHighlights,
@@ -28,7 +29,7 @@ import type { DocumentType } from "@/models/document"
 ******************************************************************************/
 
 export const Route = createFileRoute("/_layout/documents/$documentId")({
-  component: DocumentDetailPage,
+  component: DocumentDetailPageWithBoundary,
   head: () => ({
     meta: [{ title: "Document Details - HeimPath" }],
   }),
@@ -228,4 +229,15 @@ function DocumentDetailPage() {
                               Export
 ******************************************************************************/
 
-export default DocumentDetailPage
+/** Wraps the document detail page with a route-level error boundary so that
+ *  render failures (e.g. unexpected API response shapes) degrade gracefully
+ *  without crashing the sidebar or global navigation. */
+function DocumentDetailPageWithBoundary() {
+  return (
+    <ErrorBoundary>
+      <DocumentDetailPage />
+    </ErrorBoundary>
+  )
+}
+
+export default DocumentDetailPageWithBoundary

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.2.1,<3.0.0" },
     { name = "pyjwt", specifier = ">=2.12.0,<3.0.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
-    { name = "python-multipart", specifier = ">=0.0.26,<1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.27,<1.0.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "resend", specifier = ">=2.0.0" },
     { name = "sendgrid", specifier = ">=6.11.0" },
@@ -1808,14 +1808,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -2826,11 +2826,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `ErrorBoundary` class component (`src/components/Common/ErrorBoundary/index.tsx`) that catches render-time exceptions, captures them to Sentry with a reference ID, and shows a fallback UI with **Reload page** and **Go to dashboard** recovery actions
- Wraps the root `<Outlet />` in `__root.tsx` so any unhandled render error anywhere in the app is caught
- Adds a route-level `ErrorBoundary` on the document detail page — the highest-risk route for API shape mismatches after `transformKeys`

## Test plan

- [ ] Verify TypeScript compiles with no errors (`bunx tsc --noEmit`)
- [ ] In dev, throw an error from a child component and confirm the fallback renders instead of a white screen
- [ ] Confirm Sentry receives the event and the reference ID appears in the fallback UI
- [ ] Confirm the document detail page catches render errors without crashing the sidebar/nav
- [ ] Confirm `errorComponent` (route async errors) and `ErrorBoundary` (render errors) remain complementary — both still active