### PR TITLE
feat(validation): add server-side range validation for calculator inputs

### DIFF
--- a/backend/app/constants/calculator.py
+++ b/backend/app/constants/calculator.py
@@ -1,0 +1,24 @@
+"""Validation constants for financial calculator schemas.
+
+These bounds prevent nonsensical extreme inputs while covering realistic
+German real-estate scenarios.  Mirror the numeric limits in frontend form
+validation so users see consistent feedback.
+"""
+
+# Property price — largest German residential properties are ~€50–80M;
+# 100M leaves headroom for ultra-premium commercial use cases.
+PROPERTY_PRICE_MAX_EUR: int = 100_000_000
+
+# Monthly rent — €100 K/month covers large commercial buildings.
+MONTHLY_RENT_MAX_EUR: int = 100_000
+
+# Monthly operating expenses upper bound.
+MONTHLY_EXPENSES_MAX_EUR: int = 50_000
+
+# Annual mortgage / interest rate — historical German peaks never
+# exceeded ~15%; 30% provides a safe ceiling for stress-testing.
+INTEREST_RATE_MAX_PERCENT: float = 30.0
+
+# Property size — largest German residential buildings are well below
+# 10 000 m²; this prevents division-by-zero edge cases in unit calcs.
+SQUARE_METERS_MAX: int = 10_000

--- a/backend/app/schemas/property_evaluation.py
+++ b/backend/app/schemas/property_evaluation.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
+from app.constants.calculator import PROPERTY_PRICE_MAX_EUR, SQUARE_METERS_MAX
 from app.services.property_evaluation_calculator import (
     AnnualCashflowRow,
     EvaluationResult,
@@ -71,8 +72,8 @@ class PropertyEvaluationCalculateRequest(BaseModel):
 
     # Property details
     address: str = ""
-    square_meters: float = 0.0
-    purchase_price: float = 0.0
+    square_meters: float = Field(default=0.0, le=SQUARE_METERS_MAX)
+    purchase_price: float = Field(default=0.0, le=PROPERTY_PRICE_MAX_EUR)
     rent_per_m2: float = 0.0
     parking_space_rent: float = 0.0
 

--- a/backend/app/schemas/roi.py
+++ b/backend/app/schemas/roi.py
@@ -59,7 +59,10 @@ class ROICalculationCreate(BaseModel):
     @model_validator(mode="after")
     def _down_payment_within_purchase_price(self) -> Self:
         if self.down_payment > self.purchase_price:
-            raise ValueError("down_payment cannot exceed purchase_price")
+            raise ValueError(
+                f"down_payment ({self.down_payment}) cannot exceed "
+                f"purchase_price ({self.purchase_price})"
+            )
         return self
 
 

--- a/backend/app/schemas/roi.py
+++ b/backend/app/schemas/roi.py
@@ -3,7 +3,15 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Self
+
+from app.constants.calculator import (
+    INTEREST_RATE_MAX_PERCENT,
+    MONTHLY_EXPENSES_MAX_EUR,
+    MONTHLY_RENT_MAX_EUR,
+    PROPERTY_PRICE_MAX_EUR,
+)
 
 
 class ROICalculationCreate(BaseModel):
@@ -11,12 +19,28 @@ class ROICalculationCreate(BaseModel):
 
     name: str | None = Field(None, max_length=255)
     purchase_price: float = Field(
-        ..., gt=0, description="Property purchase price in EUR"
+        ...,
+        gt=0,
+        le=PROPERTY_PRICE_MAX_EUR,
+        description="Property purchase price in EUR",
     )
-    down_payment: float = Field(..., ge=0, description="Down payment in EUR")
-    monthly_rent: float = Field(..., gt=0, description="Monthly rental income in EUR")
+    down_payment: float = Field(
+        ...,
+        ge=0,
+        le=PROPERTY_PRICE_MAX_EUR,
+        description="Down payment in EUR",
+    )
+    monthly_rent: float = Field(
+        ...,
+        gt=0,
+        le=MONTHLY_RENT_MAX_EUR,
+        description="Monthly rental income in EUR",
+    )
     monthly_expenses: float = Field(
-        ..., ge=0, description="Monthly operating expenses in EUR"
+        ...,
+        ge=0,
+        le=MONTHLY_EXPENSES_MAX_EUR,
+        description="Monthly operating expenses in EUR",
     )
     annual_appreciation: float = Field(
         ..., ge=0, le=100, description="Expected annual appreciation %"
@@ -25,9 +49,18 @@ class ROICalculationCreate(BaseModel):
         ..., ge=0, le=100, description="Expected vacancy rate %"
     )
     mortgage_rate: float = Field(
-        ..., ge=0, le=100, description="Annual mortgage interest rate %"
+        ...,
+        ge=0,
+        le=INTEREST_RATE_MAX_PERCENT,
+        description="Annual mortgage interest rate %",
     )
     mortgage_term: int = Field(..., ge=5, le=40, description="Mortgage term in years")
+
+    @model_validator(mode="after")
+    def _down_payment_within_purchase_price(self) -> Self:
+        if self.down_payment > self.purchase_price:
+            raise ValueError("down_payment cannot exceed purchase_price")
+        return self
 
 
 class ProjectionYear(BaseModel):

--- a/backend/tests/api/routes/test_calculators.py
+++ b/backend/tests/api/routes/test_calculators.py
@@ -129,3 +129,128 @@ class TestCalculateEndpoint:
             json=_calculate_payload(purchase_price=-50_000),
         )
         assert r.status_code == 400
