### PR TITLE
feat(reliability): add audit_service with fire-and-forget log_action

### DIFF
--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -6,7 +6,7 @@ infrastructure from disrupting user-facing requests.
 """
 
 import logging
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from sqlmodel import Session
@@ -38,7 +38,7 @@ def log_action(
     user_id: UUID | None = None,
     resource_type: str | None = None,
     resource_id: str | None = None,
-    status: str = "success",
+    status: Literal["success", "failure"] = "success",
     metadata: dict[str, Any] | None = None,
     request: Request | None = None,
 ) -> None:
@@ -78,17 +78,13 @@ def log_action(
         )
         try:
             session.add(row)
-            session.commit()
+            session.flush()
         except Exception as db_exc:
             _logger.error(
                 "audit_service: DB error writing audit log (action=%s): %s",
                 action,
                 db_exc,
             )
-            try:
-                session.rollback()
-            except Exception:
-                pass
     except Exception as exc:
         _logger.error(
             "audit_service: unexpected error in log_action (action=%s): %s",

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -85,6 +85,10 @@ def log_action(
                 action,
                 db_exc,
             )
+            try:
+                session.rollback()
+            except Exception:
+                pass
     except Exception as exc:
         _logger.error(
             "audit_service: unexpected error in log_action (action=%s): %s",

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -1,0 +1,97 @@
+"""Fire-and-forget audit logging service.
+
+Records security-relevant actions to the audit_log table. log_action()
+NEVER raises — any failure is swallowed and logged to prevent audit
+infrastructure from disrupting user-facing requests.
+"""
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from sqlmodel import Session
+from starlette.requests import Request
+
+from app.models.audit_log import AuditLog
+
+_logger = logging.getLogger(__name__)
+
+# ── Action constants ───────────────────────────────────────────────────────────
+
+ACTION_DOCUMENT_UPLOAD = "document.upload"
+ACTION_DOCUMENT_DELETE = "document.delete"
+ACTION_DOCUMENT_SHARE = "document.share"
+ACTION_TRANSLATION_START = "translation.start"
+ACTION_TRANSLATION_COMPLETE = "translation.complete"
+ACTION_TRANSLATION_FAILED = "translation.failed"
+ACTION_PAYMENT_CHECKOUT_CREATED = "payment.checkout_created"
+ACTION_PAYMENT_WEBHOOK_RECEIVED = "payment.webhook_received"
+ACTION_PAYMENT_SUBSCRIPTION_UPGRADED = "payment.subscription_upgraded"
+ACTION_USER_PASSWORD_RESET = "user.password_reset"
+ACTION_USER_EMAIL_VERIFIED = "user.email_verified"
+
+
+def log_action(
+    session: Session,
+    *,
+    action: str,
+    user_id: UUID | None = None,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    status: str = "success",
+    metadata: dict[str, Any] | None = None,
+    request: Request | None = None,
+) -> None:
+    """Write one audit log row. Never raises under any circumstances.
+
+    Args:
+        session: Sync SQLModel session (caller's session).
+        action: One of the ACTION_* constants, e.g. ACTION_DOCUMENT_UPLOAD.
+        user_id: Acting user, or None for system/anonymous actions.
+        resource_type: Entity type, e.g. "document", "payment".
+        resource_id: Entity identifier as a string.
+        status: "success" or "failure".
+        metadata: Arbitrary extra payload (user-agent, tier, etc.).
+        request: Starlette Request — used to extract ip_address and request_id.
+    """
+    try:
+        ip_address: str | None = None
+        request_id: str | None = None
+
+        if request is not None:
+            if request.client is not None:
+                ip_address = request.client.host
+            try:
+                request_id = request.state.request_id
+            except AttributeError:
+                pass
+
+        row = AuditLog(
+            user_id=user_id,
+            action=action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            ip_address=ip_address,
+            request_id=request_id,
+            status=status,
+            extra_data=metadata,
+        )
+        try:
+            session.add(row)
+            session.commit()
+        except Exception as db_exc:
+            _logger.error(
+                "audit_service: DB error writing audit log (action=%s): %s",
+                action,
+                db_exc,
+            )
+            try:
+                session.rollback()
+            except Exception:
+                pass
+    except Exception as exc:
+        _logger.error(
+            "audit_service: unexpected error in log_action (action=%s): %s",
+            action,
+            exc,
+        )

--- a/backend/tests/reliability/test_safety.py
+++ b/backend/tests/reliability/test_safety.py
@@ -280,9 +280,8 @@ class TestAuditTrailSafety:
 
     def test_log_action_writes_correct_fields(self) -> None:
         """Audit log entry has all expected fields populated."""
-        from app.services.audit_service import log_action
-
         from app.models.audit_log import AuditLog
+        from app.services.audit_service import log_action
 
         mock_session = MagicMock()
         user_id = uuid.uuid4()
@@ -305,13 +304,12 @@ class TestAuditTrailSafety:
         assert entry.resource_type == "document"
         assert entry.resource_id == doc_id
         assert entry.status == "success"
-        assert entry.metadata == {"filename": "contract.pdf", "page_count": 5}
+        assert entry.extra_data == {"filename": "contract.pdf", "page_count": 5}
 
     def test_log_action_extracts_ip_and_request_id_from_request(self) -> None:
         """IP address and request ID are pulled from the Request object."""
-        from app.services.audit_service import log_action
-
         from app.models.audit_log import AuditLog
+        from app.services.audit_service import log_action
 
         mock_session = MagicMock()
         mock_request = MagicMock()

--- a/backend/tests/services/test_audit_service.py
+++ b/backend/tests/services/test_audit_service.py
@@ -30,9 +30,9 @@ def test_writes_audit_log_to_db() -> None:
     )
 
     session.add.assert_called_once()
-    session.commit.assert_called_once()
+    session.flush.assert_called_once()
 
-    row: AuditLog = session.add.call_args[0][0]
+    row: AuditLog = session.add.call_args.args[0]
     assert isinstance(row, AuditLog)
     assert row.action == ACTION_DOCUMENT_UPLOAD
     assert str(row.user_id) == str(user_id)
@@ -65,7 +65,7 @@ def test_extracts_ip_from_request() -> None:
     )
 
     session.add.assert_called_once()
-    row: AuditLog = session.add.call_args[0][0]
+    row: AuditLog = session.add.call_args.args[0]
     assert row.ip_address == "1.2.3.4"
     assert row.request_id == "test-uuid-123"
 
@@ -82,5 +82,20 @@ def test_handles_none_user_id() -> None:
     )
 
     session.add.assert_called_once()
-    row: AuditLog = session.add.call_args[0][0]
+    row: AuditLog = session.add.call_args.args[0]
     assert row.user_id is None
+
+
+def test_metadata_stored_in_extra_data() -> None:
+    """metadata kwarg is forwarded to the extra_data column on the AuditLog row."""
+    session = _mock_session()
+
+    log_action(
+        session,
+        action=ACTION_DOCUMENT_UPLOAD,
+        metadata={"tier": "premium", "pages": 5},
+    )
+
+    session.add.assert_called_once()
+    row: AuditLog = session.add.call_args.args[0]
+    assert row.extra_data == {"tier": "premium", "pages": 5}

--- a/backend/tests/services/test_audit_service.py
+++ b/backend/tests/services/test_audit_service.py
@@ -1,0 +1,86 @@
+"""Tests for audit_service.log_action() fire-and-forget behavior."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.models.audit_log import AuditLog
+from app.services.audit_service import (
+    ACTION_DOCUMENT_UPLOAD,
+    log_action,
+)
+
+
+def _mock_session() -> MagicMock:
+    """Return a fresh MagicMock that stands in for a sync SQLModel Session."""
+    return MagicMock()
+
+
+def test_writes_audit_log_to_db() -> None:
+    """Happy path — log_action adds an AuditLog row with the correct fields."""
+    session = _mock_session()
+    user_id = uuid4()
+
+    log_action(
+        session,
+        action=ACTION_DOCUMENT_UPLOAD,
+        user_id=user_id,
+        resource_type="document",
+        resource_id="doc-123",
+        status="success",
+    )
+
+    session.add.assert_called_once()
+    session.commit.assert_called_once()
+
+    row: AuditLog = session.add.call_args[0][0]
+    assert isinstance(row, AuditLog)
+    assert row.action == ACTION_DOCUMENT_UPLOAD
+    assert str(row.user_id) == str(user_id)
+    assert row.resource_type == "document"
+    assert row.resource_id == "doc-123"
+    assert row.status == "success"
+
+
+def test_never_raises_on_db_error() -> None:
+    """session.add raising RuntimeError must not propagate out of log_action."""
+    session = _mock_session()
+    session.add.side_effect = RuntimeError("simulated DB failure")
+
+    # Must not raise
+    log_action(session, action=ACTION_DOCUMENT_UPLOAD)
+
+
+def test_extracts_ip_from_request() -> None:
+    """log_action writes ip_address and request_id from the Starlette Request."""
+    session = _mock_session()
+
+    mock_request = MagicMock()
+    mock_request.client.host = "1.2.3.4"
+    mock_request.state.request_id = "test-uuid-123"
+
+    log_action(
+        session,
+        action="user.email_verified",
+        request=mock_request,
+    )
+
+    session.add.assert_called_once()
+    row: AuditLog = session.add.call_args[0][0]
+    assert row.ip_address == "1.2.3.4"
+    assert row.request_id == "test-uuid-123"
+
+
+def test_handles_none_user_id() -> None:
+    """log_action with user_id=None writes a row with a null user_id field."""
+    session = _mock_session()
+
+    log_action(
+        session,
+        action="user.password_reset",
+        user_id=None,
+        status="success",
+    )
+
+    session.add.assert_called_once()
+    row: AuditLog = session.add.call_args[0][0]
+    assert row.user_id is None


### PR DESCRIPTION
## Summary

- Adds `backend/app/services/audit_service.py` — the last missing piece of the reliability P4 track
- Defines 11 `ACTION_*` constants for security-relevant events (document upload/delete/share, translation start/complete/failed, payment events, user password reset, email verification)
- `log_action()` writes to the `audit_log` table (model and migration already merged) and **never raises** — DB errors are caught, logged, and swallowed to prevent audit infrastructure from disrupting user requests
- Extracts `ip_address` from `request.client.host` and `request_id` from `request.state.request_id` when a Starlette `Request` is provided

## Test plan

- [x] 4 unit tests in `tests/services/test_audit_service.py`
  - Happy path: verifies correct AuditLog fields written
  - DB error resilience: `session.add` raises `RuntimeError` — no exception propagates
  - Request metadata: verifies `ip_address` and `request_id` extracted correctly
  - Null user_id: verifies anonymous actions are recorded
- [x] `pre-commit run --all-files` passes (ruff, biome, migration safety)