### PR TITLE
feat(frontend): add cross-tab auth sync and periodic session validation

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -11,6 +11,7 @@ import {
 } from "@/client"
 import { queryClient } from "@/query/client"
 import { handleError } from "@/utils"
+import { broadcastLogout } from "./useAuthSync"
 import useCustomToast from "./useCustomToast"
 
 /**
@@ -70,6 +71,7 @@ const useAuth = (redirectTo?: string) => {
     } catch {
       // Ignore errors — proceed with client-side cleanup regardless
     }
+    broadcastLogout() // notify other open tabs to log out simultaneously
     queryClient.clear()
     localStorage.removeItem("heimpath-wizard-state")
     localStorage.removeItem("heimpath-wizard-step")

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -71,7 +71,6 @@ const useAuth = (redirectTo?: string) => {
     } catch {
       // Ignore errors — proceed with client-side cleanup regardless
     }
-    broadcastLogout() // notify other open tabs to log out simultaneously
     queryClient.clear()
     localStorage.removeItem("heimpath-wizard-state")
     localStorage.removeItem("heimpath-wizard-step")
@@ -81,6 +80,8 @@ const useAuth = (redirectTo?: string) => {
         localStorage.removeItem(key)
       }
     }
+    // Notify other open tabs only after local cleanup is complete.
+    broadcastLogout()
     navigate({ to: "/login" })
   }
 

--- a/frontend/src/hooks/useAuthSync.ts
+++ b/frontend/src/hooks/useAuthSync.ts
@@ -13,17 +13,21 @@ const SESSION_POLL_INTERVAL_MS = 5 * 60 * 1000
 
 /**
  * Broadcast a logout event to all other tabs that have HeimPath open.
- * Called from logout() so other tabs log out simultaneously without
- * waiting for their next API call to fail with 401.
+ * Called from logout() after local cleanup is complete, so other tabs
+ * log out simultaneously without waiting for their next API call to fail.
+ *
+ * postMessage() enqueues delivery synchronously before close() executes,
+ * so closing the channel immediately after posting is safe per spec.
  */
 export function broadcastLogout(): void {
   try {
     const channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
     channel.postMessage({ type: "logout" })
     channel.close()
-  } catch {
-    // BroadcastChannel is unavailable in some environments (e.g. certain
-    // browser extensions or sandboxed contexts). Logout still works locally.
+  } catch (error) {
+    if (!(error instanceof DOMException)) throw error
+    // DOMException means BroadcastChannel is unavailable in this environment.
+    // Logout still works locally; cross-tab sync is silently disabled.
   }
 }
 
@@ -36,11 +40,16 @@ export function broadcastLogout(): void {
  *    "logout" message is broadcast so other tabs redirect to /login
  *    immediately without waiting for an API call to fail.
  *
+ *    Trust model: BroadcastChannel is same-origin only by spec, so the
+ *    signal cannot come from a different origin. A malicious same-origin
+ *    script could still post a fake logout message (low-severity DoS), but
+ *    cannot use this channel to gain auth access.
+ *
  * 2. Periodic session poll — every 5 minutes the currentUser query is
  *    forcibly refetched against the server. If the session has been
  *    invalidated server-side (token rotation, forced logout, account
- *    suspension), the resulting 401 is caught by queryCache.onError
- *    in query/client.ts, which clears the cache and redirects to /login.
+ *    suspension), the resulting 401 is caught by queryCache.onError in
+ *    query/client.ts, which clears the cache and redirects to /login.
  *
  * Note: the `logged_in` cookie read by isLoggedIn() is a plain (non-HttpOnly)
  * boolean indicator. The actual access token remains HttpOnly and is never
@@ -52,26 +61,39 @@ export function useAuthSync(): void {
   useEffect(() => {
     // 1. Cross-tab logout via BroadcastChannel
     let channel: BroadcastChannel | null = null
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === "logout") {
+        queryClient.clear()
+        window.location.href = "/login"
+      }
+    }
+
     try {
       channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
-      channel.addEventListener("message", (event: MessageEvent) => {
-        if (event.data?.type === "logout") {
-          queryClient.clear()
-          window.location.href = "/login"
-        }
-      })
-    } catch {
+      channel.addEventListener("message", handleMessage)
+    } catch (error) {
+      if (!(error instanceof DOMException)) throw error
       // BroadcastChannel unavailable — cross-tab sync disabled gracefully
     }
 
-    // 2. Periodic session validation
-    const timerId = window.setInterval(() => {
-      void queryClient.refetchQueries({ queryKey: ["currentUser"] })
+    // 2. Periodic session validation — type: "all" ensures inactive queries
+    // (no current subscriber) are also refetched, covering edge cases where
+    // the layout is mounted but no component has the query active.
+    const timerId = setInterval(() => {
+      void queryClient
+        .refetchQueries({ queryKey: ["currentUser"], type: "all" })
+        .catch(() => {
+          // orchestration errors (e.g. network offline) are suppressed here;
+          // query-level 401s are handled by queryCache.onError in client.ts
+        })
     }, SESSION_POLL_INTERVAL_MS)
 
     return () => {
-      channel?.close()
-      window.clearInterval(timerId)
+      if (channel) {
+        channel.removeEventListener("message", handleMessage)
+        channel.close()
+      }
+      clearInterval(timerId)
     }
   }, [])
 }

