### PR TITLE
feat(frontend): improve tanstack query retry and staletime defaults

### DIFF
--- a/frontend/src/hooks/queries/useArticleQueries.ts
+++ b/frontend/src/hooks/queries/useArticleQueries.ts
@@ -49,6 +49,7 @@ export function useArticleCategories() {
   return useQuery({
     queryKey: queryKeys.articles.categories(),
     queryFn: () => ArticleService.getCategories(),
-    staleTime: Infinity, // categories are seeded static data and never change at runtime
+    staleTime: Infinity, // seeded static data — never changes at runtime
+    gcTime: Infinity, // keep in cache for the lifetime of the session
   })
 }

--- a/frontend/src/hooks/queries/useArticleQueries.ts
+++ b/frontend/src/hooks/queries/useArticleQueries.ts
@@ -49,6 +49,6 @@ export function useArticleCategories() {
   return useQuery({
     queryKey: queryKeys.articles.categories(),
     queryFn: () => ArticleService.getCategories(),
-    staleTime: 30 * 60 * 1000,
+    staleTime: Infinity, // categories are seeded static data and never change at runtime
   })
 }

--- a/frontend/src/hooks/queries/useCalculatorQueries.ts
+++ b/frontend/src/hooks/queries/useCalculatorQueries.ts
@@ -15,7 +15,7 @@ export function useStateRates() {
   return useQuery({
     queryKey: queryKeys.calculators.stateRates(),
     queryFn: () => CalculatorService.getStateRates(),
-    staleTime: 30 * 60 * 1000, // Rates rarely change
+    staleTime: 30 * 60 * 1000, // rates change when German states update Grunderwerbsteuer; finite staleTime ensures eventual refresh
   })
 }
 

--- a/frontend/src/hooks/queries/useGlossaryQueries.ts
+++ b/frontend/src/hooks/queries/useGlossaryQueries.ts
@@ -49,6 +49,6 @@ export function useGlossaryCategories() {
   return useQuery({
     queryKey: queryKeys.glossary.categories(),
     queryFn: () => GlossaryService.getCategories(),
-    staleTime: 30 * 60 * 1000,
+    staleTime: Infinity, // categories are seeded static data and never change at runtime
   })
 }

--- a/frontend/src/hooks/queries/useGlossaryQueries.ts
+++ b/frontend/src/hooks/queries/useGlossaryQueries.ts
@@ -49,6 +49,7 @@ export function useGlossaryCategories() {
   return useQuery({
     queryKey: queryKeys.glossary.categories(),
     queryFn: () => GlossaryService.getCategories(),
-    staleTime: Infinity, // categories are seeded static data and never change at runtime
+    staleTime: Infinity, // seeded static data — never changes at runtime
+    gcTime: Infinity, // keep in cache for the lifetime of the session
   })
 }

--- a/frontend/src/hooks/queries/useLegalQueries.ts
+++ b/frontend/src/hooks/queries/useLegalQueries.ts
@@ -49,7 +49,7 @@ export function useLawCategories() {
   return useQuery({
     queryKey: queryKeys.laws.categories(),
     queryFn: () => LegalService.getCategories(),
-    staleTime: 30 * 60 * 1000, // Categories rarely change
+    staleTime: Infinity, // categories are seeded static data and never change at runtime
   })
 }
 

--- a/frontend/src/hooks/queries/useLegalQueries.ts
+++ b/frontend/src/hooks/queries/useLegalQueries.ts
@@ -49,7 +49,8 @@ export function useLawCategories() {
   return useQuery({
     queryKey: queryKeys.laws.categories(),
     queryFn: () => LegalService.getCategories(),
-    staleTime: Infinity, // categories are seeded static data and never change at runtime
+    staleTime: Infinity, // seeded static data — never changes at runtime
+    gcTime: Infinity, // keep in cache for the lifetime of the session
   })
 }
 

