### PR TITLE
feat(translation): add partial mode and debug logging to batch_translate

### DIFF
--- a/backend/app/services/translation_service.py
+++ b/backend/app/services/translation_service.py
@@ -4,6 +4,7 @@ Provides document translation for German real estate documents using
 Microsoft Azure Translator API (free tier: 2M chars/month).
 """
 
+import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
@@ -26,6 +27,8 @@ from app.schemas.translation import (
 from app.schemas.translation import (
     TranslationResult as TranslationResultSchema,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class TranslationError(Exception):
@@ -528,6 +531,7 @@ class TranslationService:
         source_language: SupportedLanguage,
         target_language: SupportedLanguage,
         include_legal_warnings: bool = True,
+        partial: bool = False,
     ) -> BatchTranslationResponse:
         """Translate multiple texts in a single request.
 
@@ -536,12 +540,17 @@ class TranslationService:
             source_language: Source language.
             target_language: Target language.
             include_legal_warnings: Whether to include legal term warnings.
+            partial: If True, accept partial responses from Azure — texts with
+                no corresponding response entry are marked with
+                ``translated_text="translation_failed"`` and ``requires_review=True``.
+                If False (default), a count mismatch raises TranslationError.
 
         Returns:
             BatchTranslationResponse with all translations.
 
         Raises:
-            TranslationError: If translation fails.
+            TranslationError: If translation fails or response count mismatches
+                and ``partial=False``.
         """
         if not texts:
             return BatchTranslationResponse(
@@ -549,6 +558,9 @@ class TranslationService:
             )
 
         try:
+            logger.debug(
+                "batch_translate: sending %d texts to Azure Translator", len(texts)
+            )
             response = await _breaker_async_call(
                 translator_breaker,
                 self._make_batch_request,
@@ -556,18 +568,29 @@ class TranslationService:
                 source_language=source_language.value,
                 target_language=target_language.value,
             )
+            logger.debug(
+                "batch_translate: received %d responses for %d texts",
+                len(response),
+                len(texts),
+            )
 
             if len(response) != len(texts):
-                raise TranslationError(
-                    f"Batch response mismatch: sent {len(texts)}, received {len(response)}"
+                if not partial:
+                    raise TranslationError(
+                        f"Batch response mismatch: sent {len(texts)}, received {len(response)}"
+                    )
+                logger.warning(
+                    "batch_translate partial response: sent %d, received %d — "
+                    "unmapped texts will be marked as translation_failed",
+                    len(texts),
+                    len(response),
                 )
 
             translations: list[TranslationResponse] = []
             total_chars = 0
             total_warnings = 0
 
-            for i, result in enumerate(response):
-                original_text = texts[i]
+            for original_text, result in zip(texts, response, strict=False):
                 translated = result.get("translations", [{}])[0]
                 detected = result.get("detectedLanguage", {})
 
@@ -597,6 +620,25 @@ class TranslationService:
                         translation=translation_result,
                         legal_warnings=legal_warnings,
                         requires_review=requires_review,
+                        character_count=char_count,
+                    )
+                )
+
+            # Fill placeholders for any texts beyond the received response count.
+            for missing_text in texts[len(response) :]:
+                char_count = len(missing_text)
+                total_chars += char_count
+                translations.append(
+                    TranslationResponse(
+                        translation=TranslationResultSchema(
+                            original_text=missing_text,
+                            translated_text="translation_failed",
+                            source_language=source_language.value,
+                            target_language=target_language.value,
+                            confidence=0.0,
+                        ),
+                        legal_warnings=[],
+                        requires_review=True,
                         character_count=char_count,
                     )
                 )

--- a/backend/tests/services/test_translation_service.py
+++ b/backend/tests/services/test_translation_service.py
@@ -572,3 +572,76 @@ class TestReliability:
                 )
 
         assert "mismatch" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_batch_partial_mode_maps_received_and_marks_missing(
+        self, translation_service: TranslationService
+    ) -> None:
+        """partial=True: first 3 translations mapped, texts 4 and 5 marked translation_failed."""
+        mock_response = [
+            {
+                "detectedLanguage": {"language": "de", "score": 0.98},
+                "translations": [{"text": f"Translation {i}", "to": "en"}],
+            }
+            for i in range(3)
+        ]
+
+        with patch.object(
+            translation_service, "_make_batch_request", new_callable=AsyncMock
+        ) as mock_batch:
+            mock_batch.return_value = mock_response
+
+            result = await translation_service.batch_translate(
+                texts=["Text 1", "Text 2", "Text 3", "Text 4", "Text 5"],
+                source_language=SupportedLanguage.GERMAN,
+                target_language=SupportedLanguage.ENGLISH,
+                partial=True,
+            )
+
+        assert len(result.translations) == 5
+        # First 3 are normal translations
+        for i in range(3):
+            assert (
+                result.translations[i].translation.translated_text == f"Translation {i}"
+            )
+        # Last 2 are failure placeholders
+        for i in range(3, 5):
+            assert (
+                result.translations[i].translation.translated_text
+                == "translation_failed"
+            )
+            assert result.translations[i].translation.confidence == 0.0
+            assert result.translations[i].requires_review is True
+
+    @pytest.mark.asyncio
+    async def test_batch_debug_log_emitted(
+        self, translation_service: TranslationService
+    ) -> None:
+        """batch_translate calls logger.debug with sent/received counts."""
+        mock_response = [
+            {
+                "detectedLanguage": {"language": "de", "score": 0.98},
+                "translations": [{"text": f"T{i}", "to": "en"}],
+            }
+            for i in range(2)
+        ]
+
+        with (
+            patch.object(
+                translation_service, "_make_batch_request", new_callable=AsyncMock
+            ) as mock_batch,
+            patch("app.services.translation_service.logger") as mock_logger,
+        ):
+            mock_batch.return_value = mock_response
+            await translation_service.batch_translate(
+                texts=["A", "B"],
+                source_language=SupportedLanguage.GERMAN,
+                target_language=SupportedLanguage.ENGLISH,
+            )
+
+        # Two debug calls: one before the request (sent count) and one after (received count)
+        assert mock_logger.debug.call_count >= 2
+        all_debug_args = " ".join(
+            str(args) for args, _ in mock_logger.debug.call_args_list
+        )
+        assert "2" in all_debug_args


### PR DESCRIPTION
## Summary

- Adds `partial=True` parameter to `batch_translate` — when Azure Translator returns fewer responses than texts sent, received results are mapped normally and unmapped texts get `translated_text="translation_failed"` with `requires_review=True` instead of raising `TranslationError`
- Adds `logger.debug` calls before and after `_make_batch_request` logging sent/received counts for observability
- Adds `import logging` and module-level `logger` (previously absent from this service)

## Test plan

- [ ] `test_batch_response_length_mismatch_raises` — existing test, still passes (strict mode unchanged by default)
- [ ] `test_batch_partial_mode_maps_received_and_marks_missing` — 3 of 5 responses returned, first 3 mapped, texts 4+5 marked `translation_failed`
- [ ] `test_batch_debug_log_emitted` — verifies `logger.debug` called with sent/received counts
- [ ] `uv run pytest --tb=short -q` → 1649 passed, 0 failed
- [ ] `pre-commit run --all-files` → all hooks pass