### PR TITLE
feat(journey): add tailored-for-you badge on personalised steps

### DIFF
--- a/backend/app/alembic/versions/a3w4x5y6z7b8_add_is_personalised_to_journey_step.py
+++ b/backend/app/alembic/versions/a3w4x5y6z7b8_add_is_personalised_to_journey_step.py
@@ -1,0 +1,54 @@
+"""Add is_personalised to journey_step
+
+Revision ID: a3w4x5y6z7b8
+Revises: z2v3w4x5y6a7
+Create Date: 2026-05-15 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "a3w4x5y6z7b8"
+down_revision = "z2v3w4x5y6a7"
+branch_labels = None
+depends_on = None
+
+# content_key values for steps that are conditionally generated based on
+# questionnaire answers (financing type, property use, residency status).
+_CONDITIONAL_CONTENT_KEYS = (
+    "finance_check",
+    "mortgage_preapproval",
+    "mortgage_comparison",
+    "proof_of_funds",
+    "loan_commitment",
+    "rental_landlord_law",
+    "rental_yield_analysis",
+    "rental_property_management",
+    "rental_tax_strategy",
+    "rental_operations_setup",
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "journey_step",
+        sa.Column(
+            "is_personalised",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    # Backfill: mark known conditionally-generated steps as personalised.
+    op.execute(
+        sa.text(
+            "UPDATE journey_step SET is_personalised = TRUE "
+            "WHERE content_key = ANY(:keys)"
+        ).bindparams(keys=list(_CONDITIONAL_CONTENT_KEYS))
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("journey_step", "is_personalised")

--- a/backend/app/alembic/versions/f2g3h4i5j6k7_add_is_personalised_to_journey_step.py
+++ b/backend/app/alembic/versions/f2g3h4i5j6k7_add_is_personalised_to_journey_step.py
@@ -1,7 +1,7 @@
 """Add is_personalised to journey_step
 
-Revision ID: a3w4x5y6z7b8
-Revises: z2v3w4x5y6a7
+Revision ID: f2g3h4i5j6k7
+Revises: g3h4i5j6k7l8
 Create Date: 2026-05-15 10:00:00.000000
 
 """
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic
-revision = "a3w4x5y6z7b8"
-down_revision = "z2v3w4x5y6a7"
+revision = "f2g3h4i5j6k7"
+down_revision = "g3h4i5j6k7l8"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/alembic/versions/g3h4i5j6k7l8_merge_migration_heads.py
+++ b/backend/app/alembic/versions/g3h4i5j6k7l8_merge_migration_heads.py
@@ -1,0 +1,23 @@
+"""Merge migration heads
+
+Revision ID: g3h4i5j6k7l8
+Revises: d0e1f2g3h4i5, e1h2i3j4k5l6
+Create Date: 2026-05-15 10:05:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "g3h4i5j6k7l8"
+down_revision = ("d0e1f2g3h4i5", "e1h2i3j4k5l6")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -217,6 +217,13 @@ class JourneyStep(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         MutableList.as_mutable(JSONB), nullable=True
     )  # JSON array of step numbers
 
+    # Personalisation flag — True when the step was conditionally generated
+    # based on the user's questionnaire answers (e.g. mortgage-only steps,
+    # non-resident document steps). Drives the "Tailored for you" badge.
+    is_personalised = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+
     # Relationships
     journey = relationship("Journey", back_populates="steps")
     tasks = relationship(

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -194,6 +194,7 @@ class JourneyStepResponse(JourneyStepBase):
     content_key: str | None = None
     related_laws: list[str] | None = None
     estimated_costs: dict[str, Any] | None = None
+    is_personalised: bool = False
     tasks: list[JourneyTaskResponse] = []
 
 
@@ -208,6 +209,7 @@ class JourneyStepSummary(BaseModel):
     title: str
     status: StepStatus
     estimated_duration_days: int | None = None
+    is_personalised: bool = False
 
 
 # Journey schemas

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -1443,6 +1443,7 @@ def generate_journey(
             prerequisites=prerequisites,
             related_laws=template.related_laws,
             estimated_costs=step_estimated_costs,
+            is_personalised=template.conditions is not None,
         )
         session.add(step)
         session.flush()

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4432,6 +4432,11 @@ export const JourneyStepResponseSchema = {
             ],
             title: 'Estimated Costs'
         },
