### PR TITLE
feat(journey): categorise step tasks into actions, resources, and warnings

### DIFF
--- a/backend/app/alembic/versions/h4i5j6k7l8m9_add_task_category_to_journey_task.py
+++ b/backend/app/alembic/versions/h4i5j6k7l8m9_add_task_category_to_journey_task.py
@@ -1,0 +1,39 @@
+"""Add task_category to journey_task
+
+Revision ID: h4i5j6k7l8m9
+Revises: f2g3h4i5j6k7
+Create Date: 2026-05-15 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "h4i5j6k7l8m9"
+down_revision = "f2g3h4i5j6k7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create the PostgreSQL enum type before using it in a column
+    op.execute("CREATE TYPE taskcategory AS ENUM ('action', 'resource', 'warning')")
+    op.add_column(
+        "journey_task",
+        sa.Column(
+            "task_category",
+            sa.Enum("action", "resource", "warning", name="taskcategory", create_type=False),
+            nullable=False,
+            server_default="action",
+        ),
+    )
+    # Backfill: tasks with a resource_url are resources, not actions.
+    op.execute(
+        "UPDATE journey_task SET task_category = 'resource' WHERE resource_url IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("journey_task", "task_category")
+    op.execute("DROP TYPE taskcategory")

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -67,6 +67,14 @@ class FinancingType(str, PyEnum):
     MIXED = "mixed"
 
 
+class TaskCategory(str, PyEnum):
+    """Category of a journey task."""
+
+    ACTION = "action"
+    RESOURCE = "resource"
+    WARNING = "warning"
+
+
 # Define PostgreSQL enum types with create_type=False to prevent auto-creation
 # These will be created by Alembic migration
 _journey_type_enum = PgEnum(
@@ -102,6 +110,9 @@ _property_type_enum = PgEnum(
 )
 _financing_type_enum = PgEnum(
     "cash", "mortgage", "mixed", name="financingtype", create_type=False
+)
+_task_category_enum = PgEnum(
+    "action", "resource", "warning", name="taskcategory", create_type=False
 )
 
 
@@ -264,6 +275,14 @@ class JourneyTask(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # Optional link to external resource or document
     resource_url = Column(String(500), nullable=True)
     resource_type = Column(String(50), nullable=True)  # 'document', 'link', 'video'
+
+    # Task category — drives UI rendering in the frontend step card
+    task_category = Column(
+        _task_category_enum,
+        default=TaskCategory.ACTION.value,
+        nullable=False,
+        server_default="action",
+    )
 
     # Relationships
     step = relationship("JourneyStep", back_populates="tasks")

--- a/backend/app/schemas/journey.py
+++ b/backend/app/schemas/journey.py
@@ -12,6 +12,7 @@ from app.models.journey import (
     JourneyType,
     PropertyType,
     StepStatus,
+    TaskCategory,
 )
 
 # Market Insights schema (generated after Step 1 completion)
@@ -129,6 +130,7 @@ class JourneyTaskBase(BaseModel):
     is_required: bool = True
     resource_url: str | None = Field(default=None, max_length=500)
     resource_type: str | None = Field(default=None, max_length=50)
+    task_category: TaskCategory = TaskCategory.ACTION
 
 
 class JourneyTaskCreate(JourneyTaskBase):

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -18,6 +18,7 @@ from app.models.journey import (
     JourneyTask,
     JourneyType,
     StepStatus,
+    TaskCategory,
 )
 from app.schemas.journey import QuestionnaireAnswers
 from app.services.calculator_service import COST_DEFAULTS, STATE_RATES
@@ -1455,6 +1456,16 @@ def generate_journey(
                 task_data.get("conditions"), answers
             ):
                 continue
+            # Resolve task_category: explicit template value takes precedence,
+            # then resource_url presence implies resource, otherwise action.
+            explicit_category = task_data.get("task_category")
+            if explicit_category:
+                resolved_category = TaskCategory(explicit_category)
+            elif task_data.get("resource_url"):
+                resolved_category = TaskCategory.RESOURCE
+            else:
+                resolved_category = TaskCategory.ACTION
+
             task = JourneyTask(
                 step_id=step.id,
                 order=task_order,
@@ -1463,6 +1474,7 @@ def generate_journey(
                 description=task_data.get("description"),
                 resource_url=task_data.get("resource_url"),
                 resource_type=task_data.get("resource_type"),
+                task_category=resolved_category,
             )
             session.add(task)
             task_order += 1
@@ -1680,16 +1692,20 @@ def _sync_step_status_from_tasks(
     all_tasks_stmt = select(JourneyTask).where(JourneyTask.step_id == step.id)
     all_tasks = list(session.exec(all_tasks_stmt).all())
 
-    # Build completion map, using the in-memory state for the updated task
+    # Only action tasks count toward step completion — resource and warning
+    # tasks are informational and do not gate step progression.
+    action_tasks = [t for t in all_tasks if t.task_category == TaskCategory.ACTION]
+
+    # Build completion map using the in-memory state for the updated task.
     completed_count = 0
-    for t in all_tasks:
+    for t in action_tasks:
         is_done = (
             updated_task.is_completed if t.id == updated_task.id else t.is_completed
         )
         if is_done:
             completed_count += 1
 
-    total_tasks = len(all_tasks)
+    total_tasks = len(action_tasks)
     if total_tasks == 0:
         return
     all_complete = completed_count == total_tasks

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -14,6 +14,7 @@ from app.models.journey import (
     JourneyTask,
     PropertyType,
     StepStatus,
+    TaskCategory,
 )
 from app.schemas.journey import QuestionnaireAnswers
 from app.services.journey_service import (
@@ -836,7 +837,10 @@ class TestTailoredDocumentTasks:
 
 
 def _make_task(
-    step_id: uuid.UUID, is_completed: bool = False, task_id: uuid.UUID | None = None
+    step_id: uuid.UUID,
+    is_completed: bool = False,
+    task_id: uuid.UUID | None = None,
+    task_category: TaskCategory = TaskCategory.ACTION,
 ) -> MagicMock:
     """Create a mock JourneyTask."""
     task = MagicMock(spec=JourneyTask)
@@ -844,6 +848,7 @@ def _make_task(
     task.step_id = step_id
     task.is_completed = is_completed
     task.completed_at = datetime.now(timezone.utc) if is_completed else None
+    task.task_category = task_category
     return task
 
 
@@ -1109,6 +1114,114 @@ class TestUpdateTaskStatusSyncsStepStatus:
         )
 
         assert mock_step.status == StepStatus.NOT_STARTED
+
+
+class TestTaskCategoryGating:
+    """Tests that only action tasks count toward step completion.
+
+    Resource and warning tasks are informational — they must not gate step
+    progression regardless of their is_completed value.
+    """
+
+    def _make_step_and_journey(
+        self, step_id: uuid.UUID, step_number: int = 1
+    ) -> tuple[MagicMock, MagicMock]:
+        mock_step = MagicMock(spec=JourneyStep)
+        mock_step.id = step_id
+        mock_step.status = StepStatus.NOT_STARTED
+        mock_step.started_at = None
+        mock_step.step_number = step_number
+
+        mock_journey = MagicMock(spec=Journey)
+        mock_journey.id = uuid.uuid4()
+        mock_journey.current_step_number = step_number
+        mock_journey.completed_at = None
+
+        return mock_step, mock_journey
+
+    def _make_session(self, tasks: list[MagicMock]) -> MagicMock:
+        mock_session = MagicMock()
+        mock_session.exec.return_value.all.return_value = tasks
+        return mock_session
+
+    def test_resource_tasks_do_not_block_completion(self) -> None:
+        """A step with one action task (completed) + resource tasks completes correctly."""
+        step_id = uuid.uuid4()
+        action_task = _make_task(step_id, is_completed=True)
+        resource_task = _make_task(
+            step_id, is_completed=False, task_category=TaskCategory.RESOURCE
+        )
+        mock_step, mock_journey = self._make_step_and_journey(step_id)
+        mock_session = self._make_session([action_task, resource_task])
+
+        _sync_step_status_from_tasks(
+            session=mock_session,
+            step=mock_step,
+            updated_task=action_task,
+            journey=mock_journey,
+        )
+
+        assert mock_step.status == StepStatus.COMPLETED
+
+    def test_warning_tasks_do_not_block_completion(self) -> None:
+        """A step with one action task (completed) + warning tasks completes correctly."""
+        step_id = uuid.uuid4()
+        action_task = _make_task(step_id, is_completed=True)
+        warning_task = _make_task(
+            step_id, is_completed=False, task_category=TaskCategory.WARNING
+        )
+        mock_step, mock_journey = self._make_step_and_journey(step_id)
+        mock_session = self._make_session([action_task, warning_task])
+
+        _sync_step_status_from_tasks(
+            session=mock_session,
+            step=mock_step,
+            updated_task=action_task,
+            journey=mock_journey,
+        )
+
+        assert mock_step.status == StepStatus.COMPLETED
+
+    def test_step_with_only_resource_tasks_is_not_affected(self) -> None:
+        """A step with zero action tasks returns early — status unchanged."""
+        step_id = uuid.uuid4()
+        resource_task = _make_task(
+            step_id, is_completed=False, task_category=TaskCategory.RESOURCE
+        )
+        mock_step, mock_journey = self._make_step_and_journey(step_id)
+        mock_step.status = StepStatus.IN_PROGRESS
+        mock_session = self._make_session([resource_task])
+
+        _sync_step_status_from_tasks(
+            session=mock_session,
+            step=mock_step,
+            updated_task=resource_task,
+            journey=mock_journey,
+        )
+
+        assert mock_step.status == StepStatus.IN_PROGRESS
+
+    def test_incomplete_action_task_keeps_step_in_progress(self) -> None:
+        """Action task unchecked while resource task exists — step stays in_progress."""
+        step_id = uuid.uuid4()
+        action_task = _make_task(step_id, is_completed=True)
+        action_task2 = _make_task(step_id, is_completed=False)
+        resource_task = _make_task(
+            step_id, is_completed=False, task_category=TaskCategory.RESOURCE
+        )
+        mock_step, mock_journey = self._make_step_and_journey(step_id)
+        mock_step.status = StepStatus.IN_PROGRESS
+        mock_step.started_at = datetime.now(timezone.utc)
+        mock_session = self._make_session([action_task, action_task2, resource_task])
+
+        _sync_step_status_from_tasks(
+            session=mock_session,
+            step=mock_step,
+            updated_task=action_task2,
+            journey=mock_journey,
+        )
+
+        assert mock_step.status == StepStatus.IN_PROGRESS
 
 
 class TestStep4StatusTransitions:

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4555,6 +4555,10 @@ export const JourneyTaskResponseSchema = {
             ],
             title: 'Resource Type'
         },
+        task_category: {
+            '$ref': '#/components/schemas/TaskCategory',
+            default: 'action'
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -10133,6 +10137,13 @@ export const SupportedLanguagesResponseSchema = {
     required: ['languages'],
     title: 'SupportedLanguagesResponse',
     description: 'Response with list of supported languages.'
+} as const;
+
+export const TaskCategorySchema = {
+    type: 'string',
+    enum: ['action', 'resource', 'warning'],
+    title: 'TaskCategory',
+    description: 'Category of a journey task.'
 } as const;
 
 export const TokenSchema = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1316,6 +1316,7 @@ export type JourneyTaskResponse = {
     is_required?: boolean;
     resource_url?: (string | null);
     resource_type?: (string | null);
+    task_category?: TaskCategory;
     id: string;
     order: number;
     is_completed: boolean;
@@ -2686,6 +2687,11 @@ export type SupportedLanguageInfo = {
 export type SupportedLanguagesResponse = {
     languages: Array<SupportedLanguageInfo>;
 };
+
+/**
+ * Category of a journey task.
+ */
+export type TaskCategory = 'action' | 'resource' | 'warning';
 
 export type Token = {
     access_token: string;

--- a/frontend/src/components/Journey/ResourceCard.tsx
+++ b/frontend/src/components/Journey/ResourceCard.tsx
@@ -1,0 +1,52 @@
+/**
+ * Resource Card Component
+ * Renders a journey task categorised as "resource" — a clickable external link,
+ * not a checkbox. Resources are informational and do not count toward step completion.
+ */
+
+import { ExternalLink } from "lucide-react"
+
+import { cn } from "@/common/utils"
+import type { JourneyTask } from "@/models/journey"
+
+interface IProps {
+  task: JourneyTask
+  className?: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. External resource link card. */
+function ResourceCard(props: Readonly<IProps>) {
+  const { task, className } = props
+
+  return (
+    <a
+      href={task.resource_url ?? "#"}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "flex items-center gap-3 rounded-lg border bg-background p-3 text-sm transition-colors hover:bg-muted/30",
+        className,
+      )}
+    >
+      <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <span className="font-medium">{task.title}</span>
+        {task.description && (
+          <span className="mt-0.5 block text-xs text-muted-foreground">
+            {task.description}
+          </span>
+        )}
+      </div>
+    </a>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ResourceCard }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -16,7 +16,9 @@ import type {
 } from "@/models/journey"
 import { useJourneyContext } from "../JourneyContext"
 import { ProgressBar } from "../ProgressBar"
+import { ResourceCard } from "../ResourceCard"
 import { TaskCheckbox } from "../TaskCheckbox"
+import { WarningCallout } from "../WarningCallout"
 import { FinanceCheck } from "./FinanceCheck"
 import { MarketInsights } from "./MarketInsights"
 import { MortgageComparison } from "./MortgageComparison"
@@ -105,7 +107,7 @@ const STEP_CONTENT_REGISTRY: Record<
                               Components
 ******************************************************************************/
 
-/** Inline task list with progress for a step. */
+/** Inline task list with progress for a step, split by task category. */
 function StepTasks(props: {
   tasks: JourneyTask[]
   stepId: string
@@ -114,8 +116,12 @@ function StepTasks(props: {
 }) {
   const { tasks, stepId, stepStatus, onToggle } = props
 
-  const completedTasks = tasks.filter((t) => t.is_completed).length
-  const totalTasks = tasks.length
+  const actionTasks = tasks.filter((t) => t.task_category === "action")
+  const resourceTasks = tasks.filter((t) => t.task_category === "resource")
+  const warningTasks = tasks.filter((t) => t.task_category === "warning")
+
+  const completedTasks = actionTasks.filter((t) => t.is_completed).length
+  const totalTasks = actionTasks.length
   const progressPercent =
     totalTasks > 0 ? (completedTasks / totalTasks) * 100 : 0
   const isDisabled = stepStatus === "skipped"
@@ -126,25 +132,44 @@ function StepTasks(props: {
 
   return (
     <div className="space-y-3">
-      <div className="space-y-2">
-        <div className="flex items-center justify-between text-sm">
-          <span className="font-medium text-muted-foreground">Tasks</span>
-          <span className="text-sm text-muted-foreground">
-            {completedTasks} of {totalTasks}
-          </span>
+      {warningTasks.length > 0 && <WarningCallout tasks={warningTasks} />}
+
+      {actionTasks.length > 0 && (
+        <div className="space-y-2">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium text-muted-foreground">Tasks</span>
+              <span className="text-sm text-muted-foreground">
+                {completedTasks} of {totalTasks}
+              </span>
+            </div>
+            <ProgressBar value={progressPercent} size="sm" />
+          </div>
+          <div className="space-y-2">
+            {actionTasks.map((task) => (
+              <TaskCheckbox
+                key={task.id}
+                task={task}
+                onToggle={handleToggle}
+                disabled={isDisabled}
+              />
+            ))}
+          </div>
         </div>
-        <ProgressBar value={progressPercent} size="sm" />
-      </div>
-      <div className="space-y-2">
-        {tasks.map((task) => (
-          <TaskCheckbox
-            key={task.id}
-            task={task}
-            onToggle={handleToggle}
-            disabled={isDisabled}
-          />
-        ))}
-      </div>
+      )}
+
+      {resourceTasks.length > 0 && (
+        <div className="space-y-2">
+          <span className="text-sm font-medium text-muted-foreground">
+            Resources
+          </span>
+          <div className="space-y-1.5">
+            {resourceTasks.map((task) => (
+              <ResourceCard key={task.id} task={task} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -107,13 +107,15 @@ const STEP_CONTENT_REGISTRY: Record<
                               Components
 ******************************************************************************/
 
-/** Inline task list with progress for a step, split by task category. */
-function StepTasks(props: {
+interface IStepTasksProps {
   tasks: JourneyTask[]
   stepId: string
   stepStatus: StepStatus
   onToggle?: (stepId: string, taskId: string, isCompleted: boolean) => void
-}) {
+}
+
+/** Inline task list with progress for a step, split by task category. */
+function StepTasks(props: Readonly<IStepTasksProps>) {
   const { tasks, stepId, stepStatus, onToggle } = props
 
   const actionTasks = tasks.filter((t) => t.task_category === "action")

--- a/frontend/src/components/Journey/WarningCallout.tsx
+++ b/frontend/src/components/Journey/WarningCallout.tsx
@@ -1,0 +1,62 @@
+/**
+ * Warning Callout Component
+ * Renders journey tasks categorised as "warning" — amber callout blocks
+ * that surface important caveats or risks. Not interactive (no checkbox).
+ */
+
+import { AlertTriangle } from "lucide-react"
+
+import { cn } from "@/common/utils"
+import type { JourneyTask } from "@/models/journey"
+
+interface IProps {
+  tasks: JourneyTask[]
+  className?: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Default component. Amber callout block listing warning tasks for a step. */
+function WarningCallout(props: Readonly<IProps>) {
+  const { tasks, className } = props
+
+  if (tasks.length === 0) return null
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/30",
+        className,
+      )}
+    >
+      <div className="mb-2 flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <span className="text-sm font-medium text-amber-800 dark:text-amber-300">
+          Important
+        </span>
+      </div>
+      <ul className="space-y-1.5">
+        {tasks.map((task) => (
+          <li key={task.id}>
+            <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+              {task.title}
+            </p>
+            {task.description && (
+              <p className="mt-0.5 text-xs text-amber-700 dark:text-amber-400">
+                {task.description}
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { WarningCallout }

--- a/frontend/src/models/journey.ts
+++ b/frontend/src/models/journey.ts
@@ -35,6 +35,8 @@ export type ResidencyStatus =
   | "non_eu_resident"
   | "non_resident"
 
+export type TaskCategory = "action" | "resource" | "warning"
+
 export interface JourneyTask {
   id: string
   order: number
@@ -45,6 +47,7 @@ export interface JourneyTask {
   completed_at?: string
   resource_url?: string
   resource_type?: string
+  task_category: TaskCategory
 }
 
 export interface JourneyStep {


### PR DESCRIPTION
## Summary

- Adds a `task_category` enum (`action` / `resource` / `warning`) to the `JourneyTask` model with an Alembic migration and backfill
- Step completion progress now counts only `action` tasks — resources and warnings no longer block step completion
- Introduces `ResourceCard` (external link) and `WarningCallout` (amber callout) frontend components
- `StepBody` splits tasks by category: warnings displayed first, then action checkboxes with progress bar, then resource links

## Test plan

- [ ] Existing steps with all-action tasks render unchanged
- [ ] Steps with resource tasks show `ResourceCard` links below the action task list; progress bar ignores them
- [ ] Steps with warning tasks show amber `WarningCallout` above the action task list
- [ ] Toggling action tasks updates the progress bar; resource/warning tasks have no checkbox
- [ ] Migration backfills `task_category = 'resource'` for any task with a `resource_url`
- [ ] `alembic upgrade head` succeeds from a fresh DB
- [ ] `alembic downgrade -1` correctly drops the column and enum type