### PR TITLE
feat(api): sanitize Pydantic 422 errors to hide internal field names

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -270,7 +270,10 @@ def _sanitize_validation_errors(
         loc: tuple = err.get("loc", ())
         # Strip the transport-layer prefix ("body", "query", "path") and take
         # the last meaningful segment as the user-facing field identifier.
-        field_parts = [str(p) for p in loc if p not in ("body", "query", "path")]
+        # The first element is the transport-layer source ("body", "query", "path").
+        # Slice it off unconditionally so field names that happen to equal those
+        # strings are preserved correctly.
+        field_parts = [str(p) for p in loc[1:]]
         raw_field = field_parts[-1] if field_parts else "field"
 
         if raw_field in _INTERNAL_FIELD_MAP:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 import sentry_sdk
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI, Request
-from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import HTTPException, RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
@@ -247,12 +246,59 @@ async def http_exception_handler(_request: Request, exc: HTTPException) -> JSONR
     )
 
 
+# Mapping from internal DB/model field names to safe public equivalents.
+# None means the field is server-managed and should be omitted entirely.
+_INTERNAL_FIELD_MAP: dict[str, str | None] = {
+    "hashed_password": "password",
+    "stripe_customer_id": None,
+    "stripe_subscription_id": None,
+    "email_verified": None,
+}
+
+
+def _sanitize_validation_errors(
+    errors: list[dict],
+) -> list[dict[str, str]]:
+    """Strip internal field paths from Pydantic validation errors.
+
+    Converts raw Pydantic error dicts to a safe public format that removes
+    loc path details exposing schema structure, input values that may contain
+    PII, and maps/omits known internal field names.
+    """
+    sanitized = []
+    for err in errors:
+        loc: tuple = err.get("loc", ())
+        # Strip the transport-layer prefix ("body", "query", "path") and take
+        # the last meaningful segment as the user-facing field identifier.
+        field_parts = [str(p) for p in loc if p not in ("body", "query", "path")]
+        raw_field = field_parts[-1] if field_parts else "field"
+
+        if raw_field in _INTERNAL_FIELD_MAP:
+            mapped = _INTERNAL_FIELD_MAP[raw_field]
+            if mapped is None:
+                # Omit server-managed fields — they should never appear in
+                # client requests and exposing their names leaks schema details.
+                continue
+            field_name = mapped
+        else:
+            field_name = raw_field
+
+        sanitized.append(
+            {"field": field_name, "message": err.get("msg", "Invalid value")}
+        )
+    return sanitized
+
+
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(
     _request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    """Consistent JSON format for request validation errors (422)."""
+    """Consistent, sanitized JSON format for request validation errors (422).
+
+    Strips internal field paths, input values, and server-managed field names
+    to avoid leaking database schema details to API clients.
+    """
     return JSONResponse(
         status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
+        content={"detail": _sanitize_validation_errors(exc.errors())},
     )

--- a/backend/tests/api/test_exception_handlers.py
+++ b/backend/tests/api/test_exception_handlers.py
@@ -149,3 +149,80 @@ def test_validation_error_body_has_detail_list(client: TestClient) -> None:
     assert "detail" in body
     assert isinstance(body["detail"], list)
     assert len(body["detail"]) > 0
+
+
+def test_validation_error_items_have_field_and_message_keys(client: TestClient) -> None:
+    """Each error item in the 422 detail list has 'field' and 'message' keys."""
+    response = client.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        data={},
+    )
+    errors = response.json()["detail"]
+    for err in errors:
+        assert "field" in err, f"'field' key missing from error: {err}"
+        assert "message" in err, f"'message' key missing from error: {err}"
+
+
+def test_validation_error_items_do_not_expose_internal_pydantic_fields(
+    client: TestClient,
+) -> None:
+    """Internal Pydantic fields (loc, input, url, type) are stripped from 422 responses."""
+    response = client.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        data={},
+    )
+    errors = response.json()["detail"]
+    for err in errors:
+        assert "loc" not in err
+        assert "input" not in err
+        assert "url" not in err
+        assert "type" not in err
+
+
+def test_validation_error_sanitizes_hashed_password_field() -> None:
+    """hashed_password is remapped to 'password' to hide the internal field name."""
+    from app.main import _sanitize_validation_errors
+
+    raw = [
+        {"loc": ("body", "hashed_password"), "msg": "Field required", "type": "missing"}
+    ]
+    result = _sanitize_validation_errors(raw)
+    assert result == [{"field": "password", "message": "Field required"}]
+
+
+def test_validation_error_omits_stripe_internal_fields() -> None:
+    """stripe_customer_id and stripe_subscription_id are omitted from error output."""
+    from app.main import _sanitize_validation_errors
+
+    raw = [
+        {
+            "loc": ("body", "stripe_customer_id"),
+            "msg": "Field required",
+            "type": "missing",
+        },
+        {
+            "loc": ("body", "stripe_subscription_id"),
+            "msg": "Field required",
+            "type": "missing",
+        },
+        {
+            "loc": ("body", "email"),
+            "msg": "value is not a valid email address",
+            "type": "value_error",
+        },
+    ]
+    result = _sanitize_validation_errors(raw)
+    assert len(result) == 1
+    assert result[0]["field"] == "email"
+    assert result[0]["message"] == "value is not a valid email address"
+
+
+def test_validation_error_multiple_errors_all_returned(client: TestClient) -> None:
+    """All validation errors are returned, not just the first."""
+    # Login endpoint requires both username and password — both missing triggers two errors.
+    response = client.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        data={},
+    )
+    errors = response.json()["detail"]
+    assert len(errors) >= 2