--- a/frontend/src/hooks/useAuthSync.ts
+++ b/frontend/src/hooks/useAuthSync.ts
@@ -1,0 +1,77 @@
+import { useEffect } from "react"
+
+import { queryClient } from "@/query/client"
+
+const AUTH_CHANNEL_NAME = "heimpath-auth"
+
+/**
+ * How often to silently re-validate the session against the server.
+ * A 401 from /users/me is caught by queryCache.onError in client.ts,
+ * which clears the cache and redirects to /login.
+ */
+const SESSION_POLL_INTERVAL_MS = 5 * 60 * 1000
+
+/**
+ * Broadcast a logout event to all other tabs that have HeimPath open.
+ * Called from logout() so other tabs log out simultaneously without
+ * waiting for their next API call to fail with 401.
+ */
+export function broadcastLogout(): void {
+  try {
+    const channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
+    channel.postMessage({ type: "logout" })
+    channel.close()
+  } catch {
+    // BroadcastChannel is unavailable in some environments (e.g. certain
+    // browser extensions or sandboxed contexts). Logout still works locally.
+  }
+}
+
+/**
+ * Installs cross-tab auth synchronisation for the lifetime of the layout.
+ *
+ * Two mechanisms keep auth state in sync:
+ *
+ * 1. BroadcastChannel — when the user explicitly logs out in one tab, a
+ *    "logout" message is broadcast so other tabs redirect to /login
+ *    immediately without waiting for an API call to fail.
+ *
+ * 2. Periodic session poll — every 5 minutes the currentUser query is
+ *    forcibly refetched against the server. If the session has been
+ *    invalidated server-side (token rotation, forced logout, account
+ *    suspension), the resulting 401 is caught by queryCache.onError
+ *    in query/client.ts, which clears the cache and redirects to /login.
+ *
+ * Note: the `logged_in` cookie read by isLoggedIn() is a plain (non-HttpOnly)
+ * boolean indicator. The actual access token remains HttpOnly and is never
+ * accessible from JavaScript. This means isLoggedIn() can go stale — these
+ * two mechanisms ensure the JS auth state eventually converges with the
+ * server's view.
+ */
+export function useAuthSync(): void {
+  useEffect(() => {
+    // 1. Cross-tab logout via BroadcastChannel
+    let channel: BroadcastChannel | null = null
+    try {
+      channel = new BroadcastChannel(AUTH_CHANNEL_NAME)
+      channel.addEventListener("message", (event: MessageEvent) => {
+        if (event.data?.type === "logout") {
+          queryClient.clear()
+          window.location.href = "/login"
+        }
+      })
+    } catch {
+      // BroadcastChannel unavailable — cross-tab sync disabled gracefully
+    }
+
+    // 2. Periodic session validation
+    const timerId = window.setInterval(() => {
+      void queryClient.refetchQueries({ queryKey: ["currentUser"] })
+    }, SESSION_POLL_INTERVAL_MS)
+
+    return () => {
+      channel?.close()
+      window.clearInterval(timerId)
+    }
+  }, [])
+}

--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/tooltip"
 import { useDashboardOverview } from "@/hooks/queries/useDashboardQueries"
 import { isLoggedIn } from "@/hooks/useAuth"
+import { useAuthSync } from "@/hooks/useAuthSync"
 import useCustomToast from "@/hooks/useCustomToast"
 import type { ActivityItem, ActivityType } from "@/models/dashboard"
 import { handleError } from "@/utils"
@@ -293,6 +294,7 @@ function UnverifiedEmailBanner(
 
 /** Default component. App shell with sidebar, header, and content area. */
 function Layout() {
+  useAuthSync()
   const { isUnverified, resendMutation } = useEmailVerification()
   const [dismissed, setDismissed] = useState(isBannerDismissed)
 


### PR DESCRIPTION
## Summary

- Adds `useAuthSync` hook with a `BroadcastChannel` listener — when the user logs out in one tab, all other open HeimPath tabs immediately redirect to `/login` without waiting for their next API call to return 401
- Broadcasts a logout event from `logout()` in `useAuth.ts`
- Mounts `useAuthSync()` in the root `Layout` component so the listener and polling timer run for the full duration of any authenticated session
- Polls `GET /users/me` every 5 minutes to detect server-side session expiry (forced logout, token rotation, account suspension); a 401 response is caught by the existing `queryCache.onError` handler in `client.ts` which clears the cache and redirects

## Test plan

- [ ] Log in with two browser tabs open — log out in tab A — verify tab B redirects to `/login` immediately
- [ ] Simulate session expiry (delete auth cookies in devtools) — within 5 minutes the tab should redirect to `/login` on the next poll cycle
- [ ] Confirm single-tab logout still works normally
- [ ] Confirm TypeScript compiles clean (`bunx tsc --noEmit`)
- [ ] All Playwright E2E tests pass