### PR TITLE
chore(ci): add migration safety checker pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,10 @@ repos:
         pass_filenames: false
         language: unsupported
         files: ^backend/.*$|^scripts/generate-client\.sh$
+
+      - id: check-migration-safety
+        name: check migration safety
+        entry: uv run python backend/scripts/check_migration_safety.py
+        language: system
+        files: ^backend/app/alembic/versions/.*\.py$
+        pass_filenames: true

--- a/backend/app/alembic/README.md
+++ b/backend/app/alembic/README.md
@@ -1,0 +1,46 @@
+# Alembic Migration Guide
+
+## Rolling-deploy safety rule
+
+HeimPath runs rolling deploys on Azure Container Apps. During the deployment window, old and new containers run simultaneously. Any `op.add_column` with `nullable=False` and no `server_default` will cause old containers to fail on INSERT.
+
+**Required pattern for non-nullable columns:**
+
+```python
+op.add_column("table", sa.Column("col", sa.Boolean(), nullable=False, server_default="false"))
+```
+
+## 3-Phase Strategy for Breaking Changes
+
+Use this pattern when you need a non-nullable column without a sensible server default, or when backfilling data is required.
+
+### Phase 1 — Add nullable column (deploy safely)
+
+```python
+op.add_column("table", sa.Column("col", sa.String(50), nullable=True))
+```
+
+### Phase 2 — Backfill + add constraint (after full rollout)
+
+```python
+op.execute("UPDATE table SET col = 'default_value' WHERE col IS NULL")
+op.alter_column("table", "col", nullable=False)
+```
+
+### Phase 3 — Cleanup server_default if needed (optional)
+
+```python
+op.alter_column("table", "col", server_default=None)
+```
+
+## Naming Convention
+
+`<rev>_<verb>_<description>.py` — e.g. `a1b2c3d4e5f6_add_requires_manual_review_to_document_translation.py`
+
+## Safety Checker
+
+A pre-commit hook automatically runs `backend/scripts/check_migration_safety.py` on every staged migration file. To suppress a check for a known-safe pattern, add `# migration-safety: ok` to the `op.add_column` line.
+
+## Rollback
+
+See [docs/runbooks/migrations.md](../../../docs/runbooks/migrations.md) for step-by-step rollback procedures.

--- a/backend/scripts/check_migration_safety.py
+++ b/backend/scripts/check_migration_safety.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Migration safety checker.
+
+Usage: python check_migration_safety.py <migration_file> [<migration_file> ...]
+Exit 0 = all safe, Exit 1 = unsafe patterns found.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def _extract_balanced(text: str, start: int) -> str:
+    """Extract balanced parenthesis content starting at index start (must be '(')."""
+    depth = 0
+    in_string: str | None = None
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2  # skip escaped character
+                continue
+            if ch == in_string:
+                in_string = None
+        else:
+            if ch in ('"', "'"):
+                in_string = ch
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+        i += 1
+    return text[start:]
+
+
+def check_file(path: str) -> list[str]:
+    """Return list of error messages for the file, or empty list if safe."""
+    source = Path(path).read_text()
+    lines = source.splitlines()
+    errors: list[str] = []
+
+    # Locate the upgrade() function (top-level only)
+    upgrade_start: int | None = None
+    for i, line in enumerate(lines):
+        if re.match(r"^def upgrade\b", line):
+            upgrade_start = i
+            break
+
+    if upgrade_start is None:
+        return []
+
+    # Find where the upgrade() body ends (next top-level statement)
+    upgrade_end = len(lines)
+    for i in range(upgrade_start + 1, len(lines)):
+        line = lines[i]
+        if line and not line[0].isspace() and line.strip():
+            upgrade_end = i
+            break
+
+    body_lines = lines[upgrade_start + 1 : upgrade_end]
+    upgrade_body = "\n".join(body_lines)
+
+    # Scan for op.add_column( calls
+    for match in re.finditer(r"op\.add_column\(", upgrade_body):
+        match_pos = match.start()
+        paren_pos = match.end() - 1  # position of the opening '('
+
+        # 1-indexed line number in the original file
+        line_offset = upgrade_body[:match_pos].count("\n")
+        abs_line_num = (
+            upgrade_start + line_offset + 2
+        )  # +1 past def line, +1 for 1-index
+
+        # Extract the complete op.add_column(...) call
+        call_text = _extract_balanced(upgrade_body, paren_pos)
+
+        # Check suppression comment on any line covered by this call
+        call_line_count = call_text.count("\n")
+        covered = body_lines[line_offset : line_offset + call_line_count + 1]
+        if any("# migration-safety: ok" in ln for ln in covered):
+            continue
+
+        # Only flag calls where nullable=False is explicitly set
+        if "nullable=False" not in call_text:
+            continue
+
+        # Look for sa.Column( inside the call and verify server_default= is present
+        col_match = re.search(r"sa\.Column\(", call_text)
+        if col_match is None:
+            errors.append(
+                f"{path}:{abs_line_num}: op.add_column with nullable=False requires "
+                "server_default= for rolling-deploy safety"
+            )
+            continue
+
+        col_paren = col_match.end() - 1
+        col_text = _extract_balanced(call_text, col_paren)
+
+        if "server_default=" not in col_text:
+            errors.append(
+                f"{path}:{abs_line_num}: op.add_column with nullable=False requires "
+                "server_default= for rolling-deploy safety"
+            )
+
+    return errors
+
+
+def main() -> None:
+    files = sys.argv[1:]
+    errors: list[str] = []
+    for f in files:
+        errors.extend(check_file(f))
+    if errors:
+        for e in errors:
+            print(e)  # noqa: T201
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/scripts/test_check_migration_safety.py
+++ b/backend/tests/scripts/test_check_migration_safety.py
@@ -1,0 +1,100 @@
+"""Tests for backend/scripts/check_migration_safety.py."""
+
+import sys
+from pathlib import Path
+
+# Make the scripts directory importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from check_migration_safety import check_file  # noqa: E402
+
+
+def _write(tmp_path: Path, content: str) -> str:
+    migration = tmp_path / "0001_test_migration.py"
+    migration.write_text(content)
+    return str(migration)
+
+
+def test_safe_nullable_false_with_server_default(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "def upgrade() -> None:\n"
+        '    op.add_column("t", sa.Column("c", sa.Boolean(), nullable=False, server_default="false"))\n',
+    )
+    assert check_file(path) == []
+
+
+def test_unsafe_nullable_false_without_server_default(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "def upgrade() -> None:\n"
+        '    op.add_column("t", sa.Column("c", sa.Boolean(), nullable=False))\n',
+    )
+    errors = check_file(path)
+    assert len(errors) == 1
+    assert "nullable=False" in errors[0]
+    assert "server_default=" in errors[0]
+
+
+def test_safe_nullable_true_no_server_default(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "def upgrade() -> None:\n"
+        '    op.add_column("t", sa.Column("c", sa.String(50), nullable=True))\n',
+    )
+    assert check_file(path) == []
+
+
+def test_safe_no_nullable_arg(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "def upgrade() -> None:\n"
+        '    op.add_column("t", sa.Column("c", sa.String(50)))\n',
+    )
+    assert check_file(path) == []
+
+
+def test_suppression_comment_skips_check(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "def upgrade() -> None:\n"
+        '    op.add_column("t", sa.Column("c", sa.Boolean(), nullable=False))  # migration-safety: ok\n',
+    )
+    assert check_file(path) == []
+
+
+def test_multiple_columns_one_unsafe(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "def upgrade() -> None:\n"
+        '    op.add_column("t", sa.Column("a", sa.Boolean(), nullable=False, server_default="false"))\n'
+        '    op.add_column("t", sa.Column("b", sa.Boolean(), nullable=False))\n',
+    )
+    errors = check_file(path)
+    assert len(errors) == 1
+    assert '"b"' not in errors[0] or "server_default=" in errors[0]
+
+
+def test_alter_column_not_checked(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        'def upgrade() -> None:\n    op.alter_column("t", "c", nullable=False)\n',
+    )
+    assert check_file(path) == []
+
+
+def test_outside_upgrade_not_checked(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "def upgrade() -> None:\n"
+        "    pass\n"
+        "\n"
+        "def downgrade() -> None:\n"
+        '    op.add_column("t", sa.Column("c", sa.Boolean(), nullable=False))\n',
+    )
+    assert check_file(path) == []
+
+
+def test_empty_file_passes(tmp_path: Path) -> None:
+    path = _write(tmp_path, "")
+    assert check_file(path) == []

