### PR TITLE
chore: set emails_from_email to mail subdomain for deliverability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,13 @@ FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=changethis
 
 # Emails
+# Use a dedicated subdomain (mail.heimpath.com) rather than the root domain so
+# that any reputation impact from transactional email stays isolated.
+# The subdomain must be verified in Resend with MX + SPF + DKIM records.
 SMTP_HOST=
 SMTP_USER=
 SMTP_PASSWORD=
-EMAILS_FROM_EMAIL=info@example.com
+EMAILS_FROM_EMAIL=hello@mail.heimpath.com
 SMTP_TLS=True
 SMTP_SSL=False
 SMTP_PORT=587


### PR DESCRIPTION
## Summary

- Updates `EMAILS_FROM_EMAIL` in `.env.example` from the generic `info@example.com` placeholder to `hello@mail.heimpath.com`
- Adds a comment explaining that the dedicated `mail.heimpath.com` subdomain isolates transactional email reputation from the root domain, and that the subdomain must be verified in Resend with MX + SPF + DKIM records

## Manual steps required (not in this PR)

The following steps require external access and must be performed manually:

1. **Resend dashboard** — add `mail.heimpath.com` as a verified domain; copy the MX, SPF TXT, and DKIM CNAME records Resend provides
2. **DNS zone** — add the records above to the heimpath.com DNS zone (Azure DNS or registrar)
3. **Azure staging** — update `EMAILS_FROM_EMAIL=hello@mail.heimpath.com` via `az containerapp update`
4. **Azure production** — same update on the production container app
5. **Verify** — send a test email via `/api/v1/utils/test-emails` and confirm Resend Insights no longer flags the subdomain or no-reply warnings

## Test plan

- [x] `.env.example` updated with correct sender address and explanatory comment
- [x] Pre-commit passes
- [ ] (Manual) Resend domain verified, DNS records propagated
- [ ] (Manual) Test email arrives from `hello@mail.heimpath.com` in staging