### PR TITLE
feat(document): add translation coverage gate and partial coverage tracking

### DIFF
--- a/backend/app/alembic/versions/c9d0e1f2g3h4_add_partial_translation_coverage.py
+++ b/backend/app/alembic/versions/c9d0e1f2g3h4_add_partial_translation_coverage.py
@@ -1,0 +1,27 @@
+"""Add partial_translation_coverage to document_translation
+
+Revision ID: c9d0e1f2g3h4
+Revises: b4w5x6y7z8c9
+Create Date: 2026-05-08 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "c9d0e1f2g3h4"
+down_revision = "b4w5x6y7z8c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document_translation",
+        sa.Column("partial_translation_coverage", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("document_translation", "partial_translation_coverage")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -177,6 +177,11 @@ class Settings(BaseSettings):
 
     # Reliability settings
     TRANSLATION_CONFIDENCE_THRESHOLD: float = 0.70
+    # Minimum fraction of pages/clauses that must be translated before the document
+    # is allowed to reach COMPLETED status. If Azure Translator returns fewer
+    # results than submitted, the document is marked FAILED rather than silently
+    # accepted as complete with missing pages.
+    TRANSLATION_COVERAGE_THRESHOLD: float = 0.95
     AZURE_TRANSLATOR_TIMEOUT_SECONDS: int = 60
     # Quota: default 1,900,000 leaves a 5% buffer below the 2M free-tier limit.
     AZURE_TRANSLATOR_QUOTA_LIMIT: int = 1_900_000

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -178,6 +178,13 @@ class DocumentTranslation(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     translation_confidence_score = Column(Float, nullable=True)
 
+    # Coverage — fraction of pages actually translated (0.0–1.0). Values < 1.0
+    # indicate Azure returned fewer results than submitted (placeholder pages).
+    # Documents with coverage below TRANSLATION_COVERAGE_THRESHOLD are marked
+    # FAILED rather than COMPLETED, so this field is always >= the threshold
+    # on successfully completed documents.
+    partial_translation_coverage = Column(Float, nullable=True)
+
     # Timing
     processing_started_at = Column(DateTime(timezone=True), nullable=True)
     processing_completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -177,6 +177,7 @@ class DocumentTranslationResponse(BaseModel):
     processing_completed_at: datetime | None = None
     requires_manual_review: bool = False
     translation_confidence_score: float | None = None
+    partial_translation_coverage: float | None = None
 
 
 class DocumentDetailResponse(BaseModel):

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -363,6 +363,16 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                         include_legal_warnings=True,
                     )
 
+                    # Coverage gate — fail fast before mapping if Azure returned too few
+                    page_coverage = len(batch_result.translations) / len(page_texts)
+                    if page_coverage < settings.TRANSLATION_COVERAGE_THRESHOLD:
+                        raise RuntimeError(
+                            f"Incomplete page translation: "
+                            f"{len(batch_result.translations)}/{len(page_texts)} pages translated "
+                            f"(coverage={page_coverage:.1%}, "
+                            f"minimum={settings.TRANSLATION_COVERAGE_THRESHOLD:.0%})"
+                        )
+
                     # Map translations back to pages
                     text_idx = 0
                     for page in pages:
@@ -411,16 +421,6 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                             low_count,
                             len(page_confidences),
                             avg_confidence,
-                        )
-
-                    # Coverage gate — fail if Azure returned too few translations
-                    page_coverage = len(batch_result.translations) / len(page_texts)
-                    if page_coverage < settings.TRANSLATION_COVERAGE_THRESHOLD:
-                        raise RuntimeError(
-                            f"Incomplete page translation: "
-                            f"{len(batch_result.translations)}/{len(page_texts)} pages translated "
-                            f"(coverage={page_coverage:.1%}, "
-                            f"minimum={settings.TRANSLATION_COVERAGE_THRESHOLD:.0%})"
                         )
 
                 # Translate clause contexts

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -348,6 +348,7 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
             all_risk_warnings: list[dict] = []
             requires_manual_review: bool = False
             avg_confidence: float | None = None
+            page_coverage: float = 1.0
 
             if translation_service:
                 # Translate page texts
@@ -412,6 +413,16 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                             avg_confidence,
                         )
 
+                    # Coverage gate — fail if Azure returned too few translations
+                    page_coverage = len(batch_result.translations) / len(page_texts)
+                    if page_coverage < settings.TRANSLATION_COVERAGE_THRESHOLD:
+                        raise RuntimeError(
+                            f"Incomplete page translation: "
+                            f"{len(batch_result.translations)}/{len(page_texts)} pages translated "
+                            f"(coverage={page_coverage:.1%}, "
+                            f"minimum={settings.TRANSLATION_COVERAGE_THRESHOLD:.0%})"
+                        )
+
                 # Translate clause contexts
                 clause_texts = [
                     c["original_text"]
@@ -425,6 +436,14 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                         target_language=SupportedLanguage.ENGLISH,
                         include_legal_warnings=False,
                     )
+                    clause_coverage = len(clause_batch.translations) / len(clause_texts)
+                    if clause_coverage < settings.TRANSLATION_COVERAGE_THRESHOLD:
+                        raise RuntimeError(
+                            f"Incomplete clause translation: "
+                            f"{len(clause_batch.translations)}/{len(clause_texts)} clauses translated "
+                            f"(coverage={clause_coverage:.1%}, "
+                            f"minimum={settings.TRANSLATION_COVERAGE_THRESHOLD:.0%})"
+                        )
                     text_idx = 0
                     for clause in all_clauses:
                         if clause["original_text"].strip() and text_idx < len(
@@ -478,6 +497,7 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                 processing_completed_at=datetime.now(timezone.utc),
                 requires_manual_review=requires_manual_review,
                 translation_confidence_score=avg_confidence,
+                partial_translation_coverage=page_coverage,
             )
             session.add(translation)
 

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -586,3 +586,227 @@ class TestTranslationConfidenceThreshold:
 
         added = mock_session.add.call_args[0][0]
         assert added.translation_confidence_score == pytest.approx(expected_avg)
+
+
+# ── Translation coverage gate tests ──────────────────────────────────────────
+
+
+def _make_partial_batch_result_mock(
+    confidences: list[float], total_sent: int
+) -> MagicMock:
+    """Create a mock batch result returning only len(confidences) of total_sent items."""
+    batch = MagicMock()
+    batch.translations = [_make_translation_mock(c) for c in confidences]
+    # total_sent is used to set up the pages fixture with more pages than responses
+    _ = total_sent  # referenced by caller to size pages list
+    return batch
+
+
+class TestTranslationCoverageGate:
+    """Tests for partial translation coverage gate (Task #211)."""
+
+    def _make_setup_with_coverage(
+        self,
+        document_id: uuid.UUID,
+        user_id: uuid.UUID,
+        total_pages: int,
+        returned_translations: int,
+    ) -> tuple[MagicMock, object, MagicMock, list[dict], AsyncMock]:
+        """Setup where Azure returns fewer translations than pages sent."""
+        mock_session, session_factory = _make_process_document_mocks(
+            document_id, user_id
+        )
+        mock_sync_cm = _make_sync_session_mock()
+
+        pages = [
+            {
+                "page_number": i + 1,
+                "original_text": f"Text page {i + 1}",
+                "translated_text": "",
+            }
+            for i in range(total_pages)
+        ]
+
+        confidences = [0.95] * returned_translations
+        batch_result = _make_batch_result_mock(confidences)
+
+        mock_svc = AsyncMock()
+        mock_svc.batch_translate = AsyncMock(return_value=batch_result)
+
+        return mock_session, session_factory, mock_sync_cm, pages, mock_svc
+
+    async def _run(
+        self,
+        document_id: uuid.UUID,
+        session_factory: object,
+        pages: list[dict],
+        mock_svc: AsyncMock,
+        mock_sync_cm: MagicMock,
+    ) -> None:
+        with (
+            patch(
+                "app.services.document_service._extract_pages_sync",
+                return_value=pages,
+            ),
+            patch(
+                "app.services.document_service.get_translation_service",
+                return_value=mock_svc,
+            ),
+            patch(
+                "app.services.document_service.analyze_clause_risks",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "app.services.document_service.analyze_kaufvertrag",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.services.document_service.analyze_document_type",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.services.document_service.link_glossary_terms",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("sqlmodel.Session", return_value=mock_sync_cm),
+            patch("app.services.notification_service.create_notification"),
+        ):
+            await document_service.process_document(document_id, session_factory)
+
+    @pytest.mark.asyncio
+    async def test_fails_document_when_page_coverage_below_threshold(self) -> None:
+        """Document is marked FAILED when Azure returns < 95% of submitted pages."""
+        document_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        # 5 pages sent, only 4 returned → 80% coverage < 95% threshold
+        mock_session, session_factory, mock_sync_cm, pages, mock_svc = (
+            self._make_setup_with_coverage(document_id, user_id, 5, 4)
+        )
+        await self._run(document_id, session_factory, pages, mock_svc, mock_sync_cm)
+
+        # DocumentTranslation must NOT be added to session
+        assert mock_session.add.call_count == 0
+        # Document must be re-fetched and marked FAILED
+        doc = mock_session.execute.return_value.scalar_one_or_none.return_value
+        assert doc.status == "failed"
+        assert "coverage" in doc.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_succeeds_when_page_coverage_meets_threshold(self) -> None:
+        """Document is marked COMPLETED when coverage exactly meets 95% threshold."""
+        document_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        # 20 pages sent, 19 returned → 95% coverage == threshold
+        mock_session, session_factory, mock_sync_cm, pages, mock_svc = (
+            self._make_setup_with_coverage(document_id, user_id, 20, 19)
+        )
+        await self._run(document_id, session_factory, pages, mock_svc, mock_sync_cm)
+
+        # DocumentTranslation was added
+        assert mock_session.add.call_count == 1
+        added = mock_session.add.call_args[0][0]
+        assert added.partial_translation_coverage == pytest.approx(19 / 20)
+
+    @pytest.mark.asyncio
+    async def test_partial_translation_coverage_is_1_for_full_translation(
+        self,
+    ) -> None:
+        """partial_translation_coverage equals 1.0 when all pages are returned."""
+        document_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        # 3 pages sent, 3 returned → coverage = 1.0
+        mock_session, session_factory, mock_sync_cm, pages, mock_svc = (
+            self._make_setup_with_coverage(document_id, user_id, 3, 3)
+        )
+        await self._run(document_id, session_factory, pages, mock_svc, mock_sync_cm)
+
+        added = mock_session.add.call_args[0][0]
+        assert added.partial_translation_coverage == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_fails_document_when_clause_coverage_below_threshold(self) -> None:
+        """Document is marked FAILED when Azure returns < 95% of submitted clauses."""
+        document_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_session, session_factory = _make_process_document_mocks(
+            document_id, user_id
+        )
+        mock_sync_cm = _make_sync_session_mock()
+
+        # Pages translate successfully (full coverage)
+        pages = [
+            {
+                "page_number": 1,
+                "original_text": "Der Kaufpreis beträgt EUR 350.000",
+                "translated_text": "",
+            }
+        ]
+        full_page_batch = _make_batch_result_mock([0.95])
+        # Clauses: 5 sent, only 4 returned → 80% < 95%
+        partial_clause_batch = MagicMock()
+        partial_clause_batch.translations = [
+            _make_translation_mock(0.95) for _ in range(4)
+        ]
+
+        call_count = 0
+
+        async def _side_effect(**_kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            return full_page_batch if call_count == 1 else partial_clause_batch
+
+        mock_svc = AsyncMock()
+        mock_svc.batch_translate = AsyncMock(side_effect=_side_effect)
+
+        # Patch _detect_clauses to return 5 clauses so clause_texts has 5 entries
+        five_clauses = [
+            {
+                "clause_type": "purchase_price",
+                "original_text": f"Kaufpreis {i}",
+                "translated_text": "",
+                "page_number": 1,
+                "risk_level": "high",
+            }
+            for i in range(5)
+        ]
+
+        with (
+            patch(
+                "app.services.document_service._extract_pages_sync",
+                return_value=pages,
+            ),
+            patch(
+                "app.services.document_service.get_translation_service",
+                return_value=mock_svc,
+            ),
+            patch(
+                "app.services.document_service._detect_clauses",
+                return_value=five_clauses,
+            ),
+            patch(
+                "app.services.document_service.analyze_clause_risks",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "app.services.document_service.analyze_kaufvertrag",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.services.document_service.analyze_document_type",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.services.document_service.link_glossary_terms",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("sqlmodel.Session", return_value=mock_sync_cm),
+            patch("app.services.notification_service.create_notification"),
+        ):
+            await document_service.process_document(document_id, session_factory)
+
+        # DocumentTranslation must NOT be added
+        assert mock_session.add.call_count == 0
+        doc = mock_session.execute.return_value.scalar_one_or_none.return_value
+        assert doc.status == "failed"
+        assert "coverage" in doc.error_message.lower()

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -591,17 +591,6 @@ class TestTranslationConfidenceThreshold:
 # ── Translation coverage gate tests ──────────────────────────────────────────
 
 
-def _make_partial_batch_result_mock(
-    confidences: list[float], total_sent: int
-) -> MagicMock:
-    """Create a mock batch result returning only len(confidences) of total_sent items."""
-    batch = MagicMock()
-    batch.translations = [_make_translation_mock(c) for c in confidences]
-    # total_sent is used to set up the pages fixture with more pages than responses
-    _ = total_sent  # referenced by caller to size pages list
-    return batch
-
-
 class TestTranslationCoverageGate:
     """Tests for partial translation coverage gate (Task #211)."""
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2558,6 +2558,17 @@ export const DocumentTranslationResponseSchema = {
                 }
             ],
             title: 'Translation Confidence Score'
+        },
+        partial_translation_coverage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Partial Translation Coverage'
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -750,6 +750,7 @@ export type DocumentTranslationResponse = {
     processing_completed_at?: (string | null);
     requires_manual_review?: boolean;
     translation_confidence_score?: (number | null);
+    partial_translation_coverage?: (number | null);
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds `TRANSLATION_COVERAGE_THRESHOLD` (default 95%) to config — minimum fraction of pages/clauses Azure must return before a document is allowed to reach COMPLETED
- Raises `RuntimeError` when coverage falls below threshold, causing the outer error handler to mark the document FAILED with a descriptive message (no silent partial completions)
- Adds `partial_translation_coverage` (Float, 0.0–1.0) column to `DocumentTranslation` so completed documents record actual page coverage
- Exposes `partial_translation_coverage` in `DocumentTranslationResponse` schema (auto-generated TypeScript types updated)
- Adds Alembic migration for the new column

## Test plan

- [ ] `test_fails_document_when_page_coverage_below_threshold` — 5 pages sent / 4 returned (80%) → FAILED, no DocumentTranslation added
- [ ] `test_succeeds_when_page_coverage_meets_threshold` — 20 pages sent / 19 returned (95%) → COMPLETED, `partial_translation_coverage=0.95`
- [ ] `test_partial_translation_coverage_is_1_for_full_translation` — 3/3 pages → coverage = 1.0
- [ ] `test_fails_document_when_clause_coverage_below_threshold` — 5 clauses sent / 4 returned → FAILED
- [ ] Full suite: 1705 tests pass