### PR TITLE
feat(rate-limiting): add per-user rate limits to document, translation, and contract endpoints

### DIFF
--- a/backend/app/api/routes/contracts.py
+++ b/backend/app/api/routes/contracts.py
@@ -1,5 +1,6 @@
 """Contract explainer API endpoints."""
 
+import logging
 import uuid
 from typing import Annotated
 
@@ -16,8 +17,10 @@ from app.schemas.contract import (
     ContractSharedPreviewResponse,
     NotaryQuestion,
 )
-from app.services import contract_service
+from app.services import contract_service, rate_limit_service
 from app.services.document_service import validate_pdf_bytes
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/contracts", tags=["contracts"])
 
@@ -122,7 +125,24 @@ async def analyze_contract(
     """Upload a PDF Kaufvertrag and receive an AI clause-by-clause analysis.
 
     Premium users see all clauses. Free users see the first 3 only.
+
+    **Rate limits:**
+    - 5 analyses per hour per user
     """
+    limit_info = rate_limit_service.record_contract_analysis(str(current_user.id))
+    if limit_info.is_locked:
+        retry_after = rate_limit_service.retry_after_seconds(
+            limit_info, rate_limit_service.CONTRACT_ANALYSIS_HOURLY_LOCKOUT
+        )
+        logger.warning(
+            "Contract analysis hourly limit exceeded for user %s", current_user.id
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Analysis limit reached. You can run up to {rate_limit_service.CONTRACT_ANALYSIS_HOURLY_MAX} contract analyses per hour.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -31,7 +31,7 @@ from app.schemas.document import (
     DocumentUploadResponse,
     DocumentUsageResponse,
 )
-from app.services import document_service
+from app.services import document_service, rate_limit_service
 from app.tasks.document_tasks import process_document_task
 
 logger = logging.getLogger(__name__)
@@ -99,7 +99,43 @@ async def upload_document(
     **Page limits:**
     - Free tier: 10 pages
     - Premium/Enterprise: 20 pages
+
+    **Rate limits:**
+    - 3 uploads per minute (burst)
+    - 10 uploads per hour
     """
+    user_id_str = str(current_user.id)
+
+    # Burst check first (tighter constraint — 3/minute)
+    burst_info = rate_limit_service.record_document_upload_burst(user_id_str)
+    if burst_info.is_locked:
+        retry_after = rate_limit_service.retry_after_seconds(
+            burst_info, rate_limit_service.UPLOAD_BURST_LOCKOUT
+        )
+        logger.warning(
+            "Document upload burst limit exceeded for user %s", current_user.id
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many uploads. Wait a minute before trying again.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    # Hourly check (10/hour)
+    hourly_info = rate_limit_service.record_document_upload_hourly(user_id_str)
+    if hourly_info.is_locked:
+        retry_after = rate_limit_service.retry_after_seconds(
+            hourly_info, rate_limit_service.UPLOAD_HOURLY_LOCKOUT
+        )
+        logger.warning(
+            "Document upload hourly limit exceeded for user %s", current_user.id
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Upload limit reached. You can upload up to {rate_limit_service.UPLOAD_HOURLY_MAX} documents per hour.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     if file.content_type != "application/pdf":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/routes/translations.py
+++ b/backend/app/api/routes/translations.py
@@ -4,6 +4,8 @@ Provides translation services for German real estate documents using
 Microsoft Azure Translator API with legal term detection and warnings.
 """
 
+import logging
+
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
 
@@ -17,12 +19,15 @@ from app.schemas.translation import (
     TranslationRequest,
     TranslationResponse,
 )
+from app.services import rate_limit_service
 from app.services.translation_service import (
     TranslationError,
     get_translation_service,
 )
 
 router = APIRouter(prefix="/translations", tags=["translations"])
+
+logger = logging.getLogger(__name__)
 
 
 # Response schemas specific to this router
@@ -62,7 +67,7 @@ LANGUAGE_NAMES = {
 @router.post("/translate", response_model=TranslationResponse)
 async def translate_text(
     request: TranslationRequest,
-    current_user: CurrentUser,  # noqa: ARG001
+    current_user: CurrentUser,
 ) -> TranslationResponse:
     """
     Translate text from source to target language.
@@ -82,9 +87,22 @@ async def translate_text(
     - Plus French, Spanish, Italian, Polish, Turkish, Russian, Arabic, Chinese
 
     **Rate Limits:**
-    - Free tier: 2 million characters/month
+    - 50 translation requests per hour per user
+    - Free tier: 2 million characters/month via Azure Translator
     - Character count included in response for tracking
     """
+    limit_info = rate_limit_service.record_translation_request(str(current_user.id))
+    if limit_info.is_locked:
+        retry_after = rate_limit_service.retry_after_seconds(
+            limit_info, rate_limit_service.TRANSLATION_HOURLY_LOCKOUT
+        )
+        logger.warning("Translation hourly limit exceeded for user %s", current_user.id)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Translation limit reached. You can make up to {rate_limit_service.TRANSLATION_HOURLY_MAX} translation requests per hour.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     translation_service = get_translation_service()
     if translation_service is None:
         raise HTTPException(
@@ -109,7 +127,7 @@ async def translate_text(
 @router.post("/detect", response_model=LanguageDetectionResponse)
 async def detect_language(
     request: LanguageDetectionRequest,
-    current_user: CurrentUser,  # noqa: ARG001
+    current_user: CurrentUser,  # noqa: ARG001 — auth only, no rate limit (detection is cheap)
 ) -> LanguageDetectionResponse:
     """
     Detect the language of given text.
@@ -142,7 +160,7 @@ async def detect_language(
 @router.post("/batch", response_model=BatchTranslationResponse)
 async def batch_translate(
     request: BatchTranslationRequest,
-    current_user: CurrentUser,  # noqa: ARG001
+    current_user: CurrentUser,
 ) -> BatchTranslationResponse:
     """
     Translate multiple texts in a single request.
@@ -153,7 +171,24 @@ async def batch_translate(
     **Limits:**
     - Maximum 100 texts per request
     - Each text limited to 50,000 characters
+
+    **Rate Limits:**
+    - 50 translation requests per hour per user (shared with /translate)
     """
+    limit_info = rate_limit_service.record_translation_request(str(current_user.id))
+    if limit_info.is_locked:
+        retry_after = rate_limit_service.retry_after_seconds(
+            limit_info, rate_limit_service.TRANSLATION_HOURLY_LOCKOUT
+        )
+        logger.warning(
+            "Translation hourly limit exceeded for user %s (batch)", current_user.id
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Translation limit reached. You can make up to {rate_limit_service.TRANSLATION_HOURLY_MAX} translation requests per hour.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     translation_service = get_translation_service()
     if translation_service is None:
         raise HTTPException(

--- a/backend/app/services/rate_limit_service.py
+++ b/backend/app/services/rate_limit_service.py
@@ -7,6 +7,7 @@ so limits survive server restarts and work correctly across
 horizontally-scaled instances.
 """
 
+import math
 from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
@@ -392,3 +393,99 @@ def record_ip_resend_verification(ip: str) -> RateLimitInfo:
         IP_RESEND_VERIFICATION_WINDOW_SECONDS,
         IP_RESEND_VERIFICATION_LOCKOUT_SECONDS,
     )
+
+
+# ── Document upload rate limiting ─────────────────────────────────────────────
+# Per-user hourly limit: protects Azure Translator + Anthropic from bulk abuse.
+UPLOAD_HOURLY_MAX: int = 10
+UPLOAD_HOURLY_WINDOW: int = 3600  # 1 hour
+UPLOAD_HOURLY_LOCKOUT: int = 3600  # 1 hour
+
+# Per-user burst limit: prevents rapid hammering of the upload endpoint.
+UPLOAD_BURST_MAX: int = 3
+UPLOAD_BURST_WINDOW: int = 60  # 1 minute
+UPLOAD_BURST_LOCKOUT: int = 60  # 1 minute
+
+_UPLOAD_HOURLY_ATTEMPTS_PREFIX = "api:ratelimit:doc_upload:hourly:attempts:"
+_UPLOAD_HOURLY_LOCKOUT_PREFIX = "api:ratelimit:doc_upload:hourly:lockout:"
+_UPLOAD_BURST_ATTEMPTS_PREFIX = "api:ratelimit:doc_upload:burst:attempts:"
+_UPLOAD_BURST_LOCKOUT_PREFIX = "api:ratelimit:doc_upload:burst:lockout:"
+
+
+def record_document_upload_hourly(user_id: str) -> RateLimitInfo:
+    """Record a document upload for the hourly limit (10 uploads/hour per user)."""
+    return _record_attempt(
+        user_id,
+        _UPLOAD_HOURLY_ATTEMPTS_PREFIX,
+        _UPLOAD_HOURLY_LOCKOUT_PREFIX,
+        UPLOAD_HOURLY_MAX,
+        UPLOAD_HOURLY_WINDOW,
+        UPLOAD_HOURLY_LOCKOUT,
+    )
+
+
+def record_document_upload_burst(user_id: str) -> RateLimitInfo:
+    """Record a document upload for the burst limit (3 uploads/minute per user)."""
+    return _record_attempt(
+        user_id,
+        _UPLOAD_BURST_ATTEMPTS_PREFIX,
+        _UPLOAD_BURST_LOCKOUT_PREFIX,
+        UPLOAD_BURST_MAX,
+        UPLOAD_BURST_WINDOW,
+        UPLOAD_BURST_LOCKOUT,
+    )
+
+
+# ── Translation rate limiting ──────────────────────────────────────────────────
+# Per-user hourly limit: protects Azure Translator monthly character quota.
+TRANSLATION_HOURLY_MAX: int = 50
+TRANSLATION_HOURLY_WINDOW: int = 3600  # 1 hour
+TRANSLATION_HOURLY_LOCKOUT: int = 3600  # 1 hour
+
+_TRANSLATION_ATTEMPTS_PREFIX = "api:ratelimit:translation:hourly:attempts:"
+_TRANSLATION_LOCKOUT_PREFIX = "api:ratelimit:translation:hourly:lockout:"
+
+
+def record_translation_request(user_id: str) -> RateLimitInfo:
+    """Record a translation request for the hourly limit (50 requests/hour per user)."""
+    return _record_attempt(
+        user_id,
+        _TRANSLATION_ATTEMPTS_PREFIX,
+        _TRANSLATION_LOCKOUT_PREFIX,
+        TRANSLATION_HOURLY_MAX,
+        TRANSLATION_HOURLY_WINDOW,
+        TRANSLATION_HOURLY_LOCKOUT,
+    )
+
+
+# ── Contract analysis rate limiting ───────────────────────────────────────────
+# Per-user hourly limit: each analysis invokes Anthropic Claude — highest cost.
+CONTRACT_ANALYSIS_HOURLY_MAX: int = 5
+CONTRACT_ANALYSIS_HOURLY_WINDOW: int = 3600  # 1 hour
+CONTRACT_ANALYSIS_HOURLY_LOCKOUT: int = 3600  # 1 hour
+
+_CONTRACT_ANALYSIS_ATTEMPTS_PREFIX = "api:ratelimit:contract_analysis:attempts:"
+_CONTRACT_ANALYSIS_LOCKOUT_PREFIX = "api:ratelimit:contract_analysis:lockout:"
+
+
+def record_contract_analysis(user_id: str) -> RateLimitInfo:
+    """Record a contract analysis request (5 analyses/hour per user)."""
+    return _record_attempt(
+        user_id,
+        _CONTRACT_ANALYSIS_ATTEMPTS_PREFIX,
+        _CONTRACT_ANALYSIS_LOCKOUT_PREFIX,
+        CONTRACT_ANALYSIS_HOURLY_MAX,
+        CONTRACT_ANALYSIS_HOURLY_WINDOW,
+        CONTRACT_ANALYSIS_HOURLY_LOCKOUT,
+    )
+
+
+# ── Shared helper ──────────────────────────────────────────────────────────────
+
+
+def retry_after_seconds(info: RateLimitInfo, fallback: int = 3600) -> int:
+    """Return seconds until the rate limit resets, for use in Retry-After headers."""
+    if info.lockout_expires_at:
+        delta = (info.lockout_expires_at - datetime.now(timezone.utc)).total_seconds()
+        return max(1, math.ceil(delta))
+    return fallback

--- a/backend/tests/api/routes/test_contracts.py
+++ b/backend/tests/api/routes/test_contracts.py
@@ -2,6 +2,7 @@
 
 import io
 import uuid
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
@@ -10,6 +11,7 @@ from sqlmodel import Session
 from app import crud
 from app.core.config import settings
 from app.models import UserCreate
+from app.services.rate_limit_service import RateLimitInfo
 from tests.utils.utils import random_email, random_lower_string
 
 # Minimal PDF bytes (1-page PDF with no text content)
@@ -389,3 +391,33 @@ def test_analyze_contract_accepts_valid_pdf_regardless_of_content_type(
             headers=headers,
         )
     assert r.status_code == 201
+
+
+# ── Rate limiting tests ────────────────────────────────────────────────────────
+
+_LOCKED_RATE_LIMIT = RateLimitInfo(
+    is_locked=True,
+    attempts_remaining=0,
+    lockout_expires_at=datetime.now(timezone.utc) + timedelta(seconds=3600),
+)
+
+
+def test_analyze_contract_returns_429_when_rate_limited(
+    client: TestClient,
+    normal_user_token_headers: dict[str, str],
+) -> None:
+    """Returns 429 with Retry-After when the contract analysis hourly limit is hit."""
+    with patch(
+        "app.api.routes.contracts.rate_limit_service.record_contract_analysis",
+        return_value=_LOCKED_RATE_LIMIT,
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/contracts/analyze",
+            headers=normal_user_token_headers,
+            files={
+                "file": ("contract.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")
+            },
+        )
+    assert r.status_code == 429
+    assert "Retry-After" in r.headers
+    assert int(r.headers["Retry-After"]) >= 1

--- a/backend/tests/api/routes/test_documents.py
+++ b/backend/tests/api/routes/test_documents.py
@@ -2,12 +2,14 @@
 
 import io
 import uuid
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
 from app.core.config import settings
 from app.models.document import DocumentStatus, DocumentType
+from app.services.rate_limit_service import RateLimitInfo
 
 BASE = f"{settings.API_V1_STR}/documents"
 
@@ -35,6 +37,22 @@ def _mock_document() -> MagicMock:
     return doc
 
 
+_UNLOCKED_RATE_LIMIT = RateLimitInfo(
+    is_locked=False, attempts_remaining=9, lockout_expires_at=None
+)
+
+# Named patches — used by upload tests that are NOT testing rate limiting, to
+# prevent shared Redis state from triggering limits mid-suite.
+_patch_upload_burst = patch(
+    "app.api.routes.documents.rate_limit_service.record_document_upload_burst",
+    return_value=_UNLOCKED_RATE_LIMIT,
+)
+_patch_upload_hourly = patch(
+    "app.api.routes.documents.rate_limit_service.record_document_upload_hourly",
+    return_value=_UNLOCKED_RATE_LIMIT,
+)
+
+
 class TestDocumentUpload:
     def test_upload_unauthenticated_returns_401(self, client: TestClient) -> None:
         r = client.post(
@@ -46,17 +64,18 @@ class TestDocumentUpload:
     def test_upload_non_pdf_returns_400(
         self, client: TestClient, normal_user_token_headers: dict[str, str]
     ) -> None:
-        r = client.post(
-            f"{BASE}/upload",
-            headers=normal_user_token_headers,
-            files={
-                "file": (
-                    "evil.html",
-                    io.BytesIO(b"<html>not a pdf</html>"),
-                    "text/html",
-                )
-            },
-        )
+        with _patch_upload_burst, _patch_upload_hourly:
+            r = client.post(
+                f"{BASE}/upload",
+                headers=normal_user_token_headers,
+                files={
+                    "file": (
+                        "evil.html",
+                        io.BytesIO(b"<html>not a pdf</html>"),
+                        "text/html",
+                    )
+                },
+            )
         assert r.status_code == 400
         assert "PDF" in r.json()["detail"]
 
@@ -67,6 +86,8 @@ class TestDocumentUpload:
         mock_task = MagicMock()
         mock_task.id = "celery-task-id-abc"
         with (
+            _patch_upload_burst,
+            _patch_upload_hourly,
             patch(
                 "app.api.routes.documents.document_service.save_upload",
                 new_callable=AsyncMock,
@@ -93,10 +114,14 @@ class TestDocumentUpload:
         self, client: TestClient, normal_user_token_headers: dict[str, str]
     ) -> None:
         """save_upload raises ValueError for bad PDF bytes → 400."""
-        with patch(
-            "app.api.routes.documents.document_service.save_upload",
-            new_callable=AsyncMock,
-            side_effect=ValueError("does not appear to be a valid PDF"),
+        with (
+            _patch_upload_burst,
+            _patch_upload_hourly,
+            patch(
+                "app.api.routes.documents.document_service.save_upload",
+                new_callable=AsyncMock,
+                side_effect=ValueError("does not appear to be a valid PDF"),
+            ),
         ):
             r = client.post(
                 f"{BASE}/upload",
@@ -186,3 +211,63 @@ class TestRetryDocumentProcessing:
             )
         assert r.status_code == 429
         assert "retry" in r.json()["detail"].lower()
+
+
+class TestDocumentUploadRateLimit:
+    _LOCKED_INFO = RateLimitInfo(
+        is_locked=True,
+        attempts_remaining=0,
+        lockout_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+    )
+
+    def test_upload_returns_429_on_burst_limit(
+        self, client: TestClient, normal_user_token_headers: dict[str, str]
+    ) -> None:
+        """Returns 429 with Retry-After when the per-minute burst limit is hit."""
+        with patch(
+            "app.api.routes.documents.rate_limit_service.record_document_upload_burst",
+            return_value=self._LOCKED_INFO,
+        ):
+            r = client.post(
+                f"{BASE}/upload",
+                headers=normal_user_token_headers,
+                files={
+                    "file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")
+                },
+            )
+        assert r.status_code == 429
+        assert "Retry-After" in r.headers
+        assert int(r.headers["Retry-After"]) >= 1
+
+    def test_upload_returns_429_on_hourly_limit(
+        self, client: TestClient, normal_user_token_headers: dict[str, str]
+    ) -> None:
+        """Returns 429 with Retry-After when the hourly upload limit is hit."""
+        _unlocked = RateLimitInfo(
+            is_locked=False, attempts_remaining=2, lockout_expires_at=None
+        )
+        _locked_hourly = RateLimitInfo(
+            is_locked=True,
+            attempts_remaining=0,
+            lockout_expires_at=datetime.now(timezone.utc) + timedelta(seconds=3600),
+        )
+        with (
+            patch(
+                "app.api.routes.documents.rate_limit_service.record_document_upload_burst",
+                return_value=_unlocked,
+            ),
+            patch(
+                "app.api.routes.documents.rate_limit_service.record_document_upload_hourly",
+                return_value=_locked_hourly,
+            ),
+        ):
+            r = client.post(
+                f"{BASE}/upload",
+                headers=normal_user_token_headers,
+                files={
+                    "file": ("test.pdf", io.BytesIO(_MINIMAL_PDF), "application/pdf")
+                },
+            )
+        assert r.status_code == 429
+        assert "Retry-After" in r.headers
+        assert int(r.headers["Retry-After"]) >= 1

--- a/backend/tests/api/routes/test_translations.py
+++ b/backend/tests/api/routes/test_translations.py
@@ -1,5 +1,6 @@
 """Tests for Translation API endpoints."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
@@ -11,6 +12,7 @@ from app.schemas.translation import (
     TranslationResponse,
     TranslationResult,
 )
+from app.services.rate_limit_service import RateLimitInfo
 from app.services.translation_service import TranslationError
 
 
@@ -322,3 +324,55 @@ def test_get_supported_languages(
     lang_codes = [lang["code"] for lang in data["languages"]]
     assert "de" in lang_codes
     assert "en" in lang_codes
+
+
+# ── Rate limiting tests ────────────────────────────────────────────────────────
+
+_LOCKED_RATE_LIMIT = RateLimitInfo(
+    is_locked=True,
+    attempts_remaining=0,
+    lockout_expires_at=datetime.now(timezone.utc) + timedelta(seconds=3600),
+)
+
+
+def test_translate_returns_429_when_rate_limited(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    """Returns 429 with Retry-After when the translation hourly limit is hit."""
+    with patch(
+        "app.api.routes.translations.rate_limit_service.record_translation_request",
+        return_value=_LOCKED_RATE_LIMIT,
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/translations/translate",
+            headers=normal_user_token_headers,
+            json={
+                "text": "Der Kaufvertrag",
+                "source_language": "de",
+                "target_language": "en",
+            },
+        )
+    assert r.status_code == 429
+    assert "Retry-After" in r.headers
+    assert int(r.headers["Retry-After"]) >= 1
+
+
+def test_batch_translate_returns_429_when_rate_limited(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    """Returns 429 with Retry-After when the batch translation hourly limit is hit."""
+    with patch(
+        "app.api.routes.translations.rate_limit_service.record_translation_request",
+        return_value=_LOCKED_RATE_LIMIT,
+    ):
+        r = client.post(
+            f"{settings.API_V1_STR}/translations/batch",
+            headers=normal_user_token_headers,
+            json={
+                "texts": ["Der Kaufvertrag"],
+                "source_language": "de",
+                "target_language": "en",
+            },
+        )
+    assert r.status_code == 429
+    assert "Retry-After" in r.headers

--- a/backend/tests/services/test_rate_limit_service.py
+++ b/backend/tests/services/test_rate_limit_service.py
@@ -6,16 +6,25 @@ import fakeredis
 import pytest
 
 from app.services.rate_limit_service import (
+    CONTRACT_ANALYSIS_HOURLY_MAX,
+    TRANSLATION_HOURLY_MAX,
+    UPLOAD_BURST_MAX,
+    UPLOAD_HOURLY_MAX,
     RateLimitInfo,
     get_status,
     is_locked,
     is_password_reset_locked,
     is_register_locked,
+    record_contract_analysis,
+    record_document_upload_burst,
+    record_document_upload_hourly,
     record_failed_attempt,
     record_password_reset_attempt,
     record_register_attempt,
     record_successful_login,
+    record_translation_request,
     reset,
+    retry_after_seconds,
 )
 
 
@@ -206,3 +215,130 @@ class TestPasswordResetRateLimit:
             record_password_reset_attempt(email)
         assert is_password_reset_locked(email) is True
         assert is_locked(email) is False
+
+
+# ── Document upload rate limiting ─────────────────────────────────────────────
+
+
+class TestDocumentUploadRateLimit:
+    def test_hourly_not_locked_initially(self) -> None:
+        info = record_document_upload_hourly("user-1")
+        assert info.is_locked is False
+        assert info.attempts_remaining == UPLOAD_HOURLY_MAX - 1
+
+    def test_hourly_lockout_after_max_uploads(self) -> None:
+        user = "user-hourly-lockout"
+        for i in range(UPLOAD_HOURLY_MAX - 1):
+            info = record_document_upload_hourly(user)
+            assert info.is_locked is False, f"Locked unexpectedly on attempt {i + 1}"
+        info = record_document_upload_hourly(user)
+        assert info.is_locked is True
+        assert info.attempts_remaining == 0
+        assert info.lockout_expires_at is not None
+
+    def test_burst_not_locked_initially(self) -> None:
+        info = record_document_upload_burst("user-2")
+        assert info.is_locked is False
+        assert info.attempts_remaining == UPLOAD_BURST_MAX - 1
+
+    def test_burst_lockout_after_max_uploads(self) -> None:
+        user = "user-burst-lockout"
+        for i in range(UPLOAD_BURST_MAX - 1):
+            info = record_document_upload_burst(user)
+            assert info.is_locked is False, f"Locked unexpectedly on attempt {i + 1}"
+        info = record_document_upload_burst(user)
+        assert info.is_locked is True
+        assert info.lockout_expires_at is not None
+
+    def test_hourly_and_burst_tracked_independently(self) -> None:
+        user = "user-independent"
+        # Exhaust burst
+        for _ in range(UPLOAD_BURST_MAX):
+            record_document_upload_burst(user)
+        # Hourly should still have remaining attempts
+        hourly = record_document_upload_hourly(user)
+        assert hourly.is_locked is False
+
+    def test_different_users_tracked_separately(self) -> None:
+        for _ in range(UPLOAD_HOURLY_MAX):
+            record_document_upload_hourly("user-a")
+        info_b = record_document_upload_hourly("user-b")
+        assert info_b.is_locked is False
+
+
+# ── Translation rate limiting ──────────────────────────────────────────────────
+
+
+class TestTranslationRateLimit:
+    def test_not_locked_initially(self) -> None:
+        info = record_translation_request("user-t1")
+        assert info.is_locked is False
+        assert info.attempts_remaining == TRANSLATION_HOURLY_MAX - 1
+
+    def test_lockout_after_max_requests(self) -> None:
+        user = "user-t-lockout"
+        for i in range(TRANSLATION_HOURLY_MAX - 1):
+            info = record_translation_request(user)
+            assert info.is_locked is False, f"Locked unexpectedly on attempt {i + 1}"
+        info = record_translation_request(user)
+        assert info.is_locked is True
+        assert info.lockout_expires_at is not None
+
+    def test_different_users_tracked_separately(self) -> None:
+        for _ in range(TRANSLATION_HOURLY_MAX):
+            record_translation_request("user-t-a")
+        info_b = record_translation_request("user-t-b")
+        assert info_b.is_locked is False
+
+
+# ── Contract analysis rate limiting ───────────────────────────────────────────
+
+
+class TestContractAnalysisRateLimit:
+    def test_not_locked_initially(self) -> None:
+        info = record_contract_analysis("user-c1")
+        assert info.is_locked is False
+        assert info.attempts_remaining == CONTRACT_ANALYSIS_HOURLY_MAX - 1
+
+    def test_lockout_after_max_analyses(self) -> None:
+        user = "user-c-lockout"
+        for i in range(CONTRACT_ANALYSIS_HOURLY_MAX - 1):
+            info = record_contract_analysis(user)
+            assert info.is_locked is False, f"Locked unexpectedly on attempt {i + 1}"
+        info = record_contract_analysis(user)
+        assert info.is_locked is True
+        assert info.lockout_expires_at is not None
+
+    def test_contract_and_translation_limits_independent(self) -> None:
+        user = "user-c-indep"
+        for _ in range(CONTRACT_ANALYSIS_HOURLY_MAX):
+            record_contract_analysis(user)
+        info = record_translation_request(user)
+        assert info.is_locked is False
+
+
+# ── retry_after_seconds helper ────────────────────────────────────────────────
+
+
+class TestRetryAfterSeconds:
+    def test_returns_remaining_seconds_from_lockout_expires_at(self) -> None:
+        expires = datetime.now(timezone.utc) + timedelta(seconds=120)
+        info = RateLimitInfo(
+            is_locked=True, attempts_remaining=0, lockout_expires_at=expires
+        )
+        result = retry_after_seconds(info)
+        assert 119 <= result <= 120
+
+    def test_returns_fallback_when_no_lockout_expires_at(self) -> None:
+        info = RateLimitInfo(
+            is_locked=True, attempts_remaining=0, lockout_expires_at=None
+        )
+        assert retry_after_seconds(info, fallback=999) == 999
+
+    def test_minimum_is_one_second(self) -> None:
+        # lockout_expires_at in the past — clamp to 1
+        expires = datetime.now(timezone.utc) - timedelta(seconds=5)
+        info = RateLimitInfo(
+            is_locked=True, attempts_remaining=0, lockout_expires_at=expires
+        )
+        assert retry_after_seconds(info) == 1

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -1006,6 +1006,9 @@ export class ContractsService {
      * Upload a PDF Kaufvertrag and receive an AI clause-by-clause analysis.
      *
      * Premium users see all clauses. Free users see the first 3 only.
+     *
+     * **Rate limits:**
+     * - 5 analyses per hour per user
      * @param data The data for the request.
      * @param data.formData
      * @returns ContractAnalysisResponse Successful Response
@@ -1116,6 +1119,10 @@ export class DocumentsService {
      * **Page limits:**
      * - Free tier: 10 pages
      * - Premium/Enterprise: 20 pages
+     *
+     * **Rate limits:**
+     * - 3 uploads per minute (burst)
+     * - 10 uploads per hour
      * @param data The data for the request.
      * @param data.formData
      * @param data.journeyStepId
@@ -3201,7 +3208,8 @@ export class TranslationsService {
      * - Plus French, Spanish, Italian, Polish, Turkish, Russian, Arabic, Chinese
      *
      * **Rate Limits:**
-     * - Free tier: 2 million characters/month
+     * - 50 translation requests per hour per user
+     * - Free tier: 2 million characters/month via Azure Translator
      * - Character count included in response for tracking
      * @param data The data for the request.
      * @param data.requestBody
@@ -3253,6 +3261,9 @@ export class TranslationsService {
      * **Limits:**
      * - Maximum 100 texts per request
      * - Each text limited to 50,000 characters
+     *
+     * **Rate Limits:**
+     * - 50 translation requests per hour per user (shared with /translate)
      * @param data The data for the request.
      * @param data.requestBody
      * @returns BatchTranslationResponse Successful Response


### PR DESCRIPTION
## Summary

- **Document upload**: 3 uploads/minute (burst) + 10 uploads/hour per user — both limits enforced before file processing begins, earliest limit wins
- **Translations** (`/translate`, `/batch`): 50 requests/hour per user — shared counter across both endpoints, protects Azure Translator monthly quota
- **Contract analysis** (`/analyze`): 5 analyses/hour per user — tightest limit since each call invokes Anthropic Claude

All 429 responses include a `Retry-After` header computed from the lockout expiry. Abuse events are logged at `WARNING` level for monitoring. Uses the existing `rate_limit_service` sliding-window Redis pattern (`_record_attempt` / sorted sets).

## Test plan

- [ ] `TestDocumentUploadRateLimit` — burst 429 + Retry-After, hourly 429 + Retry-After
- [ ] `test_translate_returns_429_when_rate_limited` — translate endpoint 429
- [ ] `test_batch_translate_returns_429_when_rate_limited` — batch endpoint 429
- [ ] `test_analyze_contract_returns_429_when_rate_limited` — contract analysis 429
- [ ] `TestDocumentUploadRateLimit`, `TestTranslationRateLimit`, `TestContractAnalysisRateLimit`, `TestRetryAfterSeconds` — service-level lockout, per-user isolation, cross-limit independence (20 new tests total)
- [ ] All pre-existing upload, translation, and contract tests continue to pass