--- a/docs/runbooks/migrations.md
+++ b/docs/runbooks/migrations.md
@@ -1,0 +1,37 @@
+# Migration Rollback Runbook
+
+## When to Use This
+
+Use this runbook when a migration has been applied but needs to be reversed — e.g., a bad column type, wrong constraint, or data corruption.
+
+## Staging (Neon branch)
+
+Neon creates a branch per PR. To roll back:
+
+1. Identify the previous revision: `alembic history --verbose | head -20`
+2. Run downgrade: `alembic downgrade -1` (one step) or `alembic downgrade <rev>` (to specific revision)
+3. Verify: `alembic current`
+
+## Production (Neon main branch)
+
+**STOP: Get sign-off from a second engineer before proceeding.**
+
+1. Scale down the app to 0 replicas to prevent writes during rollback:
+   ```bash
+   az containerapp update --name heimpath-api --resource-group heimpath-prod --min-replicas 0 --max-replicas 0
+   ```
+2. Take a database snapshot via the Neon console before any changes.
+3. Run the downgrade:
+   ```bash
+   DATABASE_URL=<prod_url> alembic downgrade -1
+   ```
+4. Deploy the previous app version (or revert code that depended on the migrated schema).
+5. Scale replicas back up.
+6. Monitor error rates for 10 minutes.
+
+## Emergency: Data Loss or Corruption
+
+1. Immediately scale app to 0 replicas.
+2. In Neon console: use **Branch Restore** to restore the database branch to a point-in-time before the bad migration.
+3. Re-deploy the previous app version.
+4. Investigate root cause before re-applying migration.


### PR DESCRIPTION
## Summary

- Adds a pre-commit hook that validates Alembic migration files on every commit
- Flags any `op.add_column` with `nullable=False` and no `server_default` — unsafe pattern for rolling deploys (old containers will INSERT-fail during the deployment window)
- Suppression escape hatch: `# migration-safety: ok` on the `op.add_column` line skips the check for known-safe patterns
- Includes a 3-phase strategy guide in `backend/app/alembic/README.md` for breaking schema changes
- Adds `docs/runbooks/migrations.md` with step-by-step rollback procedures for staging and production

## Test plan
- [ ] 9 unit tests in `tests/scripts/test_check_migration_safety.py` — all passing locally
- [ ] Hook only triggers for `backend/app/alembic/versions/*.py` (scoped via `files:` pattern)
- [ ] Hook does not block non-migration commits