### PR TITLE
feat(reliability): fix WEB_CONCURRENCY default and add startup logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,9 @@ AZURE_TRANSLATOR_REGION=
 AZURE_TRANSLATOR_ENDPOINT=
 AZURE_DOCUMENT_TRANSLATOR_ENDPOINT=
 
+# Worker concurrency (local=1 to avoid port conflicts, staging/production=2)
+WEB_CONCURRENCY=1
+
 # Reliability settings (optional — defaults shown)
 TRANSLATION_CONFIDENCE_THRESHOLD=0.70
 AZURE_TRANSLATOR_TIMEOUT_SECONDS=60

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,4 +42,4 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 WORKDIR /app/backend/
 
-CMD ["sh", "-c", "fastapi run --workers ${WEB_CONCURRENCY:-1} app/main.py"]
+CMD ["sh", "-c", "fastapi run --workers ${WEB_CONCURRENCY:-2} app/main.py"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -155,6 +156,10 @@ async def _run_stuck_document_cleanup() -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     logger.info("SECRET_KEY loaded, length=%d", len(settings.SECRET_KEY))
+    logger.info(
+        "Starting with WEB_CONCURRENCY=%s workers",
+        os.environ.get("WEB_CONCURRENCY", "2"),
+    )
     _stats = get_pool_stats()
     logger.info(
         "DB pool ready: size=%d, max_overflow=%d, effective_max=%d per worker",

--- a/backend/tests/reliability/test_failure_modes.py
+++ b/backend/tests/reliability/test_failure_modes.py
@@ -5,6 +5,8 @@ database unavailability, AI service timeouts, invalid API responses,
 circuit breaker activation, and Redis outages.
 """
 
+import logging
+import os
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -462,3 +464,63 @@ class TestMiddlewareFailureModes:
         """GET requests with no body are never blocked by the size limiter."""
         response = middleware_client.get("/ping")  # type: ignore[attr-defined]
         assert response.status_code == 200
+
+
+# ── Startup configuration ─────────────────────────────────────────────────────
+
+_FAKE_POOL_STATS = {
+    "pool_size": 3,
+    "max_overflow": 5,
+    "effective_max_per_worker": 8,
+    "checked_out": 0,
+    "checked_in": 3,
+    "overflow": 0,
+}
+
+
+class TestStartupConfiguration:
+    """Startup logs must surface critical process configuration on every boot."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_logs_default_web_concurrency(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When WEB_CONCURRENCY is not set, startup logs the safe default of 2."""
+        from app.main import app as fastapi_app
+        from app.main import lifespan
+
+        env_without_concurrency = {
+            k: v for k, v in os.environ.items() if k != "WEB_CONCURRENCY"
+        }
+
+        with (
+            patch.dict(os.environ, env_without_concurrency, clear=True),
+            patch("app.main.get_pool_stats", return_value=_FAKE_POOL_STATS),
+            patch("app.main.AsyncIOScheduler") as mock_sched_cls,
+        ):
+            mock_sched_cls.return_value = MagicMock()
+            with caplog.at_level(logging.INFO, logger="app.main"):
+                async with lifespan(fastapi_app):
+                    pass
+
+        assert any("WEB_CONCURRENCY=2" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_lifespan_logs_configured_web_concurrency(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When WEB_CONCURRENCY is set, startup logs the configured value."""
+        from app.main import app as fastapi_app
+        from app.main import lifespan
+
+        with (
+            patch.dict(os.environ, {"WEB_CONCURRENCY": "4"}),
+            patch("app.main.get_pool_stats", return_value=_FAKE_POOL_STATS),
+            patch("app.main.AsyncIOScheduler") as mock_sched_cls,
+        ):
+            mock_sched_cls.return_value = MagicMock()
+            with caplog.at_level(logging.INFO, logger="app.main"):
+                async with lifespan(fastapi_app):
+                    pass
+
+        assert any("WEB_CONCURRENCY=4" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Dockerfile CMD default changed from `:-1` to `:-2`: instances without an explicit `WEB_CONCURRENCY` env var now start 2 workers instead of 1, eliminating accidental single-threaded production deployments
- Startup log added confirming the effective `WEB_CONCURRENCY` value — visible on every boot, making misconfigured deployments immediately detectable in logs
- `WEB_CONCURRENCY=1` added to `.env.example` with a comment recommending 2 for staging/production (Terraform already sets 2 in both environments)

## Test plan

- [x] `test_lifespan_logs_default_web_concurrency` — lifespan logs `WEB_CONCURRENCY=2` when the env var is absent
- [x] `test_lifespan_logs_configured_web_concurrency` — lifespan logs the actual value when the env var is set
- [x] DB pool sizing re-verified: `(3+5) * 2 workers = 16 connections/replica`, well within Neon Starter limit of 100