--- a/frontend/src/hooks/queries/useMarketQueries.ts
+++ b/frontend/src/hooks/queries/useMarketQueries.ts
@@ -7,7 +7,7 @@ import { useQuery } from "@tanstack/react-query"
 import { queryKeys } from "@/query/queryKeys"
 import { CalculatorService } from "@/services/CalculatorService"
 
-/** Fetch all available areas for comparison. Static data — long stale time. */
+/** Fetch all available areas for comparison. Long stale time — new areas are added infrequently but not seeded. */
 export function useAreas() {
   return useQuery({
     queryKey: queryKeys.market.areas(),

--- a/frontend/src/hooks/queries/useNotificationQueries.ts
+++ b/frontend/src/hooks/queries/useNotificationQueries.ts
@@ -8,6 +8,7 @@ export function useNotifications(limit = 20, offset = 0, unreadOnly = false) {
     queryKey: queryKeys.notifications.list(limit, offset, unreadOnly),
     queryFn: () =>
       NotificationService.getNotifications(limit, offset, unreadOnly),
+    staleTime: 30 * 1000, // notifications are polled every 30s; don't consider cached data stale sooner
     refetchInterval: 30000,
     retry: false,
     throwOnError: false,

--- a/frontend/src/hooks/queries/useNotificationQueries.ts
+++ b/frontend/src/hooks/queries/useNotificationQueries.ts
@@ -8,7 +8,7 @@ export function useNotifications(limit = 20, offset = 0, unreadOnly = false) {
     queryKey: queryKeys.notifications.list(limit, offset, unreadOnly),
     queryFn: () =>
       NotificationService.getNotifications(limit, offset, unreadOnly),
-    staleTime: 30 * 1000, // notifications are polled every 30s; don't consider cached data stale sooner
+    staleTime: 30 * 1000, // matches refetchInterval — prevents spurious background refetch on window focus between polling ticks
     refetchInterval: 30000,
     retry: false,
     throwOnError: false,

--- a/frontend/src/query/client.ts
+++ b/frontend/src/query/client.ts
@@ -22,7 +22,8 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 5 * 60 * 1000, // 5 minutes
       gcTime: 10 * 60 * 1000, // 10 minutes (formerly cacheTime)
-      retry: 1,
+      retry: 2,
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
       refetchOnWindowFocus: true,
     },
   },

--- a/frontend/src/query/client.ts
+++ b/frontend/src/query/client.ts
@@ -1,6 +1,9 @@
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query"
 import { ApiError } from "@/client"
 
+/** Maximum delay between retry attempts (ms). */
+const MAX_RETRY_DELAY_MS = 30_000
+
 /**
  * Handle API errors globally
  */
@@ -22,8 +25,18 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 5 * 60 * 1000, // 5 minutes
       gcTime: 10 * 60 * 1000, // 10 minutes (formerly cacheTime)
-      retry: 2,
-      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+      // Never retry client errors (4xx) — they won't succeed on retry.
+      retry: (failureCount, error) => {
+        if (
+          error instanceof ApiError &&
+          error.status >= 400 &&
+          error.status < 500
+        )
+          return false
+        return failureCount < 2
+      },
+      retryDelay: (attemptIndex) =>
+        Math.min(1000 * 2 ** attemptIndex, MAX_RETRY_DELAY_MS),
       refetchOnWindowFocus: true,
     },
   },


### PR DESCRIPTION
## Summary

- Increase global query retry count from 1 to 2 and add exponential backoff delay (1s → 2s → cap at 30s) to handle transient network failures
- Set `staleTime: Infinity` on seeded static category data (glossary, article, law categories) — these are server-seeded and never mutate at runtime, so treating them as always fresh eliminates background refetches on every navigation
- Align `useNotifications` `staleTime` (30 s) with its `refetchInterval` (30 s) to prevent unnecessary cache-invalidation between polls

## Test plan

- [ ] Verify navigation between routes does not trigger background refetches for category queries within the same session
- [ ] Confirm notification list still refreshes every 30 s and does not over-refetch
- [ ] Confirm TypeScript compiles clean (`bunx tsc --noEmit`)
- [ ] All Playwright E2E tests pass