### PR TITLE
feat(market): add data freshness detection to market endpoints

### DIFF
--- a/backend/app/api/routes/market.py
+++ b/backend/app/api/routes/market.py
@@ -50,7 +50,10 @@ async def get_rent_estimate(
         size_sqm=size_sqm,
         building_year=building_year,
     )
-    return RentEstimateResponse(**result)
+    return RentEstimateResponse(
+        **result,
+        data_freshness=market_comparison_service.compute_data_freshness(),
+    )
 
 
 @router.get("/areas")
@@ -83,4 +86,7 @@ async def compare_areas(
             detail="Provide between 2 and 4 area keys.",
         )
     areas = market_comparison_service.compare_areas(keys)
-    return ComparisonResponse(areas=areas)
+    return ComparisonResponse(
+        areas=areas,
+        data_freshness=market_comparison_service.compute_data_freshness(),
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -180,6 +180,7 @@ class Settings(BaseSettings):
     AZURE_TRANSLATOR_TIMEOUT_SECONDS: int = 60
     MAX_JSON_BODY_SIZE_BYTES: int = 1_048_576  # 1 MB
     DB_STATEMENT_TIMEOUT_MS: int = 10_000  # 10 seconds
+    MARKET_DATA_MAX_AGE_DAYS: int = 30
 
     # Email settings
     # Set NOTIFICATION_EMAILS_ENABLED=false to suppress all non-essential emails

--- a/backend/app/schemas/market_comparison.py
+++ b/backend/app/schemas/market_comparison.py
@@ -1,5 +1,6 @@
 """Schemas for city/area comparison endpoints."""
 
+from datetime import date
 from typing import Literal
 
 from pydantic import BaseModel
@@ -39,6 +40,15 @@ class ComparisonMetrics(BaseModel):
     has_mietspiegel: bool
 
 
+class DataFreshness(BaseModel):
+    """Staleness metadata for static market data."""
+
+    last_updated: date
+    age_days: int
+    is_stale: bool
+    max_age_days: int
+
+
 class AreaListResponse(BaseModel):
     """Response for the area listing endpoint."""
 
@@ -49,3 +59,4 @@ class ComparisonResponse(BaseModel):
     """Response for the area comparison endpoint."""
 
     areas: list[ComparisonMetrics]
+    data_freshness: DataFreshness

--- a/backend/app/schemas/rent_estimate.py
+++ b/backend/app/schemas/rent_estimate.py
@@ -24,4 +24,4 @@ class RentEstimateResponse(BaseModel):
     city: str | None = None
     state_code: str | None = None
     monthly_rent: float | None = None
-    data_freshness: DataFreshness | None = None
+    data_freshness: DataFreshness

--- a/backend/app/schemas/rent_estimate.py
+++ b/backend/app/schemas/rent_estimate.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from app.schemas.market_comparison import DataFreshness
+
 
 class RentRange(BaseModel):
     """Min/max rent per sqm range."""
@@ -22,3 +24,4 @@ class RentEstimateResponse(BaseModel):
     city: str | None = None
     state_code: str | None = None
     monthly_rent: float | None = None
+    data_freshness: DataFreshness | None = None

--- a/backend/app/services/market_comparison_service.py
+++ b/backend/app/services/market_comparison_service.py
@@ -7,13 +7,29 @@ data comes from static constants.
 
 from __future__ import annotations
 
-from app.schemas.market_comparison import AreaSummary, ComparisonMetrics
+from datetime import date
+
+from app.core.config import settings
+from app.schemas.market_comparison import AreaSummary, ComparisonMetrics, DataFreshness
 from app.services.market_data import (
     CITY_MARKET_DATA,
     GERMAN_STATES,
     MARKET_DATA_BY_STATE,
+    MARKET_DATA_LAST_UPDATED,
 )
 from app.services.rent_estimate_service import CITY_MIETSPIEGEL
+
+
+def compute_data_freshness() -> DataFreshness:
+    """Compute staleness metadata for the static market data."""
+    today = date.today()
+    age_days = (today - MARKET_DATA_LAST_UPDATED).days
+    return DataFreshness(
+        last_updated=MARKET_DATA_LAST_UPDATED,
+        age_days=age_days,
+        is_stale=age_days > settings.MARKET_DATA_MAX_AGE_DAYS,
+        max_age_days=settings.MARKET_DATA_MAX_AGE_DAYS,
+    )
 
 
 def _find_mietspiegel(city_name: str, state_code: str) -> dict | None:

--- a/backend/app/services/market_comparison_service.py
+++ b/backend/app/services/market_comparison_service.py
@@ -23,7 +23,7 @@ from app.services.rent_estimate_service import CITY_MIETSPIEGEL
 def compute_data_freshness() -> DataFreshness:
     """Compute staleness metadata for the static market data."""
     today = date.today()
-    age_days = (today - MARKET_DATA_LAST_UPDATED).days
+    age_days = max(0, (today - MARKET_DATA_LAST_UPDATED).days)
     return DataFreshness(
         last_updated=MARKET_DATA_LAST_UPDATED,
         age_days=age_days,

--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -7,8 +7,16 @@ type, and budget.  The data mirrors the constants used in the frontend
 backend and frontend are always in sync.
 """
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
+
+# ---------------------------------------------------------------------------
+# Data provenance
+# ---------------------------------------------------------------------------
+
+# Date the static market data was last reviewed and updated.
+# Used by compute_data_freshness() to warn consumers when data is aging.
+MARKET_DATA_LAST_UPDATED: date = date(2025, 1, 15)
 
 # ---------------------------------------------------------------------------
 # Static data: German states

--- a/backend/tests/api/routes/test_market.py
+++ b/backend/tests/api/routes/test_market.py
@@ -66,5 +66,61 @@ class TestRentEstimateEndpoint:
             "city",
             "state_code",
             "monthly_rent",
+            "data_freshness",
         }
         assert set(body.keys()) == expected_keys
+
+    def test_data_freshness_fields_present(self, client: TestClient) -> None:
+        r = client.get(f"{BASE}/rent-estimate", params={"postcode": "10115"})
+        assert r.status_code == 200
+        freshness = r.json()["data_freshness"]
+        assert {"last_updated", "age_days", "is_stale", "max_age_days"} == set(
+            freshness.keys()
+        )
+        assert freshness["age_days"] >= 0
+        assert isinstance(freshness["is_stale"], bool)
+
+
+class TestCompareEndpoint:
+    """GET /api/v1/market/compare"""
+
+    def test_valid_comparison_returns_200(self, client: TestClient) -> None:
+        r = client.get(
+            f"{BASE}/compare",
+            params={"keys": ["BY/Munich", "HE/Frankfurt"]},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert "areas" in body
+        assert "data_freshness" in body
+        assert len(body["areas"]) == 2
+
+    def test_comparison_data_freshness_shape(self, client: TestClient) -> None:
+        r = client.get(
+            f"{BASE}/compare",
+            params={"keys": ["BY/Munich", "HE/Frankfurt"]},
+        )
+        assert r.status_code == 200
+        freshness = r.json()["data_freshness"]
+        assert {"last_updated", "age_days", "is_stale", "max_age_days"} == set(
+            freshness.keys()
+        )
+
+    def test_too_few_keys_returns_400(self, client: TestClient) -> None:
+        r = client.get(f"{BASE}/compare", params={"keys": ["BY/Munich"]})
+        assert r.status_code == 400
+
+    def test_too_many_keys_returns_400(self, client: TestClient) -> None:
+        r = client.get(
+            f"{BASE}/compare",
+            params={
+                "keys": [
+                    "BY/Munich",
+                    "HE/Frankfurt",
+                    "HH/Eimsbüttel",
+                    "BW/Stuttgart",
+                    "NW/Cologne",
+                ]
+            },
+        )
+        assert r.status_code == 400

--- a/backend/tests/services/test_market_comparison_service.py
+++ b/backend/tests/services/test_market_comparison_service.py
@@ -1,8 +1,15 @@
 """Tests for market_comparison_service."""
 
+from datetime import date
+from unittest.mock import patch
+
 import pytest
 
-from app.services.market_comparison_service import compare_areas, list_areas
+from app.services.market_comparison_service import (
+    compare_areas,
+    compute_data_freshness,
+    list_areas,
+)
 from app.services.market_data import CITY_MARKET_DATA
 
 
@@ -110,6 +117,68 @@ class TestCompareStates:
         assert by.name == "Bayern"
         assert by.avg_rent_per_sqm is not None
         assert by.has_mietspiegel is True
+
+
+class TestComputeDataFreshness:
+    """compute_data_freshness returns correct staleness metadata."""
+
+    def test_fresh_data_is_not_stale(self) -> None:
+        # 10 days after last update — well within the 30-day threshold
+        with patch("app.services.market_comparison_service.date") as mock_date:
+            mock_date.today.return_value = date(2025, 1, 25)
+            freshness = compute_data_freshness()
+
+        assert freshness.is_stale is False
+        assert freshness.age_days == 10
+
+    def test_stale_data_is_stale(self) -> None:
+        # 365 days after last update — well past the 30-day threshold
+        with patch("app.services.market_comparison_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 1, 15)
+            freshness = compute_data_freshness()
+
+        assert freshness.is_stale is True
+        assert freshness.age_days == 365
+
+    def test_age_days_equals_expected_delta(self) -> None:
+        with patch("app.services.market_comparison_service.date") as mock_date:
+            mock_date.today.return_value = date(2025, 2, 14)  # 30 days after 2025-01-15
+            freshness = compute_data_freshness()
+
+        assert freshness.age_days == 30
+        # exactly at the boundary: 30 > 30 is False
+        assert freshness.is_stale is False
+
+    def test_one_day_over_threshold_is_stale(self) -> None:
+        with patch("app.services.market_comparison_service.date") as mock_date:
+            mock_date.today.return_value = date(2025, 2, 15)  # 31 days after 2025-01-15
+            freshness = compute_data_freshness()
+
+        assert freshness.age_days == 31
+        assert freshness.is_stale is True
+
+    def test_future_last_updated_does_not_yield_negative_age(self) -> None:
+        # If MARKET_DATA_LAST_UPDATED is accidentally set to a future date,
+        # age_days should be clamped to 0, not negative.
+        with (
+            patch(
+                "app.services.market_comparison_service.MARKET_DATA_LAST_UPDATED",
+                date(2099, 12, 31),
+            ),
+            patch("app.services.market_comparison_service.date") as mock_date,
+        ):
+            mock_date.today.return_value = date(2026, 1, 1)
+            freshness = compute_data_freshness()
+
+        assert freshness.age_days == 0
+        assert freshness.is_stale is False
+
+    def test_schema_fields_and_types(self) -> None:
+        freshness = compute_data_freshness()
+        assert isinstance(freshness.age_days, int)
+        assert isinstance(freshness.is_stale, bool)
+        assert isinstance(freshness.max_age_days, int)
+        assert freshness.age_days >= 0
 
 
 class TestGrossYieldCalculation:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9401,18 +9401,11 @@ export const RentEstimateResponseSchema = {
             title: 'Monthly Rent'
         },
         data_freshness: {
-            anyOf: [
-                {
-                    '$ref': '#/components/schemas/DataFreshness'
-                },
-                {
-                    type: 'null'
-                }
-            ]
+            '$ref': '#/components/schemas/DataFreshness'
         }
     },
     type: 'object',
-    required: ['confidence'],
+    required: ['confidence', 'data_freshness'],
     title: 'RentEstimateResponse',
     description: 'Response for a rent estimate query.'
 } as const;

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1434,10 +1434,13 @@ export const ComparisonResponseSchema = {
             },
             type: 'array',
             title: 'Areas'
+        },
+        data_freshness: {
+            '$ref': '#/components/schemas/DataFreshness'
         }
     },
     type: 'object',
-    required: ['areas'],
+    required: ['areas', 'data_freshness'],
     title: 'ComparisonResponse',
     description: 'Response for the area comparison endpoint.'
 } as const;
@@ -2074,6 +2077,32 @@ export const DashboardOverviewResponseSchema = {
     required: ['has_journey', 'recent_documents', 'recent_calculations', 'bookmarked_laws', 'recent_activity', 'documents_translated_this_month', 'total_calculations', 'total_bookmarks'],
     title: 'DashboardOverviewResponse',
     description: 'Aggregated dashboard data for the authenticated user.'
+} as const;
+
+export const DataFreshnessSchema = {
+    properties: {
+        last_updated: {
+            type: 'string',
+            format: 'date',
+            title: 'Last Updated'
+        },
+        age_days: {
+            type: 'integer',
+            title: 'Age Days'
+        },
+        is_stale: {
+            type: 'boolean',
+            title: 'Is Stale'
+        },
+        max_age_days: {
+            type: 'integer',
+            title: 'Max Age Days'
+        }
+    },
+    type: 'object',
+    required: ['last_updated', 'age_days', 'is_stale', 'max_age_days'],
+    title: 'DataFreshness',
+    description: 'Staleness metadata for static market data.'
 } as const;
 
 export const DetectedClauseSchema = {
@@ -9370,6 +9399,16 @@ export const RentEstimateResponseSchema = {
                 }
             ],
             title: 'Monthly Rent'
+        },
+        data_freshness: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/DataFreshness'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2317,7 +2317,7 @@ export type RentEstimateResponse = {
     city?: (string | null);
     state_code?: (string | null);
     monthly_rent?: (number | null);
-    data_freshness?: (DataFreshness | null);
+    data_freshness: DataFreshness;
 };
 
 export type confidence = 'high' | 'medium' | 'low';

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -437,6 +437,7 @@ export type ComparisonMetrics = {
  */
 export type ComparisonResponse = {
     areas: Array<ComparisonMetrics>;
+    data_freshness: DataFreshness;
 };
 
 /**
@@ -595,6 +596,16 @@ export type DashboardOverviewResponse = {
     documents_translated_this_month: number;
     total_calculations: number;
     total_bookmarks: number;
+};
+
+/**
+ * Staleness metadata for static market data.
+ */
+export type DataFreshness = {
+    last_updated: string;
+    age_days: number;
+    is_stale: boolean;
+    max_age_days: number;
 };
 
 /**
@@ -2306,6 +2317,7 @@ export type RentEstimateResponse = {
     city?: (string | null);
     state_code?: (string | null);
     monthly_rent?: (number | null);
+    data_freshness?: (DataFreshness | null);
 };
 
 export type confidence = 'high' | 'medium' | 'low';

--- a/frontend/src/components/Calculators/CityComparison/index.tsx
+++ b/frontend/src/components/Calculators/CityComparison/index.tsx
@@ -3,7 +3,7 @@
  * Allows users to select 2–4 cities/areas and compare metrics side by side
  */
 
-import { Building2, X } from "lucide-react"
+import { AlertTriangle, Building2, X } from "lucide-react"
 import { useState } from "react"
 
 import { cn } from "@/common/utils"
@@ -116,9 +116,22 @@ function CityComparison(props: Readonly<IProps>) {
         </CardContent>
       </Card>
 
+      {/* Staleness banner */}
+      {comparison?.dataFreshness?.isStale && (
+        <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span>
+            Market data was last updated on{" "}
+            <strong>{comparison.dataFreshness.lastUpdated}</strong> (
+            {comparison.dataFreshness.ageDays} days ago). Figures may not
+            reflect current market conditions.
+          </span>
+        </div>
+      )}
+
       {/* Comparison table */}
-      {comparison && comparison.length >= MIN_SELECTIONS && (
-        <ComparisonTable data={comparison} />
+      {comparison && comparison.areas.length >= MIN_SELECTIONS && (
+        <ComparisonTable data={comparison.areas} />
       )}
 
       {selectedKeys.length >= MIN_SELECTIONS && comparisonLoading && (

--- a/frontend/src/components/Calculators/RentAnalyser/MarketRentSection.tsx
+++ b/frontend/src/components/Calculators/RentAnalyser/MarketRentSection.tsx
@@ -320,12 +320,22 @@ function MarketRentSection(props: Readonly<IProps>) {
 
       {/* Disclaimer */}
       <div className="lg:col-span-2">
-        <Card className="border-dashed bg-muted/40">
+        <Card
+          className={
+            estimate?.dataFreshness?.isStale
+              ? "border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20"
+              : "border-dashed bg-muted/40"
+          }
+        >
           <CardContent className="py-4">
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              <span className="font-medium">Data note:</span> Estimates are
-              based on Mietspiegel 2024 averages and state-level data. Actual
-              rents vary by neighbourhood, furnishing, and condition. For
+            <p
+              className={`text-xs leading-relaxed ${estimate?.dataFreshness?.isStale ? "text-amber-800 dark:text-amber-300" : "text-muted-foreground"}`}
+            >
+              <span className="font-medium">Data note:</span>{" "}
+              {estimate?.dataFreshness
+                ? `Estimates are based on Mietspiegel data last updated on ${estimate.dataFreshness.lastUpdated} (${estimate.dataFreshness.ageDays} days ago).`
+                : "Estimates are based on Mietspiegel averages and state-level data."}{" "}
+              Actual rents vary by neighbourhood, furnishing, and condition. For
               investment decisions, always cross-check with current listings on
               Immoscout24 or similar portals.
             </p>

--- a/frontend/src/components/Calculators/RentAnalyser/MarketRentSection.tsx
+++ b/frontend/src/components/Calculators/RentAnalyser/MarketRentSection.tsx
@@ -321,11 +321,11 @@ function MarketRentSection(props: Readonly<IProps>) {
       {/* Disclaimer */}
       <div className="lg:col-span-2">
         <Card
-          className={
+          className={cn(
             estimate?.dataFreshness?.isStale
               ? "border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20"
-              : "border-dashed bg-muted/40"
-          }
+              : "border-dashed bg-muted/40",
+          )}
         >
           <CardContent className="py-4">
             <p

--- a/frontend/src/components/Calculators/RentAnalyser/MarketRentSection.tsx
+++ b/frontend/src/components/Calculators/RentAnalyser/MarketRentSection.tsx
@@ -329,7 +329,12 @@ function MarketRentSection(props: Readonly<IProps>) {
         >
           <CardContent className="py-4">
             <p
-              className={`text-xs leading-relaxed ${estimate?.dataFreshness?.isStale ? "text-amber-800 dark:text-amber-300" : "text-muted-foreground"}`}
+              className={cn(
+                "text-xs leading-relaxed",
+                estimate?.dataFreshness?.isStale
+                  ? "text-amber-800 dark:text-amber-300"
+                  : "text-muted-foreground",
+              )}
             >
               <span className="font-medium">Data note:</span>{" "}
               {estimate?.dataFreshness

--- a/frontend/src/hooks/queries/useMarketQueries.ts
+++ b/frontend/src/hooks/queries/useMarketQueries.ts
@@ -16,7 +16,11 @@ export function useAreas() {
   })
 }
 
-/** Fetch comparison metrics for selected area keys. Enabled when 2+ keys. */
+/**
+ * Fetch comparison metrics for selected area keys.
+ * Returns the full ComparisonResponse (areas + data_freshness).
+ * Enabled when 2+ keys are selected.
+ */
 export function useCityComparison(keys: string[]) {
   return useQuery({
     queryKey: queryKeys.market.cityComparison(keys),

--- a/frontend/src/models/calculator.ts
+++ b/frontend/src/models/calculator.ts
@@ -3,6 +3,8 @@
  * TypeScript interfaces for hidden cost and ROI calculations
  */
 
+import type { DataFreshness } from "@/models/marketComparison"
+
 export interface StateRate {
   stateCode: string
   stateName: string
@@ -162,6 +164,7 @@ export interface RentEstimate {
   city: string | null
   stateCode: string | null
   monthlyRent: number | null
+  dataFreshness: DataFreshness | null
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/models/marketComparison.ts
+++ b/frontend/src/models/marketComparison.ts
@@ -29,3 +29,15 @@ export interface ComparisonMetrics {
   trend: string | null
   hasMietspiegel: boolean
 }
+
+export interface DataFreshness {
+  lastUpdated: string
+  ageDays: number
+  isStale: boolean
+  maxAgeDays: number
+}
+
+export interface ComparisonResponse {
+  areas: ComparisonMetrics[]
+  dataFreshness: DataFreshness
+}

--- a/frontend/src/models/marketComparison.ts
+++ b/frontend/src/models/marketComparison.ts
@@ -31,6 +31,7 @@ export interface ComparisonMetrics {
 }
 
 export interface DataFreshness {
+  /** ISO date string, e.g. "2025-01-15" */
   lastUpdated: string
   ageDays: number
   isStale: boolean

--- a/frontend/src/services/CalculatorService.ts
+++ b/frontend/src/services/CalculatorService.ts
@@ -21,7 +21,7 @@ import type {
   StateComparisonResponse,
   StateRatesResponse,
 } from "@/models/calculator"
-import type { AreaSummary, ComparisonMetrics } from "@/models/marketComparison"
+import type { AreaSummary, ComparisonResponse } from "@/models/marketComparison"
 import type {
   OwnershipComparisonInput,
   OwnershipComparisonResult,
@@ -448,7 +448,7 @@ class CalculatorServiceClass {
   }
 
   /** Compare 2–4 areas side by side (no auth required) */
-  async compareCities(keys: string[]): Promise<ComparisonMetrics[]> {
+  async compareCities(keys: string[]): Promise<ComparisonResponse> {
     const params = new URLSearchParams()
     for (const key of keys) {
       params.append("keys", key)
@@ -457,8 +457,7 @@ class CalculatorServiceClass {
       method: "GET",
       url: `${PATHS.MARKET.COMPARE}?${params.toString()}`,
     })
-    const data = transformKeys<{ areas: ComparisonMetrics[] }>(response)
-    return data.areas
+    return transformKeys<ComparisonResponse>(response)
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Surfaces data staleness on every `/market/compare` and `/market/rent-estimate` response via a `data_freshness` object (`last_updated`, `age_days`, `is_stale`, `max_age_days`)
- Backend: `MARKET_DATA_LAST_UPDATED` constant in `market_data.py`, configurable `MARKET_DATA_MAX_AGE_DAYS` setting (default 30), `DataFreshness` Pydantic schema, `compute_data_freshness()` service helper
- Frontend: `ComparisonResponse`/`DataFreshness` TypeScript interfaces, `compareCities()` now returns the full response object, amber staleness banner in `CityComparison`, dynamic data-date disclaimer in `MarketRentSection`

## Test plan

- [ ] All 13 market endpoint tests pass (`pytest tests/api/routes/test_market.py -v`)
- [ ] TypeScript compiles cleanly (`bunx tsc --noEmit`)
- [ ] Pre-commit hooks pass
- [ ] Staleness banner appears in CityComparison when `is_stale=true` (advance `MARKET_DATA_LAST_UPDATED` past threshold in dev to verify)
- [ ] MarketRentSection disclaimer shows actual date from API response