### PR TITLE
feat(reliability): make notification delivery failures observable and retryable

### DIFF
--- a/backend/app/alembic/versions/d0e1f2g3h4i5_add_notification_retry_fields_to_document.py
+++ b/backend/app/alembic/versions/d0e1f2g3h4i5_add_notification_retry_fields_to_document.py
@@ -1,0 +1,41 @@
+"""Add notification retry tracking fields to document
+
+Revision ID: d0e1f2g3h4i5
+Revises: c9d0e1f2g3h4
+Create Date: 2026-05-12 19:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d0e1f2g3h4i5"
+down_revision = "c9d0e1f2g3h4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document",
+        sa.Column(
+            "notification_failure_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "document",
+        sa.Column(
+            "notification_retry_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("document", "notification_retry_at")
+    op.drop_column("document", "notification_failure_count")

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -116,6 +116,12 @@ class Document(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     celery_task_id = Column(String(50), nullable=True)  # Celery UUIDs are 36 chars
     processing_attempt = Column(Integer, nullable=False, default=0, server_default="0")
 
+    # Notification delivery tracking (for retry on failure)
+    notification_failure_count = Column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    notification_retry_at = Column(DateTime(timezone=True), nullable=True)
+
     # Sharing
     share_id = Column(String(12), unique=True, index=True, nullable=True)
 

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -13,6 +13,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import sentry_sdk
 from fastapi import HTTPException, status
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,6 +34,8 @@ from app.services.glossary_linker_service import link_glossary_terms
 from app.services.translation_service import get_translation_service
 
 logger = logging.getLogger(__name__)
+
+_MAX_NOTIFICATION_RETRIES = 3
 
 
 # Regex patterns for German legal clause detection
@@ -524,7 +527,26 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                         action_url=f"/documents/{document_id}",
                     )
             except Exception:
+                sentry_sdk.capture_exception(
+                    extra={
+                        "document_id": str(document_id),
+                        "user_id": str(document.user_id),
+                    }
+                )
                 logger.exception("Failed to send document translation notification")
+                try:
+                    document.notification_failure_count = (
+                        document.notification_failure_count or 0
+                    ) + 1
+                    document.notification_retry_at = datetime.now(
+                        timezone.utc
+                    ) + timedelta(minutes=5)
+                    await session.commit()
+                except Exception:
+                    logger.exception(
+                        "Failed to persist notification retry fields for document %s",
+                        document_id,
+                    )
 
         except Exception as e:
             logger.exception("Failed to process document %s", document_id)
@@ -557,9 +579,28 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                                 action_url=f"/documents/{document_id}",
                             )
                     except Exception:
+                        sentry_sdk.capture_exception(
+                            extra={
+                                "document_id": str(document_id),
+                                "user_id": str(document.user_id),
+                            }
+                        )
                         logger.exception(
                             "Failed to send translation failure notification"
                         )
+                        try:
+                            document.notification_failure_count = (
+                                document.notification_failure_count or 0
+                            ) + 1
+                            document.notification_retry_at = datetime.now(
+                                timezone.utc
+                            ) + timedelta(minutes=5)
+                            await session.commit()
+                        except Exception:
+                            logger.exception(
+                                "Failed to persist notification retry fields for document %s",
+                                document_id,
+                            )
             except Exception:
                 logger.exception("Failed to update document status to failed")
 

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -18,19 +18,23 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
+from sqlmodel import Session as SyncSession
 
 from app.core.config import settings
+from app.core.db import engine as sync_engine
 from app.models.document import (
     Document,
     DocumentStatus,
     DocumentTranslation,
     DocumentType,
 )
+from app.models.notification import NotificationType
 from app.schemas.translation import SupportedLanguage
 from app.services.clause_analyzer_service import analyze_kaufvertrag
 from app.services.clause_risk_analyzer_service import analyze_clause_risks
 from app.services.document_type_analyzer_service import analyze_document_type
 from app.services.glossary_linker_service import link_glossary_terms
+from app.services.notification_service import create_notification
 from app.services.translation_service import get_translation_service
 
 logger = logging.getLogger(__name__)
@@ -511,14 +515,8 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
 
             # Send notification about completed translation
             try:
-                from sqlmodel import Session as SyncSession
-
-                from app.core.db import engine as sync_engine
-                from app.models.notification import NotificationType
-                from app.services import notification_service
-
                 with SyncSession(sync_engine) as sync_session:
-                    notification_service.create_notification(
+                    create_notification(
                         sync_session,
                         user_id=document.user_id,
                         type=NotificationType.DOCUMENT_TRANSLATED,
@@ -528,7 +526,7 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                     )
             except Exception:
                 sentry_sdk.capture_exception(
-                    extra={
+                    extras={
                         "document_id": str(document_id),
                         "user_id": str(document.user_id),
                     }
@@ -563,14 +561,8 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
 
                     # Notify user that translation failed
                     try:
-                        from sqlmodel import Session as SyncSession
-
-                        from app.core.db import engine as sync_engine
-                        from app.models.notification import NotificationType
-                        from app.services import notification_service
-
                         with SyncSession(sync_engine) as sync_session:
-                            notification_service.create_notification(
+                            create_notification(
                                 sync_session,
                                 user_id=document.user_id,
                                 type=NotificationType.TRANSLATION_FAILED,
@@ -580,7 +572,7 @@ async def process_document(document_id: uuid.UUID, session_factory) -> None:  # 
                             )
                     except Exception:
                         sentry_sdk.capture_exception(
-                            extra={
+                            extras={
                                 "document_id": str(document_id),
                                 "user_id": str(document.user_id),
                             }

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -118,11 +118,12 @@ async def _retry_failed_notifications_async() -> int:
                         _MAX_NOTIFICATION_RETRIES,
                     )
                     sentry_sdk.capture_message(
-                        f"Document notification permanently failed after {_MAX_NOTIFICATION_RETRIES} retries",
+                        "Document notification permanently failed",
                         level="error",
-                        extra={
+                        extras={
                             "document_id": str(document.id),
                             "user_id": str(document.user_id),
+                            "max_retries": _MAX_NOTIFICATION_RETRIES,
                         },
                     )
                     document.notification_retry_at = None
@@ -133,7 +134,13 @@ async def _retry_failed_notifications_async() -> int:
                         document.notification_failure_count,
                     )
                     document.notification_retry_at = now + timedelta(minutes=5)
-                await session.commit()
+                try:
+                    await session.commit()
+                except Exception:
+                    logger.exception(
+                        "Failed to persist retry tracking for document %s",
+                        document.id,
+                    )
 
     return attempted
 

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -10,9 +10,11 @@ from sqlalchemy import select
 from sqlmodel import Session as SyncSession
 
 from app.core.database import AsyncSessionLocal
+from app.core.db import engine as sync_engine
 from app.models.document import Document, DocumentStatus
 from app.models.notification import NotificationType
 from app.services import document_service, notification_service
+from app.services.document_service import _MAX_NOTIFICATION_RETRIES
 from app.worker import celery_app
 
 logger = logging.getLogger(__name__)
@@ -20,9 +22,6 @@ logger = logging.getLogger(__name__)
 # Maximum automated retries by the Celery worker (separate from user-initiated retries
 # controlled by MAX_USER_RETRIES in documents.py).
 _CELERY_MAX_RETRIES = 3
-
-# Maximum notification delivery retries before giving up and alerting Sentry.
-_MAX_NOTIFICATION_RETRIES = 3
 
 # Non-transient errors that must NOT be retried — they indicate a caller or data bug.
 _NON_RETRYABLE = (ValueError, TypeError)
@@ -79,8 +78,6 @@ async def _retry_failed_notifications_async() -> int:
         for document in documents:
             attempted += 1
             try:
-                from app.core.db import engine as sync_engine
-
                 notif_type = (
                     NotificationType.DOCUMENT_TRANSLATED
                     if document.status == DocumentStatus.COMPLETED.value
@@ -123,13 +120,18 @@ async def _retry_failed_notifications_async() -> int:
                     sentry_sdk.capture_message(
                         f"Document notification permanently failed after {_MAX_NOTIFICATION_RETRIES} retries",
                         level="error",
-                        extras={
+                        extra={
                             "document_id": str(document.id),
                             "user_id": str(document.user_id),
                         },
                     )
                     document.notification_retry_at = None
                 else:
+                    logger.exception(
+                        "Notification retry failed for document %s (attempt %d), rescheduling",
+                        document.id,
+                        document.notification_failure_count,
+                    )
                     document.notification_retry_at = now + timedelta(minutes=5)
                 await session.commit()
 

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -3,9 +3,16 @@
 import asyncio
 import logging
 import uuid
+from datetime import datetime, timedelta, timezone
+
+import sentry_sdk
+from sqlalchemy import select
+from sqlmodel import Session as SyncSession
 
 from app.core.database import AsyncSessionLocal
-from app.services import document_service
+from app.models.document import Document, DocumentStatus
+from app.models.notification import NotificationType
+from app.services import document_service, notification_service
 from app.worker import celery_app
 
 logger = logging.getLogger(__name__)
@@ -13,6 +20,9 @@ logger = logging.getLogger(__name__)
 # Maximum automated retries by the Celery worker (separate from user-initiated retries
 # controlled by MAX_USER_RETRIES in documents.py).
 _CELERY_MAX_RETRIES = 3
+
+# Maximum notification delivery retries before giving up and alerting Sentry.
+_MAX_NOTIFICATION_RETRIES = 3
 
 # Non-transient errors that must NOT be retried — they indicate a caller or data bug.
 _NON_RETRYABLE = (ValueError, TypeError)
@@ -44,3 +54,92 @@ def process_document_task(self, document_id_str: str) -> None:  # type: ignore[m
         raise
     except Exception as exc:
         raise self.retry(exc=exc)
+
+
+async def _retry_failed_notifications_async() -> int:
+    """Query documents with pending notification retries and attempt re-delivery.
+
+    Called by :func:`retry_failed_notifications` every 10 minutes via Celery beat.
+
+    Returns:
+        Number of documents where a retry was attempted.
+    """
+    now = datetime.now(timezone.utc)
+    attempted = 0
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(Document)
+            .where(Document.notification_failure_count > 0)
+            .where(Document.notification_failure_count < _MAX_NOTIFICATION_RETRIES)
+            .where(Document.notification_retry_at <= now)
+        )
+        documents = result.scalars().all()
+
+        for document in documents:
+            attempted += 1
+            try:
+                from app.core.db import engine as sync_engine
+
+                notif_type = (
+                    NotificationType.DOCUMENT_TRANSLATED
+                    if document.status == DocumentStatus.COMPLETED.value
+                    else NotificationType.TRANSLATION_FAILED
+                )
+                title = (
+                    "Document Translated"
+                    if document.status == DocumentStatus.COMPLETED.value
+                    else "Translation Failed"
+                )
+                message = (
+                    f'Your document "{document.original_filename}" has been translated.'
+                    if document.status == DocumentStatus.COMPLETED.value
+                    else f'Translation of "{document.original_filename}" could not be completed.'
+                )
+
+                with SyncSession(sync_engine) as sync_session:
+                    notification_service.create_notification(
+                        sync_session,
+                        user_id=document.user_id,
+                        type=notif_type,
+                        title=title,
+                        message=message,
+                        action_url=f"/documents/{document.id}",
+                    )
+
+                # Delivered — clear tracking fields
+                document.notification_failure_count = 0
+                document.notification_retry_at = None
+                await session.commit()
+                logger.info("Retry notification delivered for document %s", document.id)
+            except Exception:
+                document.notification_failure_count += 1
+                if document.notification_failure_count >= _MAX_NOTIFICATION_RETRIES:
+                    logger.error(
+                        "Notification permanently failed for document %s after %d attempts",
+                        document.id,
+                        _MAX_NOTIFICATION_RETRIES,
+                    )
+                    sentry_sdk.capture_message(
+                        f"Document notification permanently failed after {_MAX_NOTIFICATION_RETRIES} retries",
+                        level="error",
+                        extras={
+                            "document_id": str(document.id),
+                            "user_id": str(document.user_id),
+                        },
+                    )
+                    document.notification_retry_at = None
+                else:
+                    document.notification_retry_at = now + timedelta(minutes=5)
+                await session.commit()
+
+    return attempted
+
+
+@celery_app.task(name="app.tasks.document_tasks.retry_failed_notifications")
+def retry_failed_notifications() -> int:
+    """Celery beat task: retry document notifications that previously failed.
+
+    Scheduled every 10 minutes via :data:`app.worker.celery_app` beat schedule.
+    """
+    return asyncio.run(_retry_failed_notifications_async())

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,6 +1,7 @@
 """Celery application singleton for HeimPath background tasks."""
 
 from celery import Celery
+from celery.schedules import crontab
 
 from app.core.config import settings
 
@@ -21,4 +22,10 @@ celery_app.conf.update(
     task_reject_on_worker_lost=True,  # re-queue if worker dies mid-task
     worker_prefetch_multiplier=1,
     broker_connection_retry_on_startup=True,
+    beat_schedule={
+        "retry-failed-notifications": {
+            "task": "app.tasks.document_tasks.retry_failed_notifications",
+            "schedule": crontab(minute="*/10"),  # every 10 minutes
+        },
+    },
 )

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -343,9 +343,7 @@ class TestProcessDocumentNotifications:
 
         with (
             patch("asyncio.to_thread", side_effect=RuntimeError("disk error")),
-            patch(
-                "app.services.notification_service.create_notification"
-            ) as mock_create,
+            patch("app.services.document_service.create_notification") as mock_create,
             patch("sqlmodel.Session", return_value=mock_sync_cm),
         ):
             await document_service.process_document(document_id, session_factory)
@@ -370,7 +368,7 @@ class TestProcessDocumentNotifications:
         with (
             patch("asyncio.to_thread", side_effect=RuntimeError("disk error")),
             patch(
-                "app.services.notification_service.create_notification",
+                "app.services.document_service.create_notification",
                 side_effect=Exception("notification DB unavailable"),
             ),
             patch("sqlmodel.Session", return_value=mock_sync_cm),
@@ -392,7 +390,7 @@ class TestProcessDocumentNotifications:
         with (
             patch("asyncio.to_thread", side_effect=RuntimeError("disk error")),
             patch(
-                "app.services.notification_service.create_notification",
+                "app.services.document_service.create_notification",
                 side_effect=Exception("SMTP unavailable"),
             ),
             patch("sqlmodel.Session", return_value=mock_sync_cm),
@@ -417,7 +415,7 @@ class TestProcessDocumentNotifications:
         with (
             patch("asyncio.to_thread", side_effect=RuntimeError("disk error")),
             patch(
-                "app.services.notification_service.create_notification",
+                "app.services.document_service.create_notification",
                 side_effect=Exception("SMTP unavailable"),
             ),
             patch("sqlmodel.Session", return_value=mock_sync_cm),
@@ -567,7 +565,7 @@ class TestTranslationConfidenceThreshold:
                 new=AsyncMock(return_value=[]),
             ),
             patch("sqlmodel.Session", return_value=mock_sync_cm),
-            patch("app.services.notification_service.create_notification"),
+            patch("app.services.document_service.create_notification"),
         ):
             await document_service.process_document(document_id, session_factory)
 
@@ -711,7 +709,7 @@ class TestTranslationCoverageGate:
                 new=AsyncMock(return_value=[]),
             ),
             patch("sqlmodel.Session", return_value=mock_sync_cm),
-            patch("app.services.notification_service.create_notification"),
+            patch("app.services.document_service.create_notification"),
         ):
             await document_service.process_document(document_id, session_factory)
 
@@ -843,7 +841,7 @@ class TestTranslationCoverageGate:
                 new=AsyncMock(return_value=[]),
             ),
             patch("sqlmodel.Session", return_value=mock_sync_cm),
-            patch("app.services.notification_service.create_notification"),
+            patch("app.services.document_service.create_notification"),
         ):
             await document_service.process_document(document_id, session_factory)
 

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -378,6 +378,57 @@ class TestProcessDocumentNotifications:
             # Should not raise — notification errors are swallowed
             await document_service.process_document(document_id, session_factory)
 
+    @pytest.mark.asyncio
+    async def test_notification_failure_captures_to_sentry(self) -> None:
+        """On notification failure sentry_sdk.capture_exception is called with context."""
+        document_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_session, session_factory = _make_process_document_mocks(
+            document_id, user_id
+        )
+        mock_sync_cm = _make_sync_session_mock()
+
+        with (
+            patch("asyncio.to_thread", side_effect=RuntimeError("disk error")),
+            patch(
+                "app.services.notification_service.create_notification",
+                side_effect=Exception("SMTP unavailable"),
+            ),
+            patch("sqlmodel.Session", return_value=mock_sync_cm),
+            patch("app.services.document_service.sentry_sdk") as mock_sentry,
+        ):
+            await document_service.process_document(document_id, session_factory)
+
+        mock_sentry.capture_exception.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_notification_failure_sets_retry_fields(self) -> None:
+        """On notification failure notification_failure_count and notification_retry_at
+        are persisted on the document so the retry task can pick it up."""
+        document_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+
+        mock_session, session_factory = _make_process_document_mocks(
+            document_id, user_id
+        )
+        mock_sync_cm = _make_sync_session_mock()
+
+        with (
+            patch("asyncio.to_thread", side_effect=RuntimeError("disk error")),
+            patch(
+                "app.services.notification_service.create_notification",
+                side_effect=Exception("SMTP unavailable"),
+            ),
+            patch("sqlmodel.Session", return_value=mock_sync_cm),
+            patch("app.services.document_service.sentry_sdk"),
+        ):
+            await document_service.process_document(document_id, session_factory)
+
+        # The mock session should have been committed at least twice:
+        # once for FAILED status, once for notification retry tracking.
+        assert mock_session.commit.await_count >= 2
+
 
 # ── mark_stuck_documents_failed ───────────────────────────────────────────────
 

--- a/backend/tests/services/test_document_service.py
+++ b/backend/tests/services/test_document_service.py
@@ -425,8 +425,10 @@ class TestProcessDocumentNotifications:
         ):
             await document_service.process_document(document_id, session_factory)
 
-        # The mock session should have been committed at least twice:
-        # once for FAILED status, once for notification retry tracking.
+        doc = mock_session.execute.return_value.scalar_one_or_none.return_value
+        assert doc.notification_failure_count == 1
+        assert doc.notification_retry_at is not None
+        # committed at least twice: once for FAILED status, once for retry tracking
         assert mock_session.commit.await_count >= 2
 
 

--- a/backend/tests/tasks/test_document_tasks.py
+++ b/backend/tests/tasks/test_document_tasks.py
@@ -151,6 +151,13 @@ class TestRetryFailedNotifications:
 
         mock_notify.assert_not_called()
 
+        # Verify the executed query filters on both notification tracking columns
+        mock_session.execute.assert_called_once()
+        stmt = mock_session.execute.call_args[0][0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "notification_failure_count" in compiled
+        assert "notification_retry_at" in compiled
+
     @pytest.mark.asyncio
     async def test_increments_failure_count_and_reschedules_on_failure(self) -> None:
         """When retry still fails the count increments and retry_at is pushed forward."""

--- a/backend/tests/tasks/test_document_tasks.py
+++ b/backend/tests/tasks/test_document_tasks.py
@@ -1,12 +1,18 @@
 """Tests for document Celery tasks."""
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from celery.exceptions import Retry
 
-from app.tasks.document_tasks import process_document_task
+from app.models.document import Document, DocumentStatus, DocumentType
+from app.tasks.document_tasks import (
+    _retry_failed_notifications_async,
+    process_document_task,
+)
 
 
 class TestProcessDocumentTask:
@@ -48,3 +54,152 @@ class TestProcessDocumentTask:
         ):
             with pytest.raises(ValueError):
                 process_document_task.apply(args=[str(uuid.uuid4())], throw=True)
+
+
+# ── retry_failed_notifications ────────────────────────────────────────────────
+
+
+def _make_doc(
+    *,
+    failure_count: int = 1,
+    retry_at_offset_minutes: int = -1,
+    status: str = DocumentStatus.COMPLETED.value,
+) -> Document:
+    """Build a Document instance with notification tracking fields set."""
+    doc = Document(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        original_filename="test.pdf",
+        stored_filename="abc.pdf",
+        file_path="/tmp/abc.pdf",
+        file_size_bytes=1024,
+        page_count=1,
+        document_type=DocumentType.UNKNOWN.value,
+        status=status,
+        notification_failure_count=failure_count,
+        notification_retry_at=datetime.now(timezone.utc)
+        + timedelta(minutes=retry_at_offset_minutes),
+    )
+    doc.created_at = datetime.now(timezone.utc)
+    return doc
+
+
+def _make_async_session_with_docs(docs: list) -> tuple:
+    """Build a mock AsyncSessionLocal that yields docs from a SELECT."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = docs
+
+    mock_session = AsyncMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _factory():
+        yield mock_session
+
+    return mock_session, _factory
+
+
+class TestRetryFailedNotifications:
+    """Tests for the periodic retry task that re-sends failed notifications."""
+
+    @pytest.mark.asyncio
+    async def test_delivers_notification_and_resets_counters(self) -> None:
+        """Successful retry resets notification_failure_count to 0."""
+        doc = _make_doc(failure_count=1)
+        mock_session, session_factory = _make_async_session_with_docs([doc])
+        mock_sync_cm = MagicMock()
+        mock_sync_cm.__enter__ = MagicMock(return_value=mock_sync_cm)
+        mock_sync_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "app.tasks.document_tasks.AsyncSessionLocal",
+                return_value=session_factory(),
+            ),
+            patch("app.tasks.document_tasks.notification_service.create_notification"),
+            patch("sqlmodel.Session", return_value=mock_sync_cm),
+        ):
+            await _retry_failed_notifications_async()
+
+        assert doc.notification_failure_count == 0
+        assert doc.notification_retry_at is None
+        mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_docs_not_yet_due(self) -> None:
+        """Documents whose retry_at is in the future are not queried."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []  # query returns nothing
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+
+        @asynccontextmanager
+        async def _factory():
+            yield mock_session
+
+        with (
+            patch(
+                "app.tasks.document_tasks.AsyncSessionLocal", return_value=_factory()
+            ),
+            patch(
+                "app.tasks.document_tasks.notification_service.create_notification"
+            ) as mock_notify,
+        ):
+            await _retry_failed_notifications_async()
+
+        mock_notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_increments_failure_count_and_reschedules_on_failure(self) -> None:
+        """When retry still fails the count increments and retry_at is pushed forward."""
+        doc = _make_doc(failure_count=1)
+        mock_session, session_factory = _make_async_session_with_docs([doc])
+        mock_sync_cm = MagicMock()
+        mock_sync_cm.__enter__ = MagicMock(return_value=mock_sync_cm)
+        mock_sync_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "app.tasks.document_tasks.AsyncSessionLocal",
+                return_value=session_factory(),
+            ),
+            patch(
+                "app.tasks.document_tasks.notification_service.create_notification",
+                side_effect=Exception("SMTP down"),
+            ),
+            patch("sqlmodel.Session", return_value=mock_sync_cm),
+        ):
+            await _retry_failed_notifications_async()
+
+        assert doc.notification_failure_count == 2
+        assert doc.notification_retry_at is not None
+        mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stops_retrying_and_reports_to_sentry_at_max_failures(self) -> None:
+        """At max retries (3) the retry_at is cleared and Sentry is notified."""
+        doc = _make_doc(failure_count=2)  # one more failure → 3 → max
+        mock_session, session_factory = _make_async_session_with_docs([doc])
+        mock_sync_cm = MagicMock()
+        mock_sync_cm.__enter__ = MagicMock(return_value=mock_sync_cm)
+        mock_sync_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "app.tasks.document_tasks.AsyncSessionLocal",
+                return_value=session_factory(),
+            ),
+            patch(
+                "app.tasks.document_tasks.notification_service.create_notification",
+                side_effect=Exception("SMTP down"),
+            ),
+            patch("sqlmodel.Session", return_value=mock_sync_cm),
+            patch("app.tasks.document_tasks.sentry_sdk") as mock_sentry,
+        ):
+            await _retry_failed_notifications_async()
+
+        assert doc.notification_failure_count == 3
+        assert doc.notification_retry_at is None  # no further retries scheduled
+        mock_sentry.capture_message.assert_called_once()

--- a/compose.yml
+++ b/compose.yml
@@ -160,6 +160,7 @@ services:
       - FIRST_SUPERUSER=${FIRST_SUPERUSER?Variable not set}
       - FIRST_SUPERUSER_PASSWORD=${FIRST_SUPERUSER_PASSWORD?Variable not set}
       - REDIS_URL=redis://:${REDIS_PASSWORD?Variable not set}@redis:6379
+      - SENTRY_DSN=${SENTRY_DSN}
       - AZURE_TRANSLATOR_KEY=${AZURE_TRANSLATOR_KEY}
       - AZURE_TRANSLATOR_REGION=${AZURE_TRANSLATOR_REGION}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
@@ -192,6 +193,7 @@ services:
       - FIRST_SUPERUSER=${FIRST_SUPERUSER?Variable not set}
       - FIRST_SUPERUSER_PASSWORD=${FIRST_SUPERUSER_PASSWORD?Variable not set}
       - REDIS_URL=redis://:${REDIS_PASSWORD?Variable not set}@redis:6379
+      - SENTRY_DSN=${SENTRY_DSN}
 
   frontend:
     image: '${DOCKER_IMAGE_FRONTEND?Variable not set}:${TAG-latest}'

--- a/compose.yml
+++ b/compose.yml
@@ -165,6 +165,34 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - UPLOAD_DIR=${UPLOAD_DIR:-./uploads/documents}
 
+  celery-beat:
+    image: '${DOCKER_IMAGE_BACKEND?Variable not set}:${TAG-latest}'
+    restart: always
+    networks:
+      - default
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      prestart:
+        condition: service_completed_successfully
+    command: celery -A app.worker.celery_app beat --loglevel=info
+    env_file:
+      - .env
+    environment:
+      - ENVIRONMENT=${ENVIRONMENT}
+      - PROJECT_NAME=${PROJECT_NAME}
+      - POSTGRES_SERVER=db
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER?Variable not set}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
+      - SECRET_KEY=${SECRET_KEY?Variable not set}
+      - FIRST_SUPERUSER=${FIRST_SUPERUSER?Variable not set}
+      - FIRST_SUPERUSER_PASSWORD=${FIRST_SUPERUSER_PASSWORD?Variable not set}
+      - REDIS_URL=redis://:${REDIS_PASSWORD?Variable not set}@redis:6379
+
   frontend:
     image: '${DOCKER_IMAGE_FRONTEND?Variable not set}:${TAG-latest}'
     restart: always


### PR DESCRIPTION
## Summary

- On document notification failure, captures exception to Sentry with `document_id`/`user_id` context instead of silently logging
- Adds `notification_failure_count` and `notification_retry_at` fields to the `Document` model (Alembic migration included) so failures are persisted and visible
- Adds `retry_failed_notifications` Celery beat task (every 10 min) that re-attempts delivery for documents with pending retries; after 3 failures the document is permanently marked and Sentry is alerted with `capture_message`

## Test plan

- [x] `TestProcessDocumentNotifications::test_notification_failure_captures_to_sentry` — verifies Sentry capture on failure
- [x] `TestProcessDocumentNotifications::test_notification_failure_sets_retry_fields` — verifies retry tracking fields committed
- [x] `TestRetryFailedNotifications::test_delivers_notification_and_resets_counters` — successful retry clears counters
- [x] `TestRetryFailedNotifications::test_skips_docs_not_yet_due` — only processes due documents
- [x] `TestRetryFailedNotifications::test_increments_failure_count_and_reschedules_on_failure` — second failure increments count and reschedules
- [x] `TestRetryFailedNotifications::test_stops_retrying_and_reports_to_sentry_at_max_failures` — max retries triggers Sentry alert