### PR TITLE
feat(api): add json body size limit middleware

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,54 @@ from app.services.scheduler_service import record_job_run
 logger = logging.getLogger(__name__)
 
 
+class _JsonBodySizeLimitMiddleware:
+    """Rejects non-multipart requests whose body exceeds MAX_JSON_BODY_SIZE_BYTES.
+
+    Inspects the Content-Length header before any body bytes are read, preventing
+    memory pressure from oversized JSON payloads. Multipart requests (file uploads)
+    are exempt because those endpoints enforce their own limit via MAX_FILE_SIZE_MB.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            headers = dict(scope["headers"])
+            content_type = headers.get(b"content-type", b"").decode("latin1")
+            content_length_raw = headers.get(b"content-length")
+
+            if (
+                "multipart/form-data" not in content_type
+                and content_length_raw is not None
+            ):
+                try:
+                    content_length = int(content_length_raw.decode("latin1"))
+                except (ValueError, TypeError):
+                    content_length = 0
+
+                if content_length > settings.MAX_JSON_BODY_SIZE_BYTES:
+                    client_addr = scope.get("client") or ("unknown", 0)
+                    client_ip = client_addr[0]
+                    logger.warning(
+                        "Request body too large: %d bytes from %s (max %d) "
+                        "method=%s path=%s",
+                        content_length,
+                        client_ip,
+                        settings.MAX_JSON_BODY_SIZE_BYTES,
+                        scope.get("method", ""),
+                        scope.get("path", ""),
+                    )
+                    response = JSONResponse(
+                        status_code=413,
+                        content={"detail": "Request body too large."},
+                    )
+                    await response(scope, receive, send)
+                    return
+
+        await self.app(scope, receive, send)
+
+
 class _ContainerAppsProxyMiddleware:
     """Proxy header middleware for Azure Container Apps.
 
@@ -152,6 +200,9 @@ if settings.all_cors_origins:
 # Extract real client IP from X-Forwarded-For set by Azure Container Apps ingress.
 if settings.ENVIRONMENT != "local":
     app.add_middleware(_ContainerAppsProxyMiddleware)
+
+# Reject oversized JSON bodies before any body bytes are read.
+app.add_middleware(_JsonBodySizeLimitMiddleware)
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
 

--- a/backend/tests/api/test_json_body_size_limit.py
+++ b/backend/tests/api/test_json_body_size_limit.py
@@ -1,0 +1,101 @@
+"""Tests for the JSON request body size limit middleware."""
+
+import logging
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+
+_ORIGINAL_MAX_BYTES = settings.MAX_JSON_BODY_SIZE_BYTES
+_TEST_LIMIT = 100  # bytes — small value to avoid sending 1 MB in tests
+
+
+@pytest.fixture
+def small_limit(client: TestClient) -> Generator[TestClient, None, None]:
+    """Temporarily reduce MAX_JSON_BODY_SIZE_BYTES to 100 bytes.
+
+    Uses object.__setattr__ to bypass Pydantic's validation on assignment so
+    the test limit is enforced at call-time by the middleware without having to
+    transmit a full 1 MB body.
+    """
+    object.__setattr__(settings, "MAX_JSON_BODY_SIZE_BYTES", _TEST_LIMIT)
+    yield client
+    object.__setattr__(settings, "MAX_JSON_BODY_SIZE_BYTES", _ORIGINAL_MAX_BYTES)
+
+
+# ── Oversized body ─────────────────────────────────────────────────────────────
+
+
+def test_oversized_json_body_returns_413(small_limit: TestClient) -> None:
+    """Requests with Content-Length > MAX_JSON_BODY_SIZE_BYTES return HTTP 413."""
+    body = b"x" * (_TEST_LIMIT + 1)
+    response = small_limit.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 413
+
+
+def test_oversized_body_logs_warning(
+    small_limit: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Oversized requests are logged at WARNING level with size and path info."""
+    body = b"x" * (_TEST_LIMIT + 1)
+    with caplog.at_level(logging.WARNING, logger="app.main"):
+        small_limit.post(
+            f"{settings.API_V1_STR}/login/access-token",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+    assert any("body too large" in record.message for record in caplog.records)
+
+
+def test_oversized_body_response_has_detail(small_limit: TestClient) -> None:
+    """413 response body contains a 'detail' field."""
+    body = b"x" * (_TEST_LIMIT + 1)
+    response = small_limit.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    body_json = response.json()
+    assert "detail" in body_json
+    assert isinstance(body_json["detail"], str)
+
+
+# ── Body at or under the limit ────────────────────────────────────────────────
+
+
+def test_body_exactly_at_limit_is_not_blocked(small_limit: TestClient) -> None:
+    """Requests with Content-Length exactly equal to the limit are not rejected."""
+    # Strictly greater-than check — at-limit should pass (result: 422 not 413)
+    body = b"x" * _TEST_LIMIT
+    response = small_limit.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code != 413
+
+
+def test_normal_request_is_not_blocked(client: TestClient) -> None:
+    """Normal requests well under the limit pass through without issue."""
+    response = client.get(f"{settings.API_V1_STR}/utils/health-check/")
+    assert response.status_code == 200
+
+
+# ── Multipart exemption ────────────────────────────────────────────────────────
+
+
+def test_multipart_request_exempt_from_body_size_limit(small_limit: TestClient) -> None:
+    """Multipart requests are exempt even when body exceeds the JSON limit."""
+    # 200 bytes of multipart content exceeds the 100-byte test limit, but the
+    # middleware exempts multipart/form-data — the response should not be 413.
+    response = small_limit.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        files={"file": ("test.txt", b"x" * (_TEST_LIMIT * 2), "text/plain")},
+    )
+    assert response.status_code != 413


### PR DESCRIPTION
## Summary

- Adds `_JsonBodySizeLimitMiddleware` to `main.py` that inspects the `Content-Length` header before any body bytes are read — prevents memory pressure from oversized JSON payloads
- Requests with `Content-Length > MAX_JSON_BODY_SIZE_BYTES` (default 1 MB, already in `config.py`) are rejected immediately with HTTP 413 and a WARNING log line including client IP, byte count, and endpoint path
- Multipart requests (`Content-Type: multipart/form-data`) are exempt — file upload endpoints enforce their own `MAX_FILE_SIZE_MB` limit
- Middleware is outermost in the stack (runs before CORS, routing, and handler logic)

## Test plan

- [ ] `test_oversized_json_body_returns_413` — body over test limit returns 413
- [ ] `test_oversized_body_response_has_detail` — 413 body contains `{"detail": "..."}`
- [ ] `test_body_exactly_at_limit_is_not_blocked` — body at exactly the limit passes (strictly greater-than check)
- [ ] `test_normal_request_is_not_blocked` — normal small request returns 200 unaffected
- [ ] `test_multipart_request_exempt_from_body_size_limit` — multipart body over limit is not blocked by this middleware