### PR TITLE
feat(journey): auto-expand active step with collapse controls

### DIFF
--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -22,6 +22,12 @@ import { STEP_CONTENT_REGISTRY, StepBody } from "./StepContent/StepBody"
 interface IProps {
   step: JourneyStep
   isActive?: boolean
+  /** Initial expanded state (uncontrolled). Ignored when isExpanded is provided. */
+  defaultExpanded?: boolean
+  /** Controlled expanded state. Takes precedence over internal state. */
+  isExpanded?: boolean
+  /** Controlled toggle callback. Required when isExpanded is provided. */
+  onToggleExpanded?: () => void
   showPhaseBadge?: boolean
   onTaskToggle?: (stepId: string, taskId: string, isCompleted: boolean) => void
   onStepOpen?: (stepId: string) => void
@@ -92,13 +98,18 @@ function StepCard(props: IProps) {
   const {
     step,
     isActive = false,
+    defaultExpanded = false,
+    isExpanded: isExpandedProp,
+    onToggleExpanded,
     showPhaseBadge = true,
     onTaskToggle,
     onStepOpen,
     className,
   } = props
 
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [internalExpanded, setInternalExpanded] = useState(defaultExpanded)
+  const isExpanded =
+    isExpandedProp !== undefined ? isExpandedProp : internalExpanded
 
   const hasContentRenderer = step.content_key
     ? !!STEP_CONTENT_REGISTRY[step.content_key]
@@ -110,14 +121,19 @@ function StepCard(props: IProps) {
 
   const handleToggleExpanded = () => {
     if (!hasBody) return
-    setIsExpanded(!isExpanded)
+    if (onToggleExpanded) {
+      onToggleExpanded()
+    } else {
+      setInternalExpanded(!internalExpanded)
+    }
   }
 
   return (
     <Card
       className={cn(
         "gap-0 overflow-hidden py-0 transition-all",
-        isActive && "ring-2 ring-primary ring-offset-2",
+        isActive &&
+          "border-l-[3px] border-l-primary ring-2 ring-primary ring-offset-2",
         step.status === "completed" &&
           "border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20",
         className,

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -4,7 +4,7 @@
  * Primary view for journey steps — supports deep-link and auto-advance.
  */
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { JOURNEY_PHASES } from "@/common/constants"
 import type { JourneyPhase, JourneyStep } from "@/models/journey"
 import { PhaseCompletionCta } from "./PhaseCompletionCta"
@@ -39,6 +39,20 @@ function StepTabView(props: IProps) {
   const defaultPhase = initialPhase ?? activeStep?.phase ?? "research"
 
   const [selectedPhase, setSelectedPhase] = useState<JourneyPhase>(defaultPhase)
+
+  // Track which step cards are expanded. Start with just the active step open.
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() =>
+    activeStep ? new Set([activeStep.id]) : new Set(),
+  )
+
+  const toggleStep = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   const stepsByPhase: Record<JourneyPhase, JourneyStep[]> = {
     research: [],
@@ -105,6 +119,45 @@ function StepTabView(props: IProps) {
     }
   }, [isPhaseComplete, nextPhaseByStepOrder, nextPhaseStarted])
 
+  // Scroll to the active step when the user switches phases.
+  const activeCardRef = useRef<HTMLDivElement>(null)
+  const isInitialPhaseMount = useRef(true)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: effectivePhase is the intentional trigger
+  useEffect(() => {
+    if (isInitialPhaseMount.current) {
+      isInitialPhaseMount.current = false
+      return
+    }
+    const timer = setTimeout(() => {
+      activeCardRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      })
+    }, 50)
+    return () => clearTimeout(timer)
+  }, [effectivePhase])
+
+  // Expand-all / collapse-all for the currently visible phase steps.
+  const allExpanded =
+    phaseSteps.length > 0 && phaseSteps.every((s) => expandedIds.has(s.id))
+
+  const handleToggleAll = () => {
+    if (allExpanded) {
+      setExpandedIds((prev) => {
+        const next = new Set(prev)
+        for (const s of phaseSteps) next.delete(s.id)
+        return next
+      })
+    } else {
+      setExpandedIds((prev) => {
+        const next = new Set(prev)
+        for (const s of phaseSteps) next.add(s.id)
+        return next
+      })
+    }
+  }
+
   const handleContinueToPhase = (nextPhase: JourneyPhase) => {
     setSelectedPhase(nextPhase)
   }
@@ -131,17 +184,36 @@ function StepTabView(props: IProps) {
         onPhaseClick={(key) => setSelectedPhase(key as JourneyPhase)}
       />
 
+      {/* Expand / collapse all toggle */}
+      {phaseSteps.length > 0 && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleToggleAll}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            {allExpanded ? "Collapse all" : "Expand all"}
+          </button>
+        </div>
+      )}
+
       {/* Steps for selected phase */}
-      {phaseSteps.map((step) => (
-        <StepCard
-          key={step.id}
-          step={step}
-          isActive={step.step_number === activeStepNumber}
-          showPhaseBadge={false}
-          onTaskToggle={onTaskToggle}
-          onStepOpen={onStepOpen}
-        />
-      ))}
+      {phaseSteps.map((step) => {
+        const isActiveStep = step.step_number === activeStepNumber
+        return (
+          <div key={step.id} ref={isActiveStep ? activeCardRef : undefined}>
+            <StepCard
+              step={step}
+              isActive={isActiveStep}
+              isExpanded={expandedIds.has(step.id)}
+              onToggleExpanded={() => toggleStep(step.id)}
+              showPhaseBadge={false}
+              onTaskToggle={onTaskToggle}
+              onStepOpen={onStepOpen}
+            />
+          </div>
+        )
+      })}
 
       {/* Phase completion CTA */}
       {isPhaseComplete && !nextPhaseStarted && (

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -41,6 +41,10 @@ function StepTabView(props: IProps) {
   const [selectedPhase, setSelectedPhase] = useState<JourneyPhase>(defaultPhase)
 
   // Track which step cards are expanded. Start with just the active step open.
+  // Safe: StepTabView is only mounted after data loads (skeleton shown instead),
+  // so activeStep is defined on first render.
+  // Expansions are intentionally preserved across phase tab switches so users
+  // don't lose their place when browsing back to a phase.
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() =>
     activeStep ? new Set([activeStep.id]) : new Set(),
   )


### PR DESCRIPTION
## Summary

- Auto-expands only the active (current) step on load, so users see focused content instead of a wall of open cards
- Remaining steps in the phase render as compact rows; any step can be manually expanded by clicking its header
- Adds **Expand all / Collapse all** text toggle above the step list for power users
- Active step gets a 3px left accent bar alongside the existing ring highlight
- Phase tab switches smooth-scroll to the active step in the new phase

## Test plan

- [ ] Open a journey — verify only the current active step is expanded on load
- [ ] Click a different step header — verify it expands without collapsing the active step
- [ ] Click "Expand all" — verify all steps in the phase expand
- [ ] Click "Collapse all" — verify all steps collapse
- [ ] Switch to a different phase tab — verify scroll fires and only the active step (if in that phase) is expanded
- [ ] Verify active step card shows the left accent bar and ring