### PR TITLE
fix(monitoring): enable sentry in staging with environment tagging

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -186,8 +186,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     scheduler.shutdown(wait=False)
 
 
-if settings.SENTRY_DSN and settings.ENVIRONMENT != "local":
-    sentry_sdk.init(dsn=str(settings.SENTRY_DSN), enable_tracing=True)
+if settings.SENTRY_DSN and settings.ENVIRONMENT in ("staging", "production"):
+    sentry_sdk.init(
+        dsn=str(settings.SENTRY_DSN),
+        environment=settings.ENVIRONMENT,
+        enable_tracing=True,
+        traces_sample_rate=1.0 if settings.ENVIRONMENT == "staging" else 0.1,
+    )
 
 IS_LOCAL_ENV = settings.ENVIRONMENT == "local"
 app = FastAPI(


### PR DESCRIPTION
## Summary
- Fixes Sentry init guard to explicitly allow `staging` and `production` environments (was `!= local`, which is equivalent, but now uses an allowlist for clarity)
- Adds `environment=settings.ENVIRONMENT` tag so Sentry alerts are correctly labelled per environment
- Sets differential `traces_sample_rate`: 1.0 for staging (full tracing) and 0.1 for production (10% sampling to reduce noise)

## Test plan
- [ ] Verify Sentry init only fires when `SENTRY_DSN` is set and environment is `staging` or `production`
- [ ] Confirm staging errors appear in the `heimpath-backend` Sentry project tagged `staging`
- [ ] Confirm production errors appear tagged `production`
- [ ] Verify `local` environment never sends events (no DSN needed locally)