### PR TITLE
feat(journey): add next-step widget for returning user orientation

### DIFF
--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -14,7 +14,7 @@ import {
   Trash2,
   Wallet,
 } from "lucide-react"
-import { useCallback, useMemo } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { ApiError } from "@/client"
 import {
   FINANCING_TYPES,
@@ -39,6 +39,7 @@ import type {
 } from "@/models/journey"
 import { JourneyCompletionCta } from "./JourneyCompletionCta"
 import { JourneyProvider } from "./JourneyContext"
+import { NextStepWidget } from "./NextStepWidget"
 import { ProgressBar } from "./ProgressBar"
 import { StepTabView } from "./StepTabView"
 
@@ -288,6 +289,19 @@ function JourneyDetail(props: IProps) {
     [journey],
   )
 
+  // State for programmatic phase switching from the Next-Step Widget "Continue" CTA.
+  // requestedPhase switches the StepTabView to the active step's phase.
+  // scrollToActiveKey is a counter that triggers scroll-to-active-step on each click.
+  const [requestedPhase, setRequestedPhase] = useState<
+    JourneyPhase | undefined
+  >()
+  const [scrollToActiveKey, setScrollToActiveKey] = useState(0)
+
+  const handleWidgetContinue = useCallback((phaseKey: JourneyPhase) => {
+    setRequestedPhase(phaseKey)
+    setScrollToActiveKey((k) => k + 1)
+  }, [])
+
   if (isLoading || !journey) {
     return <JourneyDetailSkeleton />
   }
@@ -363,6 +377,15 @@ function JourneyDetail(props: IProps) {
         <span className="font-medium text-foreground">{currentPhaseLabel}</span>
       </p>
 
+      {/* What to do today — hidden once the journey is complete */}
+      {!isOwnershipComplete && (
+        <NextStepWidget
+          journey={journey}
+          progress={progress}
+          onContinue={handleWidgetContinue}
+        />
+      )}
+
       {/* Completion / Portfolio CTA */}
       {isOwnershipComplete &&
         (linkedPortfolioProperty ? (
@@ -382,6 +405,8 @@ function JourneyDetail(props: IProps) {
               onTaskToggle={onTaskToggle}
               onStepOpen={onStepOpen}
               initialPhase={resolvedInitialPhase}
+              requestedPhase={requestedPhase}
+              scrollToActiveKey={scrollToActiveKey}
               onAddToPortfolio={
                 isOwnershipComplete && !linkedPortfolioProperty
                   ? handleAddToPortfolio

--- a/frontend/src/components/Journey/NextStepWidget.tsx
+++ b/frontend/src/components/Journey/NextStepWidget.tsx
@@ -59,11 +59,7 @@ function NextStepWidget(props: IProps) {
   const totalSteps = progress?.total_steps ?? journey.total_steps
 
   return (
-    <Card
-      className={cn(
-        "sticky top-16 z-10 border-l-[3px] border-l-primary shadow-sm",
-      )}
-    >
+    <Card className="sticky top-16 z-10 border-l-[3px] border-l-primary shadow-sm">
       <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:gap-4">
         {/* Phase icon */}
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">

--- a/frontend/src/components/Journey/NextStepWidget.tsx
+++ b/frontend/src/components/Journey/NextStepWidget.tsx
@@ -1,0 +1,130 @@
+/**
+ * Next Step Widget
+ * Sticky orientation card showing the user exactly what to focus on right now.
+ * Designed for returning users who need to re-engage quickly after time away.
+ */
+
+import { ArrowRight, Circle, Target } from "lucide-react"
+import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
+import { cn } from "@/common/utils"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import type {
+  JourneyPhase,
+  JourneyProgress,
+  JourneyPublic,
+} from "@/models/journey"
+
+interface IProps {
+  journey: JourneyPublic
+  progress?: JourneyProgress
+  /** Called when the user clicks "Continue" — passes the active step's phase. */
+  onContinue: (phaseKey: JourneyPhase) => void
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Sticky next-step orientation card. */
+function NextStepWidget(props: IProps) {
+  const { journey, progress, onContinue } = props
+
+  const activeStep = journey.steps.find(
+    (s) => s.step_number === journey.current_step_number,
+  )
+
+  // Don't render if journey is complete or active step can't be determined.
+  const isComplete =
+    !!journey.completed_at ||
+    (journey.steps.length > 0 &&
+      journey.steps.every(
+        (s) => s.status === "completed" || s.status === "skipped",
+      ))
+
+  if (isComplete || !activeStep) return null
+
+  const pendingTasks = activeStep.tasks.filter((t) => !t.is_completed)
+  const shownTasks = pendingTasks.slice(0, 2)
+  const hiddenTaskCount = pendingTasks.length - shownTasks.length
+
+  const phaseLabel =
+    JOURNEY_PHASES.find((p) => p.key === activeStep.phase)?.label ??
+    activeStep.phase
+  const progressPercent = Math.round(
+    progress?.progress_percentage ?? journey.progress_percentage,
+  )
+  const completedSteps = progress?.completed_steps ?? journey.completed_steps
+  const totalSteps = progress?.total_steps ?? journey.total_steps
+
+  return (
+    <Card
+      className={cn(
+        "sticky top-16 z-10 border-l-[3px] border-l-primary shadow-sm",
+      )}
+    >
+      <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:gap-4">
+        {/* Phase icon */}
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+          <Target className="h-5 w-5 text-primary" />
+        </div>
+
+        {/* Step info */}
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant="secondary"
+              className={cn("shrink-0 text-xs", PHASE_COLORS[activeStep.phase])}
+            >
+              {phaseLabel}
+            </Badge>
+            <span className="text-xs text-muted-foreground">
+              {completedSteps} of {totalSteps} steps &middot; {progressPercent}%
+            </span>
+          </div>
+
+          <p className="text-sm font-medium leading-snug">
+            Step {activeStep.step_number}: {activeStep.title}
+          </p>
+
+          {shownTasks.length > 0 && (
+            <ul className="space-y-0.5">
+              {shownTasks.map((task) => (
+                <li
+                  key={task.id}
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                >
+                  <Circle className="h-3 w-3 shrink-0" />
+                  <span className="truncate">{task.title}</span>
+                </li>
+              ))}
+              {hiddenTaskCount > 0 && (
+                <li className="pl-[18px] text-xs text-muted-foreground">
+                  +{hiddenTaskCount} more{" "}
+                  {hiddenTaskCount === 1 ? "task" : "tasks"}
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
+
+        {/* Continue CTA */}
+        <Button
+          size="sm"
+          className="shrink-0 gap-1.5"
+          onClick={() => onContinue(activeStep.phase as JourneyPhase)}
+        >
+          Continue
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { NextStepWidget }

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -19,6 +19,13 @@ interface IProps {
   onAddToPortfolio?: () => void
   /** Pre-select a phase on mount (e.g. from ?phase= deep-link). */
   initialPhase?: JourneyPhase
+  /** Switch to this phase programmatically (e.g. from Next-Step Widget "Continue"). */
+  requestedPhase?: JourneyPhase
+  /**
+   * Increment to programmatically scroll to the active step card.
+   * Used together with requestedPhase to scroll after a phase switch.
+   */
+  scrollToActiveKey?: number
 }
 
 /******************************************************************************
@@ -33,6 +40,8 @@ function StepTabView(props: IProps) {
     onStepOpen,
     onAddToPortfolio,
     initialPhase,
+    requestedPhase,
+    scrollToActiveKey,
   } = props
 
   const activeStep = steps.find((s) => s.step_number === activeStepNumber)
@@ -123,6 +132,14 @@ function StepTabView(props: IProps) {
     }
   }, [isPhaseComplete, nextPhaseByStepOrder, nextPhaseStarted])
 
+  // Switch to the programmatically requested phase (from the Next-Step Widget).
+  useEffect(() => {
+    if (!requestedPhase) return
+    if (visiblePhases.some((p) => p.key === requestedPhase)) {
+      setSelectedPhase(requestedPhase)
+    }
+  }, [requestedPhase, visiblePhases])
+
   // Scroll to the active step when the user switches phases.
   const activeCardRef = useRef<HTMLDivElement>(null)
   const isInitialPhaseMount = useRef(true)
@@ -141,6 +158,19 @@ function StepTabView(props: IProps) {
     }, 50)
     return () => clearTimeout(timer)
   }, [effectivePhase])
+
+  // Programmatic scroll triggered by Next-Step Widget "Continue" click.
+  // Uses a counter so it fires even when the requested phase hasn't changed.
+  useEffect(() => {
+    if (!scrollToActiveKey) return
+    const timer = setTimeout(() => {
+      activeCardRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      })
+    }, 100)
+    return () => clearTimeout(timer)
+  }, [scrollToActiveKey])
 
   // Expand-all / collapse-all for the currently visible phase steps.
   const allExpanded =

--- a/frontend/src/components/Journey/StepTabView.tsx
+++ b/frontend/src/components/Journey/StepTabView.tsx
@@ -133,12 +133,11 @@ function StepTabView(props: IProps) {
   }, [isPhaseComplete, nextPhaseByStepOrder, nextPhaseStarted])
 
   // Switch to the programmatically requested phase (from the Next-Step Widget).
+  // Invalid phase keys are handled by effectivePhase's fallback, so no guard needed.
   useEffect(() => {
     if (!requestedPhase) return
-    if (visiblePhases.some((p) => p.key === requestedPhase)) {
-      setSelectedPhase(requestedPhase)
-    }
-  }, [requestedPhase, visiblePhases])
+    setSelectedPhase(requestedPhase)
+  }, [requestedPhase])
 
   // Scroll to the active step when the user switches phases.
   const activeCardRef = useRef<HTMLDivElement>(null)

--- a/frontend/src/components/Journey/index.ts
+++ b/frontend/src/components/Journey/index.ts
@@ -15,6 +15,7 @@ export { JourneySummary } from "./JourneySummary"
 // Wizard components
 export { JourneyWizard } from "./JourneyWizard"
 export { LocationSelector } from "./LocationSelector"
+export { NextStepWidget } from "./NextStepWidget"
 export { PhaseIndicator } from "./PhaseIndicator"
 export { ProgressBar } from "./ProgressBar"
 export { PropertyTypeSelector } from "./PropertyTypeSelector"


### PR DESCRIPTION
## Summary

- Adds a `NextStepWidget` sticky card at the top of the journey detail page — shows the active step name, phase badge, progress (`N of M steps · X%`), and up to 2 pending tasks
- "Continue" CTA switches the phase tab to the active step's phase and smooth-scrolls to the active step card
- Widget is hidden once the ownership phase is complete (journey done)
- `StepTabView` gains `requestedPhase` + `scrollToActiveKey` props so external callers can programmatically drive phase navigation

## Test plan

- [ ] Open a journey in-progress — verify widget appears with correct step, phase, and task list
- [ ] Click "Continue" when already on the correct phase tab — verify scroll fires to active step
- [ ] Click "Continue" when on a different phase tab — verify tab switches and scroll fires
- [ ] Click "Continue" twice in a row — verify scroll fires both times (counter increments)
- [ ] Complete all ownership steps — verify widget disappears and portfolio CTA appears
- [ ] Journey with no pending tasks on active step — verify widget still shows step name without task list