### PR TITLE
feat(payments): add stripe webhook idempotency via deduplication table

### DIFF
--- a/backend/app/alembic/versions/s3t4u5v6w7x8_add_processed_webhook_event.py
+++ b/backend/app/alembic/versions/s3t4u5v6w7x8_add_processed_webhook_event.py
@@ -36,12 +36,6 @@ def upgrade() -> None:
         ),
     )
     op.create_index(
-        "ix_processed_webhook_event_stripe_event_id",
-        "processed_webhook_event",
-        ["stripe_event_id"],
-        unique=True,
-    )
-    op.create_index(
         "ix_processed_webhook_event_processed_at",
         "processed_webhook_event",
         ["processed_at"],
@@ -51,10 +45,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index(
         "ix_processed_webhook_event_processed_at",
-        table_name="processed_webhook_event",
-    )
-    op.drop_index(
-        "ix_processed_webhook_event_stripe_event_id",
         table_name="processed_webhook_event",
     )
     op.drop_table("processed_webhook_event")

--- a/backend/app/alembic/versions/s3t4u5v6w7x8_add_processed_webhook_event.py
+++ b/backend/app/alembic/versions/s3t4u5v6w7x8_add_processed_webhook_event.py
@@ -1,0 +1,60 @@
+"""Add processed_webhook_event table for Stripe webhook idempotency
+
+Revision ID: s3t4u5v6w7x8
+Revises: r8e9l1i2a3b4
+Create Date: 2026-05-07 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlalchemy.dialects.postgresql as pg
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "s3t4u5v6w7x8"
+down_revision = "r8e9l1i2a3b4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "processed_webhook_event",
+        sa.Column("id", pg.UUID(as_uuid=True), nullable=False),
+        sa.Column("stripe_event_id", sa.String(255), nullable=False),
+        sa.Column("event_type", sa.String(100), nullable=True),
+        sa.Column(
+            "processed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "stripe_event_id",
+            name="uq_processed_webhook_event_stripe_event_id",
+        ),
+    )
+    op.create_index(
+        "ix_processed_webhook_event_stripe_event_id",
+        "processed_webhook_event",
+        ["stripe_event_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_processed_webhook_event_processed_at",
+        "processed_webhook_event",
+        ["processed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_processed_webhook_event_processed_at",
+        table_name="processed_webhook_event",
+    )
+    op.drop_index(
+        "ix_processed_webhook_event_stripe_event_id",
+        table_name="processed_webhook_event",
+    )
+    op.drop_table("processed_webhook_event")

--- a/backend/app/api/routes/subscriptions.py
+++ b/backend/app/api/routes/subscriptions.py
@@ -11,10 +11,11 @@ import uuid as _uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, HttpUrl
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from app.api.deps import CurrentUser, get_db
-from app.models import SubscriptionTier, User
+from app.models import ProcessedWebhookEvent, SubscriptionTier, User
 from app.services.payment_service import (
     CheckoutSessionError,
     CustomerNotFoundError,
@@ -214,10 +215,25 @@ async def handle_webhook(
             detail=str(e),
         )
 
+    # Idempotency: Stripe retries webhooks that do not receive a timely 2xx.
+    # We deduplicate on the Stripe event ID so that a retried delivery never
+    # applies the same state transition twice.
+    stripe_event_id = str(event["id"])
+    existing = session.exec(
+        select(ProcessedWebhookEvent).where(
+            ProcessedWebhookEvent.stripe_event_id == stripe_event_id
+        )
+    ).first()
+    if existing:
+        logger.info("duplicate stripe event %s — skipping", stripe_event_id)
+        return WebhookResponse(received=True)
+
     # Parse the event
     webhook_event = payment_service.parse_webhook_event(event)
 
-    # Handle different event types
+    # Handle different event types.
+    # Note: session.commit() is intentionally deferred to the single atomic
+    # commit below, which records both the state change and the event ID together.
     if webhook_event.event_type == WebhookEventType.CHECKOUT_COMPLETED.value:
         # Subscription purchased — derive tier from price_id, not metadata,
         # to prevent tier elevation via attacker-controlled metadata values.
@@ -259,7 +275,6 @@ async def handle_webhook(
                 user.stripe_customer_id = webhook_event.customer_id
                 user.stripe_subscription_id = webhook_event.subscription_id
                 session.add(user)
-                session.commit()
 
     elif webhook_event.event_type == WebhookEventType.SUBSCRIPTION_UPDATED.value:
         # Subscription plan changed — update tier and subscription ID from the new price_id.
@@ -274,7 +289,6 @@ async def handle_webhook(
                 if webhook_event.subscription_id:
                     user.stripe_subscription_id = webhook_event.subscription_id
                 session.add(user)
-                session.commit()
 
     elif webhook_event.event_type == WebhookEventType.SUBSCRIPTION_DELETED.value:
         # Subscription ended — downgrade to FREE.
@@ -287,7 +301,24 @@ async def handle_webhook(
                 user.subscription_tier = SubscriptionTier.FREE
                 user.stripe_subscription_id = None
                 session.add(user)
-                session.commit()
+
+    # Atomically record the processed event alongside any state changes.
+    # If a concurrent delivery commits first the unique constraint raises
+    # IntegrityError — we catch it and return 200 so Stripe stops retrying.
+    session.add(
+        ProcessedWebhookEvent(
+            stripe_event_id=stripe_event_id,
+            event_type=webhook_event.event_type,
+        )
+    )
+    try:
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        logger.info(
+            "concurrent duplicate stripe event %s — already processed",
+            stripe_event_id,
+        )
 
     return WebhookResponse(received=True)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -82,6 +82,7 @@ from app.models.portfolio import (
     PortfolioTransaction,
     TransactionType,
 )
+from app.models.processed_webhook_event import ProcessedWebhookEvent
 from app.models.professional import (
     ContactInquiry,
     Professional,
@@ -130,6 +131,7 @@ __all__ = [
     "OwnershipComparison",
     "PortfolioProperty",
     "PortfolioTransaction",
+    "ProcessedWebhookEvent",
     "TransactionType",
     "ContractAnalysis",
     "ContactInquiry",

--- a/backend/app/models/processed_webhook_event.py
+++ b/backend/app/models/processed_webhook_event.py
@@ -1,0 +1,46 @@
+"""Processed Stripe webhook event model for idempotency deduplication."""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, String, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models.base import Base
+
+
+class ProcessedWebhookEvent(Base):
+    """Records Stripe webhook event IDs that have been successfully processed.
+
+    Provides idempotency protection against Stripe's automatic retry behaviour.
+    Stripe retries webhooks that do not receive a timely 2xx response, so the
+    same event can arrive multiple times. This table ensures each event is
+    applied exactly once.
+
+    The stripe_event_id unique constraint is the guard: a second delivery of
+    the same event_id will hit an IntegrityError on commit, which the handler
+    catches and converts to a 200 response (Stripe requires 2xx to stop retries).
+
+    Records older than 30 days can be pruned safely — Stripe's maximum retry
+    window is 3 days, so any surviving record is long past the retry risk.
+    """
+
+    __tablename__ = "processed_webhook_event"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+    stripe_event_id = Column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    event_type = Column(String(100), nullable=True)
+    processed_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/backend/app/models/processed_webhook_event.py
+++ b/backend/app/models/processed_webhook_event.py
@@ -36,7 +36,6 @@ class ProcessedWebhookEvent(Base):
         String(255),
         unique=True,
         nullable=False,
-        index=True,
     )
     event_type = Column(String(100), nullable=True)
     processed_at = Column(

--- a/backend/tests/api/routes/test_subscriptions.py
+++ b/backend/tests/api/routes/test_subscriptions.py
@@ -329,12 +329,19 @@ def test_checkout_already_subscribed_to_same_tier(
 
 
 def _make_webhook_event(
-    event_type: str, data_object: dict, metadata: dict
+    event_type: str,
+    data_object: dict,
+    metadata: dict,
+    event_id: str | None = None,
 ) -> tuple[MagicMock, WebhookEvent]:
     """Build a MagicMock that quacks like a stripe.Event for webhook tests."""
+    eid = event_id or f"evt_{random_lower_string()}"
     raw_event: MagicMock = MagicMock()
     raw_event.__getitem__ = MagicMock(
-        side_effect=lambda k: {"data": {"object": data_object}}.get(k, MagicMock())
+        side_effect=lambda k: {
+            "id": eid,
+            "data": {"object": data_object},
+        }.get(k, MagicMock())
     )
 
     parsed = WebhookEvent(
@@ -460,7 +467,10 @@ def test_webhook_subscription_deleted_downgrades_user(
     )
     raw_event = MagicMock()
     raw_event.__getitem__ = MagicMock(
-        side_effect=lambda k: {"data": {"object": {}}}.get(k, MagicMock())
+        side_effect=lambda k: {
+            "id": f"evt_{random_lower_string()}",
+            "data": {"object": {}},
+        }.get(k, MagicMock())
     )
 
     mock_service = MagicMock()
@@ -499,7 +509,10 @@ def test_webhook_subscription_updated_changes_tier(
     )
     raw_event = MagicMock()
     raw_event.__getitem__ = MagicMock(
-        side_effect=lambda k: {"data": {"object": {}}}.get(k, MagicMock())
+        side_effect=lambda k: {
+            "id": f"evt_{random_lower_string()}",
+            "data": {"object": {}},
+        }.get(k, MagicMock())
     )
 
     mock_service = MagicMock()
@@ -710,3 +723,166 @@ def test_cancel_subscription_stripe_error(client: TestClient, db: Session) -> No
         )
         assert r.status_code == 502
         assert "Failed to cancel subscription" in r.json()["detail"]
+
+
+# ── Webhook idempotency ───────────────────────────────────────────────────────
+
+
+def test_webhook_duplicate_event_skips_state_change(
+    client: TestClient, db: Session
+) -> None:
+    """A duplicate Stripe event returns 200 without modifying subscription state."""
+
+    from app.models.processed_webhook_event import ProcessedWebhookEvent
+
+    user, _username, _password = _create_premium_user_with_stripe(db)
+    shared_event_id = f"evt_{random_lower_string()}"
+
+    # Pre-insert the event as already processed
+    db.add(
+        ProcessedWebhookEvent(
+            stripe_event_id=shared_event_id,
+            event_type=WebhookEventType.SUBSCRIPTION_DELETED.value,
+        )
+    )
+    db.commit()
+
+    # Build a deletion event that would downgrade tier — but event_id is duplicate
+    parsed_event = WebhookEvent(
+        event_type=WebhookEventType.SUBSCRIPTION_DELETED.value,
+        customer_id=user.stripe_customer_id,
+        subscription_id=user.stripe_subscription_id,
+        price_id=None,
+        status="canceled",
+        metadata={},
+    )
+    raw_event = MagicMock()
+    raw_event.__getitem__ = MagicMock(
+        side_effect=lambda k: {
+            "id": shared_event_id,
+            "data": {"object": {}},
+        }.get(k, MagicMock())
+    )
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+
+    assert r.status_code == 200
+    assert r.json()["received"] is True
+    # Tier must NOT be downgraded — the event was a duplicate
+    db.refresh(user)
+    assert user.subscription_tier == SubscriptionTier.PREMIUM
+    assert user.stripe_subscription_id is not None
+
+
+def test_webhook_event_recorded_after_processing(
+    client: TestClient, db: Session
+) -> None:
+    """Successfully processed event is stored in processed_webhook_event table."""
+    from sqlmodel import select as sql_select
+
+    from app.models.processed_webhook_event import ProcessedWebhookEvent
+
+    user, _username, _password = _create_premium_user_with_stripe(db)
+    unique_event_id = f"evt_{random_lower_string()}"
+
+    parsed_event = WebhookEvent(
+        event_type=WebhookEventType.SUBSCRIPTION_DELETED.value,
+        customer_id=user.stripe_customer_id,
+        subscription_id=None,
+        price_id=None,
+        status="canceled",
+        metadata={},
+    )
+    raw_event = MagicMock()
+    raw_event.__getitem__ = MagicMock(
+        side_effect=lambda k: {
+            "id": unique_event_id,
+            "data": {"object": {}},
+        }.get(k, MagicMock())
+    )
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+
+    assert r.status_code == 200
+    db.expire_all()
+    record = db.exec(
+        sql_select(ProcessedWebhookEvent).where(
+            ProcessedWebhookEvent.stripe_event_id == unique_event_id
+        )
+    ).first()
+    assert record is not None
+    assert record.event_type == WebhookEventType.SUBSCRIPTION_DELETED.value
+
+
+def test_webhook_first_delivery_updates_tier_and_records_event(
+    client: TestClient, db: Session
+) -> None:
+    """First delivery updates subscription tier and records the event atomically."""
+    from sqlmodel import select as sql_select
+
+    from app.models.processed_webhook_event import ProcessedWebhookEvent
+
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    db.commit()
+
+    unique_event_id = f"evt_{random_lower_string()}"
+    session_obj = {
+        "id": "cs_idempotent",
+        "customer": "cus_idem",
+        "subscription": "sub_idem",
+    }
+    raw_event, parsed_event = _make_webhook_event(
+        WebhookEventType.CHECKOUT_COMPLETED.value,
+        session_obj,
+        {"user_id": str(user.id)},
+        event_id=unique_event_id,
+    )
+
+    mock_service = MagicMock()
+    mock_service.verify_webhook_signature.return_value = raw_event
+    mock_service.parse_webhook_event.return_value = parsed_event
+    mock_service.get_checkout_price_id.return_value = "price_premium"
+    mock_service.get_tier_for_price.return_value = SubscriptionTier.PREMIUM
+
+    with patch(
+        "app.api.routes.subscriptions.get_payment_service", return_value=mock_service
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/subscriptions/webhook",
+            content=b"{}",
+            headers={"Stripe-Signature": "sig"},
+        )
+
+    assert r.status_code == 200
+    db.expire_all()
+    db.refresh(user)
+    assert user.subscription_tier == SubscriptionTier.PREMIUM
+    record = db.exec(
+        sql_select(ProcessedWebhookEvent).where(
+            ProcessedWebhookEvent.stripe_event_id == unique_event_id
+        )
+    ).first()
+    assert record is not None

--- a/backend/tests/api/routes/test_subscriptions.py
+++ b/backend/tests/api/routes/test_subscriptions.py
@@ -4,10 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session
+from sqlmodel import select as sql_select
 
 from app import crud
 from app.core.config import settings
-from app.models import SubscriptionTier, User, UserCreate
+from app.models import ProcessedWebhookEvent, SubscriptionTier, User, UserCreate
 from app.services.payment_service import (
     CheckoutSessionError,
     CheckoutSessionResult,
@@ -732,9 +733,6 @@ def test_webhook_duplicate_event_skips_state_change(
     client: TestClient, db: Session
 ) -> None:
     """A duplicate Stripe event returns 200 without modifying subscription state."""
-
-    from app.models.processed_webhook_event import ProcessedWebhookEvent
-
     user, _username, _password = _create_premium_user_with_stripe(db)
     shared_event_id = f"evt_{random_lower_string()}"
 
@@ -778,6 +776,8 @@ def test_webhook_duplicate_event_skips_state_change(
 
     assert r.status_code == 200
     assert r.json()["received"] is True
+    # Handler returns before parsing when a duplicate is detected
+    mock_service.parse_webhook_event.assert_not_called()
     # Tier must NOT be downgraded — the event was a duplicate
     db.refresh(user)
     assert user.subscription_tier == SubscriptionTier.PREMIUM
@@ -788,10 +788,6 @@ def test_webhook_event_recorded_after_processing(
     client: TestClient, db: Session
 ) -> None:
     """Successfully processed event is stored in processed_webhook_event table."""
-    from sqlmodel import select as sql_select
-
-    from app.models.processed_webhook_event import ProcessedWebhookEvent
-
     user, _username, _password = _create_premium_user_with_stripe(db)
     unique_event_id = f"evt_{random_lower_string()}"
 
@@ -838,10 +834,6 @@ def test_webhook_first_delivery_updates_tier_and_records_event(
     client: TestClient, db: Session
 ) -> None:
     """First delivery updates subscription tier and records the event atomically."""
-    from sqlmodel import select as sql_select
-
-    from app.models.processed_webhook_event import ProcessedWebhookEvent
-
     username = random_email()
     password = random_lower_string()
     user_in = UserCreate(email=username, password=password)


### PR DESCRIPTION
## Summary
- Adds `processed_webhook_event` table with a unique constraint on `stripe_event_id` to prevent duplicate Stripe webhook deliveries from applying the same subscription state change twice
- Webhook handler now checks for an existing record before processing, then commits the state change and event record in a single atomic transaction
- Race conditions (two simultaneous deliveries) are handled via `IntegrityError` catch — the loser returns 200 so Stripe stops retrying

## Test plan
- [x] `test_webhook_duplicate_event_skips_state_change` — pre-insert event, verify subscription tier is NOT changed on second delivery
- [x] `test_webhook_event_recorded_after_processing` — verify event ID is written to `processed_webhook_event` after successful processing
- [x] `test_webhook_first_delivery_updates_tier_and_records_event` — happy path: tier updated and event recorded atomically
- [x] All 28 existing subscription tests continue to pass