+
+    def test_rejects_purchase_price_above_max(self, client: TestClient) -> None:
+        """Test that purchase_price above 100M EUR returns 422."""
+        r = client.post(
+            f"{BASE}/calculate",
+            json=_calculate_payload(purchase_price=100_000_001.0),
+        )
+        assert r.status_code == 422
+
+    def test_purchase_price_at_max_boundary_returns_200(
+        self, client: TestClient
+    ) -> None:
+        """Test that purchase_price exactly at 100M EUR is accepted."""
+        r = client.post(
+            f"{BASE}/calculate",
+            json=_calculate_payload(purchase_price=100_000_000.0, square_meters=50.0),
+        )
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# ROI calculator range validation
+# ---------------------------------------------------------------------------
+
+ROI_BASE = f"{settings.API_V1_STR}/calculators/roi"
+
+
+def _roi_scenario(**overrides) -> dict:
+    """Return a valid ROICalculationCreate payload dict."""
+    base: dict = {
+        "purchase_price": 200_000.0,
+        "down_payment": 50_000.0,
+        "monthly_rent": 1_000.0,
+        "monthly_expenses": 200.0,
+        "annual_appreciation": 2.0,
+        "vacancy_rate": 5.0,
+        "mortgage_rate": 4.0,
+        "mortgage_term": 25,
+    }
+    base.update(overrides)
+    return base
+
+
+def _roi_compare_payload(scenario_overrides: dict | None = None) -> dict:
+    """Return a valid ROI compare request with two scenarios.
+
+    Overrides are applied only to the first scenario so a single-field
+    change is isolated and the second scenario stays valid.
+    """
+    s1 = _roi_scenario(**(scenario_overrides or {}))
+    s2 = _roi_scenario(purchase_price=300_000.0, down_payment=60_000.0)
+    return {"scenarios": [s1, s2]}
+
+
+class TestROIRangeValidation:
+    """Server-side range validation for ROI calculator inputs."""
+
+    def test_purchase_price_above_max_returns_422(self, client: TestClient) -> None:
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload({"purchase_price": 100_000_001.0}),
+        )
+        assert r.status_code == 422
+
+    def test_purchase_price_at_max_boundary_returns_200(
+        self, client: TestClient
+    ) -> None:
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload(
+                {"purchase_price": 100_000_000.0, "down_payment": 10_000_000.0}
+            ),
+        )
+        assert r.status_code == 200
+
+    def test_monthly_rent_above_max_returns_422(self, client: TestClient) -> None:
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload({"monthly_rent": 100_001.0}),
+        )
+        assert r.status_code == 422
+
+    def test_monthly_rent_at_max_boundary_returns_200(self, client: TestClient) -> None:
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload({"monthly_rent": 100_000.0}),
+        )
+        assert r.status_code == 200
+
+    def test_mortgage_rate_above_30_returns_422(self, client: TestClient) -> None:
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload({"mortgage_rate": 30.01}),
+        )
+        assert r.status_code == 422
+
+    def test_mortgage_rate_at_30_boundary_returns_200(self, client: TestClient) -> None:
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload({"mortgage_rate": 30.0}),
+        )
+        assert r.status_code == 200
+
+    def test_down_payment_exceeds_purchase_price_returns_422(
+        self, client: TestClient
+    ) -> None:
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload(
+                {"purchase_price": 100_000.0, "down_payment": 100_001.0}
+            ),
+        )
+        assert r.status_code == 422
+
+    def test_down_payment_equal_to_purchase_price_returns_200(
+        self, client: TestClient
+    ) -> None:
+        """100% cash purchase (down_payment == purchase_price) is valid."""
+        r = client.post(
+            f"{ROI_BASE}/compare",
+            json=_roi_compare_payload(
+                {"purchase_price": 200_000.0, "down_payment": 200_000.0}
+            ),
+        )
+        assert r.status_code == 200

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -7770,11 +7770,13 @@ export const PropertyEvaluationCalculateRequestSchema = {
         },
         square_meters: {
             type: 'number',
+            maximum: 10000,
             title: 'Square Meters',
             default: 0
         },
         purchase_price: {
             type: 'number',
+            maximum: 100000000,
             title: 'Purchase Price',
             default: 0
         },
