### PR TITLE
fix(notifications): use typed TanStack Router params for action URL navigation

### DIFF
--- a/frontend/src/components/Notifications/NotificationBell.tsx
+++ b/frontend/src/components/Notifications/NotificationBell.tsx
@@ -17,7 +17,11 @@ import {
 } from "@/hooks/mutations/useNotificationMutations"
 import { useNotifications } from "@/hooks/queries/useNotificationQueries"
 import type { Notification } from "@/models/notification"
-import { getRelativeTime, NOTIFICATION_ICONS } from "./notificationUtils"
+import {
+  getRelativeTime,
+  NOTIFICATION_ICONS,
+  navigateToActionUrl,
+} from "./notificationUtils"
 
 // ***************************************************************************
 //                              Components
@@ -85,7 +89,7 @@ function NotificationBell() {
     }
     setOpen(false)
     if (notification.actionUrl) {
-      navigate({ to: notification.actionUrl })
+      navigateToActionUrl(navigate, notification.actionUrl)
     }
   }
 

--- a/frontend/src/components/Notifications/NotificationCenter.tsx
+++ b/frontend/src/components/Notifications/NotificationCenter.tsx
@@ -16,7 +16,11 @@ import {
 } from "@/hooks/mutations/useNotificationMutations"
 import { useNotifications } from "@/hooks/queries/useNotificationQueries"
 import type { Notification } from "@/models/notification"
-import { getRelativeTime, NOTIFICATION_ICONS } from "./notificationUtils"
+import {
+  getRelativeTime,
+  NOTIFICATION_ICONS,
+  navigateToActionUrl,
+} from "./notificationUtils"
 
 /******************************************************************************
                               Constants
@@ -45,7 +49,7 @@ function NotificationRow({ notification }: INotificationRowProps) {
       markRead.mutate(notification.id)
     }
     if (notification.actionUrl) {
-      navigate({ to: notification.actionUrl })
+      navigateToActionUrl(navigate, notification.actionUrl)
     }
   }
 

--- a/frontend/src/components/Notifications/notificationUtils.ts
+++ b/frontend/src/components/Notifications/notificationUtils.ts
@@ -2,6 +2,7 @@
  * Shared utilities for notification components
  */
 
+import type { useNavigate } from "@tanstack/react-router"
 import {
   AlertTriangle,
   Bell,
@@ -15,6 +16,8 @@ import {
   XCircle,
 } from "lucide-react"
 import type { NotificationType } from "@/models/notification"
+
+type NavigateFn = ReturnType<typeof useNavigate>
 
 /******************************************************************************
                               Constants
@@ -36,6 +39,53 @@ export const NOTIFICATION_ICONS: Record<NotificationType, typeof Bell> = {
 /******************************************************************************
                               Functions
 ******************************************************************************/
+
+// Known parameterised route patterns from backend notification action_url values.
+// TanStack Router requires typed params for these — a plain string path like
+// "/laws/some-uuid" does not match the "$lawId" segment at runtime.
+const LAW_PATTERN = /^\/laws\/([^/?#]+)$/
+const JOURNEY_PATTERN = /^\/journeys\/([^/?#]+)$/
+const DOCUMENT_PATTERN = /^\/documents\/([^/?#]+)$/
+
+/**
+ * Navigate to a notification action URL using typed TanStack Router paths.
+ *
+ * Parameterised routes (e.g. /laws/{id}) must be dispatched with explicit
+ * `params` so the router can match the dynamic segment.  Static routes and
+ * query-param URLs fall back to a direct `to` string navigation.
+ */
+export function navigateToActionUrl(
+  navigate: NavigateFn,
+  actionUrl: string,
+): void {
+  const lawMatch = actionUrl.match(LAW_PATTERN)
+  if (lawMatch) {
+    navigate({ to: "/laws/$lawId", params: { lawId: lawMatch[1] } })
+    return
+  }
+
+  const journeyMatch = actionUrl.match(JOURNEY_PATTERN)
+  if (journeyMatch) {
+    navigate({
+      to: "/journeys/$journeyId",
+      params: { journeyId: journeyMatch[1] },
+    })
+    return
+  }
+
+  const documentMatch = actionUrl.match(DOCUMENT_PATTERN)
+  if (documentMatch) {
+    navigate({
+      to: "/documents/$documentId",
+      params: { documentId: documentMatch[1] },
+    })
+    return
+  }
+
+  // Static routes (/notifications) and query-param paths (/calculators?tab=…)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigate({ to: actionUrl as any })
+}
 
 export function getRelativeTime(dateString: string): string {
   const now = new Date()


### PR DESCRIPTION
## Summary

- Clicking a law-bookmarked (or journey) notification did nothing because `navigate({ to: "/laws/some-uuid" })` does not match TanStack Router's dynamic `$lawId` segment at runtime — the router needs typed params, not a resolved path string.
- Add `navigateToActionUrl(navigate, actionUrl)` in `notificationUtils.ts` that parses known backend `action_url` patterns and dispatches typed navigation with explicit `params`.
- Both `NotificationBell` and `NotificationCenter` now call this helper instead of the bare `navigate`.

**URL pattern handling:**
| Backend `action_url` | Navigation dispatched |
|---|---|
| `/laws/{uuid}` | `{ to: "/laws/$lawId", params: { lawId } }` |
| `/journeys/{uuid}` | `{ to: "/journeys/$journeyId", params: { journeyId } }` |
| `/calculators?tab=…` / `/notifications` | fallback string `to` (static routes work fine) |

## Test plan

- [ ] Bookmark a law → receive notification → click it → lands on law detail page
- [ ] Same for journey notifications
- [ ] Calculator/notifications action URLs still navigate correctly
- [ ] TypeScript: `tsc --noEmit` passes with no errors