### PR TITLE
feat(reliability): add Redis circuit breaker to auth and rate-limit

### DIFF
--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, text
 from app.api.deps import get_current_active_superuser, get_db
 from app.core.circuit_breakers import (
     anthropic_breaker,
+    redis_breaker,
     stripe_breaker,
     translator_breaker,
 )
@@ -83,4 +84,5 @@ def circuit_breaker_health_check() -> dict[str, dict[str, int | str]]:
         "stripe": _state(stripe_breaker),
         "translator": _state(translator_breaker),
         "anthropic": _state(anthropic_breaker),
+        "redis": _state(redis_breaker),
     }

--- a/backend/app/core/circuit_breakers.py
+++ b/backend/app/core/circuit_breakers.py
@@ -4,6 +4,7 @@ Each breaker protects one external integration:
 - stripe_breaker     — Stripe API (sync calls)
 - translator_breaker — Azure Translator API (async calls)
 - anthropic_breaker  — Anthropic Claude API (async calls)
+- redis_breaker      — Redis (sync calls; fail_max=10, reset_timeout=15)
 
 Usage at call sites::
 
@@ -78,6 +79,17 @@ anthropic_breaker = pybreaker.CircuitBreaker(
     fail_max=5,
     reset_timeout=60,
     name="anthropic",
+    listeners=[_listener],
+)
+
+# Redis has a higher fail_max (10) and shorter reset_timeout (15 s) because:
+# - Redis calls are very frequent (every auth + rate-limit check)
+# - Redis recovers quickly and we want to resume protection ASAP
+# - fail-open is already implemented in callers, so a short window is safe
+redis_breaker = pybreaker.CircuitBreaker(
+    fail_max=10,
+    reset_timeout=15,
+    name="redis",
     listeners=[_listener],
 )
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -5,16 +5,19 @@ The token blacklist is backed by Redis for persistence across restarts and
 horizontal scaling.
 """
 
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any
 
 import jwt
+import pybreaker
 import redis as redis_lib
 from jwt.exceptions import InvalidTokenError
 from pydantic import BaseModel
 
+from app.core.circuit_breakers import redis_breaker
 from app.core.config import settings
 from app.services.redis_client import get_redis
 
@@ -22,6 +25,8 @@ ALGORITHM = "HS256"
 _BLACKLIST_PREFIX = "auth:blacklist:"
 _GRACE_PREFIX = "auth:refresh_grace:"
 REFRESH_ROTATION_GRACE_SECONDS = 30
+
+_logger = logging.getLogger(__name__)
 
 # Module-level Redis client (connection pool, created lazily)
 _redis_client: redis_lib.Redis | None = None
@@ -184,17 +189,33 @@ def blacklist_token(jti: str, expires_at: datetime) -> None:
     The Redis key TTL matches the remaining token lifetime so the blacklist
     entry is automatically evicted when the token would have expired anyway.
 
+    Fail-safe: if Redis is unavailable (circuit open or ``RedisError``), a
+    warning is logged and the operation is skipped.  The caller (logout) still
+    succeeds — the token will expire on its own.
+
     Args:
         jti: Unique token identifier (``jti`` claim).
         expires_at: Token expiry timestamp (used to compute TTL).
     """
     ttl = max(int((expires_at - datetime.now(timezone.utc)).total_seconds()), 1)
-    _redis().setex(f"{_BLACKLIST_PREFIX}{jti}", ttl, "1")
+    try:
+        redis_breaker.call(_redis().setex, f"{_BLACKLIST_PREFIX}{jti}", ttl, "1")
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        _logger.warning(
+            "Redis unavailable — token %s could not be blacklisted (logout proceeds)",
+            jti,
+        )
 
 
 def is_token_blacklisted(jti: str) -> bool:
-    """Return *True* if the JTI is present in the Redis blacklist."""
-    return bool(_redis().exists(f"{_BLACKLIST_PREFIX}{jti}"))
+    """Return *True* if the JTI is present in the Redis blacklist.
+
+    Fail-open: returns *False* (token accepted) when Redis is unavailable.
+    """
+    try:
+        return bool(redis_breaker.call(_redis().exists, f"{_BLACKLIST_PREFIX}{jti}"))
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def is_token_in_grace_period(jti: str) -> bool:
@@ -202,8 +223,13 @@ def is_token_in_grace_period(jti: str) -> bool:
 
     After refresh token rotation the old JTI is blacklisted but a short
     grace key is set so concurrent in-flight refresh requests still succeed.