@@ -8800,24 +8802,28 @@ export const ROICalculationCreateSchema = {
         },
         purchase_price: {
             type: 'number',
+            maximum: 100000000,
             exclusiveMinimum: 0,
             title: 'Purchase Price',
             description: 'Property purchase price in EUR'
         },
         down_payment: {
             type: 'number',
+            maximum: 100000000,
             minimum: 0,
             title: 'Down Payment',
             description: 'Down payment in EUR'
         },
         monthly_rent: {
             type: 'number',
+            maximum: 100000,
             exclusiveMinimum: 0,
             title: 'Monthly Rent',
             description: 'Monthly rental income in EUR'
         },
         monthly_expenses: {
             type: 'number',
+            maximum: 50000,
             minimum: 0,
             title: 'Monthly Expenses',
             description: 'Monthly operating expenses in EUR'
@@ -8838,7 +8844,7 @@ export const ROICalculationCreateSchema = {
         },
         mortgage_rate: {
             type: 'number',
-            maximum: 100,
+            maximum: 30,
             minimum: 0,
             title: 'Mortgage Rate',
             description: 'Annual mortgage interest rate %'


### PR DESCRIPTION
## Summary
- Introduces `app/constants/calculator.py` as a single source of truth for numeric limits that can be mirrored in frontend form validation
- `ROICalculationCreate`: adds `le=100_000_000` to `purchase_price`/`down_payment`, `le=100_000` to `monthly_rent`, `le=50_000` to `monthly_expenses`, tightens `mortgage_rate` from `le=100` to `le=30`, and adds a `@model_validator` to reject `down_payment > purchase_price`
- `PropertyEvaluationCalculateRequest`: adds `le=100_000_000` to `purchase_price` and `le=10_000` to `square_meters`
- 10 new tests covering boundary values and the cross-field constraint, all via public (unauthenticated) endpoints

## Test plan
- [ ] `purchase_price=100_000_001` on ROI compare → 422
- [ ] `purchase_price=100_000_000` on ROI compare → 200
- [ ] `monthly_rent=100_001` → 422; `monthly_rent=100_000` → 200
- [ ] `mortgage_rate=30.01` → 422; `mortgage_rate=30.0` → 200
- [ ] `down_payment > purchase_price` → 422; equal → 200
- [ ] `purchase_price=100_000_001` on property-evaluations/calculate → 422
- [ ] All existing calculator tests still pass