--- a/backend/tests/api/test_exception_handlers.py
+++ b/backend/tests/api/test_exception_handlers.py
@@ -11,7 +11,7 @@ from sqlmodel import Session
 
 from app.api.deps import get_db
 from app.core.config import settings
-from app.main import app
+from app.main import _sanitize_validation_errors, app
 
 
 @pytest.fixture
@@ -181,8 +181,6 @@ def test_validation_error_items_do_not_expose_internal_pydantic_fields(
 
 def test_validation_error_sanitizes_hashed_password_field() -> None:
     """hashed_password is remapped to 'password' to hide the internal field name."""
-    from app.main import _sanitize_validation_errors
-
     raw = [
         {"loc": ("body", "hashed_password"), "msg": "Field required", "type": "missing"}
     ]
@@ -192,8 +190,6 @@ def test_validation_error_sanitizes_hashed_password_field() -> None:
 
 def test_validation_error_omits_stripe_internal_fields() -> None:
     """stripe_customer_id and stripe_subscription_id are omitted from error output."""
-    from app.main import _sanitize_validation_errors
-
     raw = [
         {
             "loc": ("body", "stripe_customer_id"),

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -12,7 +12,7 @@ function extractErrorMessage(err: Error): string {
   if (err instanceof ApiError) {
     const errDetail = (err.body as Record<string, unknown>)?.detail
     if (Array.isArray(errDetail) && errDetail.length > 0) {
-      return errDetail[0]?.msg ?? "Validation failed"
+      return errDetail[0]?.message ?? "Validation failed"
     }
     if (typeof errDetail === "string" && errDetail) {
       return errDetail


### PR DESCRIPTION
## Summary
- Strip `loc`, `input`, `url`, and `type` from Pydantic validation error responses so internal schema paths are never sent to clients
- Add `_INTERNAL_FIELD_MAP` to remap `hashed_password` → `password` and omit server-managed fields (`stripe_customer_id`, `stripe_subscription_id`, `email_verified`)
- Update `extractErrorMessage` in frontend `utils.ts` to read the new `message` key instead of `msg`
- Remove unused `jsonable_encoder` import

## Test plan
- [ ] `pytest tests/api/test_exception_handlers.py -v` — all 14 tests pass including 5 new sanitization tests
- [ ] `pytest --tb=short` — 1742 tests, 0 failures
- [ ] `bunx tsc --noEmit` — TypeScript check passes
- [ ] `pre-commit run --all-files` — all hooks clean