+        is_personalised: {
+            type: 'boolean',
+            title: 'Is Personalised',
+            default: false
+        },
         tasks: {
             items: {
                 '$ref': '#/components/schemas/JourneyTaskResponse'
@@ -4478,6 +4483,11 @@ export const JourneyStepSummarySchema = {
                 }
             ],
             title: 'Estimated Duration Days'
+        },
+        is_personalised: {
+            type: 'boolean',
+            title: 'Is Personalised',
+            default: false
         }
     },
     type: 'object',

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1283,6 +1283,7 @@ export type JourneyStepResponse = {
     estimated_costs?: ({
     [key: string]: unknown;
 } | null);
+    is_personalised?: boolean;
     tasks?: Array<JourneyTaskResponse>;
 };
 
@@ -1296,6 +1297,7 @@ export type JourneyStepSummary = {
     title: string;
     status: StepStatus;
     estimated_duration_days?: (number | null);
+    is_personalised?: boolean;
 };
 
 /**

--- a/frontend/src/components/Journey/StepCard.tsx
+++ b/frontend/src/components/Journey/StepCard.tsx
@@ -3,7 +3,7 @@
  * Collapsible journey step with status, dynamic content, and tasks
  */
 
-import { Check, ChevronRight, Circle, Clock } from "lucide-react"
+import { Check, ChevronRight, Circle, Clock, Sparkles } from "lucide-react"
 import { useState } from "react"
 
 import { JOURNEY_PHASES, PHASE_COLORS } from "@/common/constants"
@@ -16,6 +16,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { JourneyStep, StepStatus } from "@/models/journey"
 import { STEP_CONTENT_REGISTRY, StepBody } from "./StepContent/StepBody"
 
@@ -168,7 +173,20 @@ function StepCard(props: IProps) {
           <CardTitle className="min-w-0 truncate text-sm" title={step.title}>
             {step.title}
           </CardTitle>
-          <div className="ml-auto shrink-0">
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            {step.is_personalised && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-400">
+                    <Sparkles className="h-3 w-3" />
+                    For you
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={6}>
+                  This step was added based on your questionnaire answers
+                </TooltipContent>
+              </Tooltip>
+            )}
             <StatusBadge status={step.status} />
           </div>
         </div>

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -60,6 +60,8 @@ export interface JourneyStep {
   content_key?: string
   related_laws?: string
   estimated_costs?: Record<string, string>
+  /** True when this step was conditionally generated from the user's questionnaire answers. */
+  is_personalised: boolean
   tasks: JourneyTask[]
 }
 


### PR DESCRIPTION
## Summary

- Adds `is_personalised` boolean to `JourneyStep` — set to `True` at journey generation time when the step was conditionally included based on the user's questionnaire answers (financing type, property use, residency status)
- Alembic migration backfills known conditional content keys (`finance_check`, `mortgage_preapproval`, `loan_commitment`, `rental_*` steps, etc.)
- Frontend: renders a "For you" badge (sparkle icon, blue pill) in the `StepCard` header with a tooltip: _"This step was added based on your questionnaire answers"_; badge is keyboard-accessible (focusable span, tooltip shows on focus)

## Test plan

- [ ] Create a mortgage journey — verify steps `finance_check`, `mortgage_preapproval`, `mortgage_comparison`, `loan_commitment` show the "For you" badge
- [ ] Create a cash-only journey — verify `proof_of_funds` shows the badge but mortgage steps are absent
- [ ] Create a rent-out investor journey — verify rental management steps show the badge
- [ ] Verify standard unconditional steps (e.g. `property_search`, `due_diligence`) have no badge
- [ ] Tab to a "For you" badge — verify tooltip is visible on keyboard focus
- [ ] Run existing backend tests to confirm step generation and status sync are unaffected