+
+    Fail-open: returns *False* when Redis is unavailable.
     """
-    return bool(_redis().exists(f"{_GRACE_PREFIX}{jti}"))
+    try:
+        return bool(redis_breaker.call(_redis().exists, f"{_GRACE_PREFIX}{jti}"))
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def _rotate_refresh_token(jti: str, expires_at: datetime) -> None:
@@ -214,7 +240,15 @@ def _rotate_refresh_token(jti: str, expires_at: datetime) -> None:
     :data:`REFRESH_ROTATION_GRACE_SECONDS` window.
     """
     blacklist_token(jti, expires_at)
-    _redis().setex(f"{_GRACE_PREFIX}{jti}", REFRESH_ROTATION_GRACE_SECONDS, "1")
+    try:
+        redis_breaker.call(
+            _redis().setex, f"{_GRACE_PREFIX}{jti}", REFRESH_ROTATION_GRACE_SECONDS, "1"
+        )
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        _logger.warning(
+            "Redis unavailable — refresh grace window for token %s not set",
+            jti,
+        )
 
 
 # ── higher-level operations ───────────────────────────────────────────────────

--- a/backend/app/services/rate_limit_service.py
+++ b/backend/app/services/rate_limit_service.py
@@ -7,12 +7,15 @@ so limits survive server restarts and work correctly across
 horizontally-scaled instances.
 """
 
+import logging
 import math
 from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
+import pybreaker
 import redis as redis_lib
 
+from app.core.circuit_breakers import redis_breaker
 from app.services.redis_client import get_redis
 
 # Login rate limit constants
@@ -101,6 +104,8 @@ CLICK_LOCKOUT_SECONDS: int = 60  # 1 minute
 _CLICK_ATTEMPTS_PREFIX = "api:ratelimit:click:attempts:"
 _CLICK_LOCKOUT_PREFIX = "api:ratelimit:click:lockout:"
 
+_logger = logging.getLogger(__name__)
+
 # Module-level Redis client (connection pool, lazily initialised)
 _redis_client: redis_lib.Redis | None = None
 
@@ -122,8 +127,14 @@ def _redis() -> redis_lib.Redis:
 
 # ── Generic helpers ──────────────────────────────────────────────────────────
 
+# Returned when Redis is unavailable — fail-open: treat every identifier as
+# having no lockout and unlimited remaining attempts.
+_REDIS_OPEN_INFO = RateLimitInfo(
+    is_locked=False, attempts_remaining=999, lockout_expires_at=None
+)
 
-def _check_limit(
+
+def _check_limit_core(
     identifier: str,
     attempts_prefix: str,
     lockout_prefix: str,
@@ -149,7 +160,31 @@ def _check_limit(
     )
 
 
-def _record_attempt(
+def _check_limit(
+    identifier: str,
+    attempts_prefix: str,
+    lockout_prefix: str,
+    max_attempts: int,
+    window_seconds: int,
+) -> RateLimitInfo:
+    """Circuit-breaker wrapper for _check_limit_core; fails open on Redis errors."""
+    try:
+        return redis_breaker.call(
+            _check_limit_core,
+            identifier,
+            attempts_prefix,
+            lockout_prefix,
+            max_attempts,
+            window_seconds,
+        )
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        _logger.warning(
+            "Redis circuit open — rate-limit check failed open for %s", identifier
+        )
+        return _REDIS_OPEN_INFO
+
+
+def _record_attempt_core(
     identifier: str,
     attempts_prefix: str,
     lockout_prefix: str,
@@ -196,11 +231,47 @@ def _record_attempt(
     )
 
 
-def _clear(identifier: str, attempts_prefix: str, lockout_prefix: str) -> None:
+def _record_attempt(
+    identifier: str,
+    attempts_prefix: str,
+    lockout_prefix: str,
+    max_attempts: int,
+    window_seconds: int,
+    lockout_seconds: int,
+) -> RateLimitInfo:
+    """Circuit-breaker wrapper for _record_attempt_core; fails open on Redis errors."""
+    try:
+        return redis_breaker.call(
+            _record_attempt_core,
+            identifier,
+            attempts_prefix,
+            lockout_prefix,
+            max_attempts,
+            window_seconds,
+            lockout_seconds,
+        )
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        _logger.warning(
+            "Redis circuit open — failed attempt not recorded for %s", identifier
+        )
+        return _REDIS_OPEN_INFO
+
+
+def _clear_core(identifier: str, attempts_prefix: str, lockout_prefix: str) -> None:
     """Clear all rate-limit state for an identifier."""
     r = _redis()
     r.delete(f"{attempts_prefix}{identifier}")
     r.delete(f"{lockout_prefix}{identifier}")
+
+
+def _clear(identifier: str, attempts_prefix: str, lockout_prefix: str) -> None:
+    """Circuit-breaker wrapper for _clear_core; logs and skips on Redis errors."""
+    try:
+        redis_breaker.call(_clear_core, identifier, attempts_prefix, lockout_prefix)
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        _logger.warning(
+            "Redis circuit open — rate-limit state not cleared for %s", identifier
+        )
 
 
 # ── Login rate limiting ──────────────────────────────────────────────────────
@@ -208,7 +279,11 @@ def _clear(identifier: str, attempts_prefix: str, lockout_prefix: str) -> None:
 
 def is_locked(identifier: str) -> bool:
     """Return *True* if the identifier is currently locked out."""
-    return _redis().ttl(f"{_LOCKOUT_PREFIX}{identifier}") > 0
+    try:
+        ttl = redis_breaker.call(_redis().ttl, f"{_LOCKOUT_PREFIX}{identifier}")
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def get_status(identifier: str) -> RateLimitInfo:
@@ -245,7 +320,13 @@ def reset(identifier: str) -> None:
 
 def is_register_locked(identifier: str) -> bool:
     """Return *True* if the identifier is locked for registration."""
-    return _redis().ttl(f"{_REGISTER_LOCKOUT_PREFIX}{identifier}") > 0
+    try:
+        ttl = redis_breaker.call(
+            _redis().ttl, f"{_REGISTER_LOCKOUT_PREFIX}{identifier}"
+        )
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def record_register_attempt(identifier: str) -> RateLimitInfo:
@@ -265,7 +346,13 @@ def record_register_attempt(identifier: str) -> RateLimitInfo:
 
 def is_password_reset_locked(identifier: str) -> bool:
     """Return *True* if the identifier is locked for password resets."""
-    return _redis().ttl(f"{_PASSWORD_RESET_LOCKOUT_PREFIX}{identifier}") > 0
+    try:
+        ttl = redis_breaker.call(
+            _redis().ttl, f"{_PASSWORD_RESET_LOCKOUT_PREFIX}{identifier}"
+        )
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def record_password_reset_attempt(identifier: str) -> RateLimitInfo:
@@ -285,7 +372,13 @@ def record_password_reset_attempt(identifier: str) -> RateLimitInfo:
 
 def is_resend_verification_locked(identifier: str) -> bool:
     """Return *True* if the identifier is locked for resend verification."""
-    return _redis().ttl(f"{_RESEND_VERIFICATION_LOCKOUT_PREFIX}{identifier}") > 0
+    try:
+        ttl = redis_breaker.call(
+            _redis().ttl, f"{_RESEND_VERIFICATION_LOCKOUT_PREFIX}{identifier}"
+        )
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def record_resend_verification_attempt(identifier: str) -> RateLimitInfo:
@@ -320,7 +413,11 @@ def record_click_attempt(identifier: str) -> RateLimitInfo:
 
 def is_ip_blocked(ip: str) -> bool:
     """Return *True* if the IP is currently locked due to too many failed logins."""
-    return _redis().ttl(f"{_IP_FAILED_LOCKOUT_PREFIX}{ip}") > 0
+    try:
+        ttl = redis_breaker.call(_redis().ttl, f"{_IP_FAILED_LOCKOUT_PREFIX}{ip}")
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def record_ip_failed(ip: str) -> RateLimitInfo:
@@ -340,7 +437,11 @@ def record_ip_failed(ip: str) -> RateLimitInfo:
 
 def is_ip_register_locked(ip: str) -> bool:
     """Return *True* if the IP is locked for new account registrations."""
-    return _redis().ttl(f"{_IP_REGISTER_LOCKOUT_PREFIX}{ip}") > 0
+    try:
+        ttl = redis_breaker.call(_redis().ttl, f"{_IP_REGISTER_LOCKOUT_PREFIX}{ip}")
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def record_ip_register(ip: str) -> RateLimitInfo:
@@ -360,7 +461,13 @@ def record_ip_register(ip: str) -> RateLimitInfo:
 
 def is_ip_password_reset_locked(ip: str) -> bool:
     """Return *True* if the IP is locked for password reset requests."""
-    return _redis().ttl(f"{_IP_PASSWORD_RESET_LOCKOUT_PREFIX}{ip}") > 0
+    try:
+        ttl = redis_breaker.call(
+            _redis().ttl, f"{_IP_PASSWORD_RESET_LOCKOUT_PREFIX}{ip}"
+        )
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def record_ip_password_reset(ip: str) -> RateLimitInfo:
@@ -380,7 +487,13 @@ def record_ip_password_reset(ip: str) -> RateLimitInfo:
 
 def is_ip_resend_verification_locked(ip: str) -> bool:
     """Return *True* if the IP is locked for resend-verification requests."""
-    return _redis().ttl(f"{_IP_RESEND_VERIFICATION_LOCKOUT_PREFIX}{ip}") > 0
+    try:
+        ttl = redis_breaker.call(
+            _redis().ttl, f"{_IP_RESEND_VERIFICATION_LOCKOUT_PREFIX}{ip}"
+        )
+        return ttl > 0
+    except (pybreaker.CircuitBreakerError, redis_lib.RedisError):
+        return False
 
 
 def record_ip_resend_verification(ip: str) -> RateLimitInfo:

--- a/backend/app/services/redis_client.py
+++ b/backend/app/services/redis_client.py
@@ -34,7 +34,12 @@ def get_redis() -> redis_lib.Redis:
         return _redis_client
 
     try:
-        client = redis_lib.from_url(settings.REDIS_URL, decode_responses=True)
+        client = redis_lib.from_url(
+            settings.REDIS_URL,
+            decode_responses=True,
+            socket_timeout=0.5,
+            socket_connect_timeout=0.5,
+        )
         # ping() forces the first actual connection attempt so we fail fast at
         # initialisation time rather than on the first Redis operation.
         client.ping()

--- a/backend/tests/api/routes/test_utils.py
+++ b/backend/tests/api/routes/test_utils.py
@@ -100,15 +100,15 @@ def test_redis_health_check_requires_authentication(client: TestClient) -> None:
 def test_circuit_breaker_health_check_returns_all_breakers(
     client: TestClient, superuser_token_headers: dict
 ) -> None:
-    """Circuit breaker health check returns state for all three breakers."""
+    """Circuit breaker health check returns state for all four breakers."""
     response = client.get(
         f"{settings.API_V1_STR}/utils/health-check/circuit-breakers/",
         headers=superuser_token_headers,
     )
     assert response.status_code == 200
     body = response.json()
-    assert set(body.keys()) == {"stripe", "translator", "anthropic"}
-    for name in ("stripe", "translator", "anthropic"):
+    assert set(body.keys()) == {"stripe", "translator", "anthropic", "redis"}
+    for name in ("stripe", "translator", "anthropic", "redis"):
         assert "state" in body[name]
         assert "fail_counter" in body[name]
         assert "fail_max" in body[name]

--- a/backend/tests/core/test_circuit_breakers.py
+++ b/backend/tests/core/test_circuit_breakers.py
@@ -7,6 +7,7 @@ import pybreaker
 from app.core.circuit_breakers import (
     _LoggingListener,
     anthropic_breaker,
+    redis_breaker,
     stripe_breaker,
     translator_breaker,
 )
@@ -46,6 +47,18 @@ class TestCircuitBreakerConfiguration:
         for breaker in (stripe_breaker, translator_breaker, anthropic_breaker):
             assert breaker.current_state == "closed"
 
+    def test_redis_breaker_fail_max(self) -> None:
+        assert redis_breaker.fail_max == 10
+
+    def test_redis_breaker_reset_timeout(self) -> None:
+        assert redis_breaker.reset_timeout == 15
+
+    def test_redis_breaker_name(self) -> None:
+        assert redis_breaker.name == "redis"
+
+    def test_redis_breaker_starts_closed(self) -> None:
+        assert redis_breaker.current_state == "closed"
+
 
 class TestCircuitBreakerSingletons:
     """Singletons must be distinct objects sharing the same listener."""
@@ -54,16 +67,29 @@ class TestCircuitBreakerSingletons:
         assert stripe_breaker is not translator_breaker
         assert translator_breaker is not anthropic_breaker
         assert stripe_breaker is not anthropic_breaker
+        assert redis_breaker is not stripe_breaker
+        assert redis_breaker is not translator_breaker
+        assert redis_breaker is not anthropic_breaker
 
     def test_each_breaker_has_listener(self) -> None:
-        for breaker in (stripe_breaker, translator_breaker, anthropic_breaker):
+        for breaker in (
+            stripe_breaker,
+            translator_breaker,
+            anthropic_breaker,
+            redis_breaker,
+        ):
             assert len(breaker.listeners) == 1
             assert isinstance(breaker.listeners[0], _LoggingListener)
 
     def test_all_breakers_share_same_listener_instance(self) -> None:
         listener_ids = {
             id(b.listeners[0])
-            for b in (stripe_breaker, translator_breaker, anthropic_breaker)
+            for b in (
+                stripe_breaker,
+                translator_breaker,
+                anthropic_breaker,
+                redis_breaker,
+            )
         }
         assert len(listener_ids) == 1, (
             "All breakers should share the same _LoggingListener"

--- a/backend/tests/services/test_auth_service.py
+++ b/backend/tests/services/test_auth_service.py
@@ -2,10 +2,13 @@
 
 import uuid
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import fakeredis
 import jwt
+import pybreaker
 import pytest
+import redis as redis_lib
 
 from app.services.auth_service import (
     ALGORITHM,
@@ -301,3 +304,55 @@ class TestLogout:
         logout(refresh)
         # logout uses blacklist_token (no grace key) so refresh is immediately rejected
         assert refresh_access_token(refresh) is None
+
+
+# ── Redis circuit breaker behavior ────────────────────────────────────────────
+
+
+class TestRedisCircuitBreakerBehavior:
+    """Verify fail-safe / fail-open behavior when the Redis circuit is open."""
+
+    def test_blacklist_token_does_not_raise_when_circuit_open(self) -> None:
+        with patch("app.services.auth_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            # Must not raise — logout should still succeed
+            blacklist_token("test-jti", datetime.now(timezone.utc) + timedelta(hours=1))
+
+    def test_blacklist_token_logs_warning_when_circuit_open(self) -> None:
+        with patch("app.services.auth_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            with patch("app.services.auth_service._logger") as mock_logger:
+                blacklist_token(
+                    "test-jti", datetime.now(timezone.utc) + timedelta(hours=1)
+                )
+            mock_logger.warning.assert_called_once()
+
+    def test_is_token_blacklisted_returns_false_when_circuit_open(self) -> None:
+        with patch("app.services.auth_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            assert is_token_blacklisted("some-jti") is False
+
+    def test_is_token_in_grace_period_returns_false_when_circuit_open(self) -> None:
+        with patch("app.services.auth_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            assert is_token_in_grace_period("some-jti") is False
+
+    def test_blacklist_token_does_not_raise_on_redis_error(self) -> None:
+        with patch("app.services.auth_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = redis_lib.RedisError("connection refused")
+            blacklist_token(
+                "test-jti", datetime.now(timezone.utc) + timedelta(hours=1)
+            )  # must not raise
+
+    def test_rotate_refresh_token_logs_warning_when_grace_setex_fails(self) -> None:
+        from app.services.auth_service import _rotate_refresh_token
+
+        with patch("app.services.auth_service.redis_breaker") as mock_breaker:
+            # First call (blacklist_token) succeeds; second call (grace setex) fails
+            mock_breaker.call.side_effect = [None, pybreaker.CircuitBreakerError()]
+            with patch("app.services.auth_service._logger") as mock_logger:
+                _rotate_refresh_token(
+                    "test-jti", datetime.now(timezone.utc) + timedelta(hours=1)
+                )
+            mock_logger.warning.assert_called_once()
+            assert "grace window" in mock_logger.warning.call_args.args[0]

--- a/backend/tests/services/test_rate_limit_service.py
+++ b/backend/tests/services/test_rate_limit_service.py
@@ -1,11 +1,14 @@
 """Tests for rate limit service module-level functions."""
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import fakeredis
+import pybreaker
 import pytest
 
 from app.services.rate_limit_service import (
+    _REDIS_OPEN_INFO,
     CONTRACT_ANALYSIS_HOURLY_MAX,
     TRANSLATION_HOURLY_MAX,
     UPLOAD_BURST_MAX,
@@ -342,3 +345,49 @@ class TestRetryAfterSeconds:
             is_locked=True, attempts_remaining=0, lockout_expires_at=expires
         )
         assert retry_after_seconds(info) == 1
+
+
+# ── Redis circuit breaker behavior ────────────────────────────────────────────
+
+
+class TestRedisCircuitBreakerBehavior:
+    """Verify fail-open behavior when the Redis circuit breaker is open."""
+
+    def test_is_locked_returns_false_when_circuit_open(self) -> None:
+        with patch("app.services.rate_limit_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            assert is_locked("test@example.com") is False
+
+    def test_is_register_locked_returns_false_when_circuit_open(self) -> None:
+        with patch("app.services.rate_limit_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            assert is_register_locked("test@example.com") is False
+
+    def test_is_password_reset_locked_returns_false_when_circuit_open(self) -> None:
+        with patch("app.services.rate_limit_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            assert is_password_reset_locked("test@example.com") is False
+
+    def test_record_failed_attempt_returns_open_info_when_circuit_open(self) -> None:
+        with patch("app.services.rate_limit_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            info = record_failed_attempt("test@example.com")
+            assert info == _REDIS_OPEN_INFO
+            assert info.is_locked is False
+            assert info.attempts_remaining == 999
+
+    def test_get_status_returns_open_info_when_circuit_open(self) -> None:
+        with patch("app.services.rate_limit_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            info = get_status("test@example.com")
+            assert info == _REDIS_OPEN_INFO
+
+    def test_record_successful_login_does_not_raise_when_circuit_open(self) -> None:
+        with patch("app.services.rate_limit_service.redis_breaker") as mock_breaker:
+            mock_breaker.call.side_effect = pybreaker.CircuitBreakerError()
+            record_successful_login("test@example.com")  # must not raise
+
+    def test_redis_open_info_sentinel_values(self) -> None:
+        assert _REDIS_OPEN_INFO.is_locked is False
+        assert _REDIS_OPEN_INFO.attempts_remaining == 999
+        assert _REDIS_OPEN_INFO.lockout_expires_at is None


### PR DESCRIPTION
## Summary

- Adds `redis_breaker` (fail_max=10, reset_timeout=15 s) to `circuit_breakers.py` with the shared `_LoggingListener`
- Wraps all Redis operations in `auth_service.py` and `rate_limit_service.py` with the circuit breaker
- Fail-open strategy: rate-limit checks allow requests when Redis is down; token blacklist validation accepts tokens
- Fail-safe strategy: `blacklist_token` (logout) logs a warning and continues without crashing
- Adds `socket_timeout=0.5` to Redis client for fast-fail on stale connections
- Exposes `redis` breaker state in `/health-check/circuit-breakers/`

## Test plan

- [ ] 13 new circuit-breaker tests pass (5 auth, 7 rate-limit, 4 config/singleton)
- [ ] All 1721 existing tests continue to pass
- [ ] `pre-commit run --all-files` clean (ruff, biome, migration check)
- [ ] `/health-check/circuit-breakers/` response includes `"redis"` key