### PR TITLE
feat(journey): consolidate buying journey to ~18 steps (v2)

### DIFF
--- a/backend/app/alembic/versions/i5j6k7l8m9n0_add_journey_version_to_journey.py
+++ b/backend/app/alembic/versions/i5j6k7l8m9n0_add_journey_version_to_journey.py
@@ -1,0 +1,36 @@
+"""Add journey_version to journey
+
+Revision ID: i5j6k7l8m9n0
+Revises: h4i5j6k7l8m9
+Create Date: 2026-05-15 13:00:00.000000
+
+Existing journeys retain journey_version=1 (legacy STEP_TEMPLATES).
+New buying journeys are created with journey_version=2 (BUYING_STEP_TEMPLATES_V2,
+consolidated from ~28 templates to ~18).  The column is additive-only — no
+existing step data is modified.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "i5j6k7l8m9n0"
+down_revision = "h4i5j6k7l8m9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "journey",
+        sa.Column(
+            "journey_version",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("journey", "journey_version")

--- a/backend/app/models/journey.py
+++ b/backend/app/models/journey.py
@@ -166,6 +166,10 @@ class Journey(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # Market insights (generated after Step 1 completion)
     market_insights = Column(MutableDict.as_mutable(JSONB), nullable=True)
 
+    # Step template version — v1 uses STEP_TEMPLATES, v2 uses BUYING_STEP_TEMPLATES_V2.
+    # Existing journeys remain on v1; new buying journeys are created at v2.
+    journey_version = Column(Integer, default=1, nullable=False, server_default="1")
+
     # Progress tracking
     started_at = Column(DateTime(timezone=True), nullable=True)
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -980,6 +980,7 @@ BUYING_STEP_TEMPLATES_V2: list[StepTemplate] = [
         ],
         related_laws=["BGB §488-505 (Darlehensvertrag)"],
     ),
+    # Mutually exclusive with "Secure Your Financing" above — only one step 4 is generated per journey.
     StepTemplate(
         step_number=4,
         phase=JourneyPhase.PREPARATION,
@@ -2110,6 +2111,10 @@ def generate_journey(
             continue
 
         current_step += 1
+        assert template.step_number not in step_number_map, (
+            f"Duplicate template step_number {template.step_number} — "
+            "only one branch should be included per journey"
+        )
         step_number_map[template.step_number] = current_step
 
         # Map prerequisites to new step numbers

--- a/backend/app/services/journey_service.py
+++ b/backend/app/services/journey_service.py
@@ -822,6 +822,694 @@ STEP_TEMPLATES: list[StepTemplate] = [
     ),
 ]
 
+# ─────────────────────────────────────────────────────────────────────────────
+# V2 buying journey — consolidated from ~28 templates down to ~18.
+# step_number values are sequential (1-18) and serve as stable prerequisite
+# references within this list.  Existing v1 journeys are not affected.
+# ─────────────────────────────────────────────────────────────────────────────
+# Task order in the "buying_costs" step MUST match _personalize_buying_costs():
+# index 0 = transfer tax, 1 = notary, 2 = land registry, 3 = agent commission.
+BUYING_STEP_TEMPLATES_V2: list[StepTemplate] = [
+    # RESEARCH PHASE
+    StepTemplate(
+        step_number=1,
+        phase=JourneyPhase.RESEARCH,
+        title="Set Your Goals & Explore the Market",
+        description="Define what you're looking for in a property and understand German market prices and trends.",
+        estimated_duration_days=12,
+        content_key="property_goals_and_market",
+        tasks=[
+            # Goals tasks (from old step 1)
+            {"title": "List your must-have features", "is_required": True},
+            {"title": "Set your budget range", "is_required": True},
+            {"title": "Choose preferred locations", "is_required": True},
+            {"title": "Decide on property type", "is_required": False},
+            # Market tasks (from old step 2)
+            {
+                "title": "Research average prices in your target area",
+                "is_required": True,
+            },
+            {"title": "Understand price per sqm trends", "is_required": True},
+            {
+                "title": "Learn about Makler (agent) fees in your state",
+                "is_required": True,
+            },
+            {
+                "title": "Compare Grunderwerbsteuer (transfer tax) rates across states",
+                "is_required": True,
+            },
+            {
+                "title": "Research neighborhood amenities and infrastructure",
+                "is_required": False,
+            },
+        ],
+        related_laws=["BGB §433-453 (Kaufvertrag)"],
+    ),
+    StepTemplate(
+        step_number=2,
+        phase=JourneyPhase.RESEARCH,
+        title="Find & Evaluate Properties",
+        description="Search for properties matching your criteria, attend viewings, and assess value.",
+        estimated_duration_days=37,
+        content_key="find_and_evaluate_property",
+        prerequisites=[1],
+        tasks=[
+            # Search tasks (from old step 3)
+            {"title": "Set up alerts on ImmoScout24, Immowelt", "is_required": True},
+            {"title": "Contact local Makler (agents)", "is_required": False},
+            {"title": "Schedule and attend viewings", "is_required": True},
+            {"title": "Take notes and photos at viewings", "is_required": True},
+            {
+                "title": "Request the property exposé from the agent",
+                "is_required": True,
+            },
+            {
+                "title": "Check the Grundbuchauszug (land registry extract)",
+                "is_required": True,
+            },
+            {
+                "title": "Review the Energieausweis (energy certificate)",
+                "is_required": True,
+            },
+            {
+                "title": "Verify building permits and planning permissions",
+                "is_required": False,
+            },
+            {
+                "title": "Check for encumbrances or easements on the property",
+                "is_required": False,
+            },
+            {
+                "title": "Consider commissioning a building survey",
+                "is_required": False,
+            },
+            # Evaluation tasks (from old step 4)
+            {"title": "Run evaluation calculator", "is_required": True},
+            {"title": "Review cashflow analysis", "is_required": True},
+            {"title": "Understand cost breakdown", "is_required": True},
+            {"title": "Compare with market averages", "is_required": True},
+        ],
+        related_laws=[
+            "GBO (Grundbuchordnung)",
+            "EnEV (Energieeinsparverordnung)",
+        ],
+    ),
+    StepTemplate(
+        step_number=3,
+        phase=JourneyPhase.RESEARCH,
+        title="Learn About Buying Costs",
+        description="Understand all the additional costs beyond the purchase price.",
+        estimated_duration_days=3,
+        content_key="buying_costs",
+        prerequisites=[2],
+        tasks=[
+            # Task order matters: _personalize_buying_costs() accesses by index
+            # (0=transfer tax, 1=notary, 2=land registry, 3=agent commission).
+            {
+                "title": "Calculate Grunderwerbsteuer (property transfer tax)",
+                "is_required": True,
+            },
+            {"title": "Estimate notary fees (1.5-2%)", "is_required": True},
+            {"title": "Factor in land registry fees (0.5%)", "is_required": True},
+            {
+                "title": "Budget for agent commission if applicable",
+                "is_required": False,
+            },
+        ],
+        estimated_costs={
+            "grunderwerbsteuer": "3.5-6.5% (varies by state)",
+            "notary_fees": "1.5-2%",
+            "land_registry": "0.5%",
+            "agent_commission": "3-7% (if applicable)",
+        },
+    ),
+    # PREPARATION PHASE
+    StepTemplate(
+        step_number=4,
+        phase=JourneyPhase.PREPARATION,
+        title="Secure Your Financing",
+        description="Assess your finances, obtain pre-approval, and compare mortgage offers.",
+        estimated_duration_days=28,
+        content_key="secure_financing",
+        prerequisites=[3],
+        conditions={"financing_type": ["mortgage", "mixed"]},
+        tasks=[
+            # Finance check tasks (from old step 6)
+            {"title": "Calculate your available savings", "is_required": True},
+            {"title": "Review your monthly income and expenses", "is_required": True},
+            {"title": "Check your SCHUFA credit score", "is_required": True},
+            {
+                "title": "Gather salary statements (last 3 months)",
+                "is_required": True,
+            },
+            # Pre-approval tasks (from old step 7)
+            {
+                "title": "Compare mortgage offers from multiple banks",
+                "is_required": True,
+            },
+            {"title": "Submit mortgage application", "is_required": True},
+            {
+                "title": "Receive Finanzierungsbestätigung (financing confirmation)",
+                "is_required": True,
+            },
+            # Comparison tasks (from old step 8)
+            {"title": "Compare interest rates", "is_required": True},
+            {"title": "Review loan terms", "is_required": True},
+            {"title": "Understand application requirements", "is_required": True},
+            {"title": "Prepare application documents", "is_required": True},
+        ],
+        related_laws=["BGB §488-505 (Darlehensvertrag)"],
+    ),
+    StepTemplate(
+        step_number=4,
+        phase=JourneyPhase.PREPARATION,
+        title="Prepare Proof of Funds",
+        description="As a cash buyer, prove you have the funds available and plan your transfer.",
+        estimated_duration_days=7,
+        content_key="proof_of_funds",
+        prerequisites=[3],
+        conditions={"financing_type": ["cash"]},
+        tasks=[
+            {
+                "title": "Gather recent bank statements (last 3-6 months)",
+                "is_required": True,
+            },
+            {
+                "title": "Request a proof of funds letter from your bank",
+                "is_required": True,
+            },
+            {
+                "title": "Open a German bank account if you don't have one",
+                "is_required": True,
+            },
+            {
+                "title": "Plan your funds transfer (exchange rates, fees, timing)",
+                "is_required": True,
+            },
+        ],
+        related_laws=[
+            "GwG §10-11 (Sorgfaltspflichten — Anti-money laundering due diligence)"
+        ],
+    ),
+    StepTemplate(
+        step_number=5,
+        phase=JourneyPhase.PREPARATION,
+        title="Prepare Required Documents",
+        description="Gather all documents needed for the property purchase, tailored to your situation.",
+        estimated_duration_days=7,
+        content_key="documents_prep",
+        prerequisites=[3],
+        tasks=[
+            {"title": "Obtain proof of identity (passport/ID)", "is_required": True},
+            {"title": "Get proof of address in Germany", "is_required": True},
+            {"title": "Prepare recent bank statements", "is_required": True},
+            {
+                "title": "Get apostilled or translated copies of personal documents",
+                "is_required": True,
+                "conditions": {"has_german_residency": False},
+            },
+            {
+                "title": "Obtain proof of legal residency or visa documentation",
+                "is_required": True,
+                "conditions": {"has_german_residency": False},
+            },
+            {
+                "title": "Gather salary statements and employment contract",
+                "is_required": True,
+                "conditions": {"financing_type": ["mortgage", "mixed"]},
+            },
+            {
+                "title": "Request your SCHUFA credit report",
+                "is_required": True,
+                "conditions": {"financing_type": ["mortgage", "mixed"]},
+            },
+        ],
+    ),
+    # RENTAL INVESTOR RESEARCH STEPS (conditional on property_use = rent_out)
+    StepTemplate(
+        step_number=6,
+        phase=JourneyPhase.RENTAL_SETUP,
+        title="Understand Landlord Obligations",
+        description="Learn about German landlord duties, tenant protections, and rental regulations.",
+        estimated_duration_days=5,
+        content_key="rental_landlord_law",
+        prerequisites=[1],
+        conditions={"property_use": ["rent_out"]},
+        tasks=[
+            {
+                "title": "Study BGB Mietrecht (§535-580a) tenant protection basics",
+                "is_required": True,
+            },
+            {
+                "title": "Understand Mietpreisbremse (rent control) rules in your target area",
+                "is_required": True,
+            },
+            {
+                "title": "Learn Kaution (deposit) regulations — max 3 months' cold rent",
+                "is_required": True,
+            },
+            {
+                "title": "Review Kündigungsschutz (eviction protection) requirements",
+                "is_required": True,
+            },
+            {
+                "title": "Check local Zweckentfremdungsverbot (prohibition of misuse) rules",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "BGB §535-580a (Mietrecht)",
+            "MietpreisbremseVO (Rent Control Ordinance)",
+        ],
+    ),
+    StepTemplate(
+        step_number=7,
+        phase=JourneyPhase.RENTAL_SETUP,
+        title="Analyze Rental Yield",
+        description="Calculate expected rental returns and assess the investment viability.",
+        estimated_duration_days=5,
+        content_key="rental_yield_analysis",
+        prerequisites=[2],
+        conditions={"property_use": ["rent_out"]},
+        tasks=[
+            {
+                "title": "Look up local Mietspiegel (rent index) for your target area",
+                "is_required": True,
+            },
+            {
+                "title": "Calculate gross Mietrendite (rental yield) for the property",
+                "is_required": True,
+            },
+            {
+                "title": "Estimate net yield after costs (Hausgeld, maintenance, vacancy)",
+                "is_required": True,
+            },
+            {
+                "title": "Compare yields with market averages using the ROI calculator",
+                "is_required": True,
+            },
+            {
+                "title": "Research comparable rental listings in the neighborhood",
+                "is_required": False,
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=8,
+        phase=JourneyPhase.OWNERSHIP,
+        title="Plan Property Management",
+        description="Decide between self-management and hiring a Hausverwaltung.",
+        estimated_duration_days=7,
+        content_key="rental_property_management",
+        prerequisites=[3],
+        conditions={"property_use": ["rent_out"]},
+        tasks=[
+            {
+                "title": "Compare self-management vs Hausverwaltung (property management agency)",
+                "is_required": True,
+            },
+            {
+                "title": "Get quotes from local Hausverwaltung companies (typically 20-30 EUR/unit/month)",
+                "is_required": True,
+            },
+            {
+                "title": "Understand WEG-Verwaltung vs Mietverwaltung responsibilities",
+                "is_required": True,
+            },
+            {
+                "title": "Plan for maintenance reserve (Instandhaltungsrücklage)",
+                "is_required": False,
+            },
+        ],
+    ),
+    # BUYING PHASE
+    StepTemplate(
+        step_number=9,
+        phase=JourneyPhase.BUYING,
+        title="Inspect, Evaluate & Make an Offer",
+        description="Complete due diligence on your chosen property and submit your purchase offer.",
+        estimated_duration_days=21,
+        content_key="due_diligence_and_offer",
+        prerequisites=[2],
+        tasks=[
+            # Due diligence tasks (from old step 10)
+            {
+                "title": "Review the property exposé",
+                "is_required": True,
+            },
+            {
+                "title": "Request Grundbuchauszug (land registry extract)",
+                "is_required": True,
+            },
+            {
+                "title": "Review Energieausweis (energy certificate)",
+                "is_required": True,
+            },
+            {"title": "Check for encumbrances or easements", "is_required": True},
+            {"title": "Verify building permits and compliance", "is_required": True},
+            {"title": "Consider hiring a property surveyor", "is_required": False},
+            {
+                "title": "Review HOA documents (Teilungserklärung)",
+                "is_required": False,
+            },
+            {
+                "title": "Consider hiring a real estate lawyer (Immobilienanwalt)",
+                "is_required": False,
+            },
+            # Offer tasks (from old step 11)
+            {"title": "Determine your offer price", "is_required": True},
+            {"title": "Submit written offer (Kaufangebot)", "is_required": True},
+            {"title": "Negotiate terms if needed", "is_required": False},
+            {"title": "Receive seller acceptance", "is_required": True},
+        ],
+        related_laws=[
+            "GBO (Grundbuchordnung)",
+            "EnEV (Energieeinsparverordnung)",
+        ],
+    ),
+    StepTemplate(
+        step_number=10,
+        phase=JourneyPhase.BUYING,
+        title="Prepare Rental Tax Strategy",
+        description="Understand tax obligations for rental income in Germany.",
+        estimated_duration_days=7,
+        content_key="rental_tax_strategy",
+        prerequisites=[9],
+        conditions={"property_use": ["rent_out"]},
+        tasks=[
+            {
+                "title": "Learn about Anlage V (income from renting) tax filing",
+                "is_required": True,
+            },
+            {
+                "title": "Identify deductible expenses (mortgage interest, repairs, Hausverwaltung fees)",
+                "is_required": True,
+            },
+            {
+                "title": "Understand AfA (Absetzung für Abnutzung) — 2% linear depreciation over 50 years",
+                "is_required": True,
+            },
+            {
+                "title": "Consider consulting a Steuerberater (tax advisor) for rental income",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "EStG §21 (Einkünfte aus Vermietung und Verpachtung)",
+            "EStG §7 (AfA — Absetzung für Abnutzung)",
+        ],
+    ),
+    StepTemplate(
+        step_number=11,
+        phase=JourneyPhase.BUYING,
+        title="Notary Selection & Contract Review",
+        description="Choose a notary and carefully review the Kaufvertrag before signing.",
+        estimated_duration_days=21,
+        content_key="notary_and_contract",
+        prerequisites=[9],
+        tasks=[
+            # Notary selection tasks (from old step 12)
+            {"title": "Research local notaries", "is_required": True},
+            {"title": "Schedule appointment", "is_required": True},
+            {"title": "Provide required documents to notary", "is_required": True},
+            # Contract review tasks (from old step 13)
+            {"title": "Receive draft Kaufvertrag from notary", "is_required": True},
+            {"title": "Review all terms and conditions", "is_required": True},
+            {"title": "Clarify any questions with notary", "is_required": True},
+            {
+                "title": "Consider professional contract review",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "BeurkG (Beurkundungsgesetz)",
+            "BNotO (Bundesnotarordnung)",
+            "BGB §311b (Formvorschriften)",
+        ],
+    ),
+    StepTemplate(
+        step_number=12,
+        phase=JourneyPhase.BUYING,
+        title="Secure Final Loan Commitment",
+        description="Submit the purchase contract to your bank and receive the binding Darlehenszusage.",
+        estimated_duration_days=14,
+        content_key="loan_commitment",
+        prerequisites=[11],
+        conditions={"financing_type": ["mortgage", "mixed"]},
+        tasks=[
+            {
+                "title": "Submit the purchase contract draft to your bank",
+                "is_required": True,
+            },
+            {
+                "title": "Complete any remaining loan application documents",
+                "is_required": True,
+            },
+            {
+                "title": "Receive the formal loan commitment (Darlehenszusage)",
+                "is_required": True,
+            },
+            {
+                "title": "Review and sign the loan agreement (Darlehensvertrag)",
+                "is_required": True,
+            },
+        ],
+        related_laws=[
+            "BGB §488-505 (Darlehensvertrag)",
+            "BGB §492 (Schriftform bei Verbraucherdarlehen)",
+        ],
+    ),
+    StepTemplate(
+        step_number=13,
+        phase=JourneyPhase.BUYING,
+        title="Sign at the Notary",
+        description="Attend the notary appointment and sign the purchase contract.",
+        estimated_duration_days=1,
+        content_key="notary_signing",
+        # prerequisite 12 is conditional (mortgage/mixed) — resolved at generation time
+        prerequisites=[11, 12],
+        tasks=[
+            {"title": "Bring valid ID to appointment", "is_required": True},
+            {"title": "Listen to full contract reading", "is_required": True},
+            {"title": "Sign the Kaufvertrag", "is_required": True},
+            {"title": "Receive notarized copies", "is_required": True},
+        ],
+    ),
+    # CLOSING PHASE
+    StepTemplate(
+        step_number=14,
+        phase=JourneyPhase.CLOSING,
+        title="Complete Payment & Transfer Tax",
+        description="Transfer the purchase price and pay the Grunderwerbsteuer.",
+        estimated_duration_days=44,
+        content_key="payment_and_transfer_tax",
+        prerequisites=[13],
+        tasks=[
+            # Payment tasks (from old step 15)
+            {
+                "title": "Wait for Auflassungsvormerkung (priority notice)",
+                "is_required": True,
+            },
+            {"title": "Receive payment request from notary", "is_required": True},
+            {"title": "Transfer purchase price", "is_required": True},
+            {"title": "Confirm receipt with notary", "is_required": True},
+            # Transfer tax tasks (from old step 16)
+            {"title": "Receive tax assessment from Finanzamt", "is_required": True},
+            {"title": "Pay Grunderwerbsteuer", "is_required": True},
+            {
+                "title": "Receive Unbedenklichkeitsbescheinigung (tax clearance)",
+                "is_required": True,
+            },
+        ],
+        related_laws=[
+            "BGB §925 (Auflassung)",
+            "GrEStG (Grunderwerbsteuergesetz)",
+        ],
+    ),
+    StepTemplate(
+        step_number=15,
+        phase=JourneyPhase.CLOSING,
+        title="Ownership Transfer",
+        description="Complete the transfer and receive the keys.",
+        estimated_duration_days=30,
+        content_key="ownership_transfer",
+        prerequisites=[14],
+        tasks=[
+            {"title": "Notary submits for land registry update", "is_required": True},
+            {"title": "Receive updated Grundbuchauszug", "is_required": True},
+            {"title": "Collect keys from seller", "is_required": True},
+            {
+                "title": "Arrange utility transfer with seller (Übergabe)",
+                "is_required": True,
+            },
+        ],
+        related_laws=["GBO §13 (Eintragungsgrundsatz)"],
+    ),
+    # OWNERSHIP PHASE
+    StepTemplate(
+        step_number=16,
+        phase=JourneyPhase.OWNERSHIP,
+        title="Register Property & Arrange Insurance",
+        description="Finalize ownership records and secure essential insurance coverage.",
+        estimated_duration_days=12,
+        content_key="registration_and_insurance",
+        prerequisites=[15],
+        tasks=[
+            # Registration tasks (from old step 25)
+            {
+                "title": "Confirm Grundbuch (land register) transfer is complete with notary",
+                "is_required": True,
+            },
+            {
+                "title": "Obtain all property keys and complete Übergabeprotokoll (handover protocol)",
+                "is_required": True,
+            },
+            {
+                "title": "Transfer utilities (electricity, gas, water, internet) to your name",
+                "is_required": True,
+            },
+            {
+                "title": "Register new address at Bürgeramt (Anmeldung)",
+                "is_required": True,
+                "conditions": {"property_use": ["live_in"]},
+            },
+            {
+                "title": "Set up mail forwarding (Nachsendeauftrag) via Deutsche Post",
+                "is_required": False,
+            },
+            # Insurance tasks (from old step 26)
+            {
+                "title": "Arrange Wohngebäudeversicherung (building insurance)",
+                "is_required": True,
+            },
+            {
+                "title": "Consider Haus- und Grundbesitzerhaftpflicht (property liability insurance)",
+                "is_required": True,
+            },
+            {
+                "title": "Evaluate Elementarschadenversicherung (natural disaster) coverage for your region",
+                "is_required": False,
+            },
+            {
+                "title": "Set up Hausratversicherung (contents insurance)",
+                "is_required": True,
+                "conditions": {"property_use": ["live_in"]},
+            },
+            {
+                "title": "Verify WEG building insurance policy covers your unit",
+                "is_required": False,
+                "conditions": {"property_type": ["apartment"]},
+            },
+        ],
+    ),
+    StepTemplate(
+        step_number=17,
+        phase=JourneyPhase.OWNERSHIP,
+        title="Set Up Property Management & Finance",
+        description="Establish ongoing management and set up property tax payments.",
+        estimated_duration_days=12,
+        content_key="management_and_finance_setup",
+        prerequisites=[16],
+        tasks=[
+            # Management tasks (from old step 27)
+            {
+                "title": "Contact WEG-Verwaltung and register as new owner",
+                "is_required": True,
+                "conditions": {"property_type": ["apartment"]},
+            },
+            {
+                "title": "Set up Hausgeld (condo fees) payment via Dauerauftrag",
+                "is_required": True,
+                "conditions": {"property_type": ["apartment"]},
+            },
+            {
+                "title": "Review Teilungserklärung and Hausordnung (house rules)",
+                "is_required": False,
+                "conditions": {"property_type": ["apartment"]},
+            },
+            {
+                "title": "Plan annual maintenance budget (Instandhaltungsrücklage)",
+                "is_required": True,
+                "conditions": {"property_type": ["house"]},
+            },
+            {
+                "title": "Identify local tradespeople for repairs (plumber, electrician, heating)",
+                "is_required": False,
+                "conditions": {"property_type": ["house"]},
+            },
+            {
+                "title": "Register for waste collection (Müllabfuhr) service",
+                "is_required": True,
+            },
+            {
+                "title": "Schedule heating system inspection (Heizungswartung)",
+                "is_required": False,
+            },
+            # Finance tasks (from old step 28)
+            {
+                "title": "Register for Grundsteuer (property tax) at local Finanzamt",
+                "is_required": True,
+            },
+            {
+                "title": "Set up Grundsteuer payment via Dauerauftrag (quarterly or annual)",
+                "is_required": True,
+            },
+            {
+                "title": "Track mortgage payments and request annual interest statement",
+                "is_required": True,
+                "conditions": {"financing_type": ["mortgage", "mixed"]},
+            },
+            {
+                "title": "Prepare for Anlage V rental income tax filing",
+                "is_required": True,
+                "conditions": {"property_use": ["rent_out"]},
+            },
+            {
+                "title": "Keep records of all property expenses for tax deduction",
+                "is_required": True,
+            },
+        ],
+    ),
+    # RENTAL SETUP (rental investors only)
+    StepTemplate(
+        step_number=18,
+        phase=JourneyPhase.RENTAL_SETUP,
+        title="Set Up Rental Operations",
+        description="Prepare everything needed to start renting: lease template, tenant screening, and utility accounting.",
+        estimated_duration_days=14,
+        content_key="rental_operations_setup",
+        prerequisites=[15],
+        conditions={"property_use": ["rent_out"]},
+        tasks=[
+            {
+                "title": "Prepare a Mietvertrag (lease agreement) using a standard template",
+                "is_required": True,
+            },
+            {
+                "title": "Set up tenant screening process (SCHUFA check, income verification)",
+                "is_required": True,
+            },
+            {
+                "title": "Plan Nebenkostenabrechnung (utility cost accounting) for tenants",
+                "is_required": True,
+            },
+            {
+                "title": "Arrange landlord insurance (Haus- und Grundbesitzerhaftpflicht)",
+                "is_required": True,
+            },
+            {
+                "title": "Create a Wohnungsübergabeprotokoll (handover protocol) template",
+                "is_required": False,
+            },
+        ],
+        related_laws=[
+            "BGB §535 (Mietvertrag)",
+            "BetrKV (Betriebskostenverordnung)",
+            "HeizkostenV (Heizkostenverordnung)",
+        ],
+    ),
+]
+
 # Step templates for the tenant rental journey (apartment search → move-in).
 RENTAL_STEP_TEMPLATES: list[StepTemplate] = [
     # RENTAL_SEARCH phase
@@ -1388,6 +2076,7 @@ def generate_journey(
             target_purchase_date=answers.target_purchase_date,
             property_use=answers.property_use,
             started_at=datetime.now(timezone.utc),
+            journey_version=2,
             property_goals={
                 "preferred_property_type": answers.property_type.value
                 if answers.property_type
@@ -1400,8 +2089,17 @@ def generate_journey(
     session.add(journey)
     session.flush()  # Get journey ID
 
-    # Select template list based on journey type
-    templates = RENTAL_STEP_TEMPLATES if is_rental else STEP_TEMPLATES
+    # Select template list based on journey type and version.
+    # Rental journeys always use RENTAL_STEP_TEMPLATES.
+    # New buying journeys (v2) use the consolidated BUYING_STEP_TEMPLATES_V2.
+    # Existing buying journeys (v1, journey_version=1) keep the legacy STEP_TEMPLATES
+    # so that their existing steps are never altered.
+    if is_rental:
+        templates = RENTAL_STEP_TEMPLATES
+    elif journey.journey_version == 2:
+        templates = BUYING_STEP_TEMPLATES_V2
+    else:
+        templates = STEP_TEMPLATES
 
     # Generate steps based on conditions
     step_number_map: dict[int, int] = {}  # Original -> New step number

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -2065,6 +2065,16 @@ class TestOwnershipPhaseSteps:
         assert template.prerequisites == [25]
 
 
+def _v2_template(content_key: str) -> StepTemplate:
+    """Return the BUYING_STEP_TEMPLATES_V2 entry with the given content_key."""
+    return next(t for t in BUYING_STEP_TEMPLATES_V2 if t.content_key == content_key)
+
+
+def _v2_task_titles(content_key: str) -> list[str]:
+    """Return the task titles for the V2 template with the given content_key."""
+    return [t["title"] for t in _v2_template(content_key).tasks]
+
+
 class TestBuyingStepTemplatesV2:
     """Tests for the consolidated v2 buying journey templates.
 
@@ -2079,9 +2089,7 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_buying_costs_is_step_3(self) -> None:
         """Buying costs step retains same content_key and is step 3 in v2."""
-        template = next(
-            t for t in BUYING_STEP_TEMPLATES_V2 if t.content_key == "buying_costs"
-        )
+        template = _v2_template("buying_costs")
         assert template.step_number == 3
         assert template.phase == JourneyPhase.RESEARCH
         # task order must be preserved for _personalize_buying_costs()
@@ -2092,13 +2100,9 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_goals_and_market_merged(self) -> None:
         """Step 1 combines goals and market research tasks."""
-        template = next(
-            t
-            for t in BUYING_STEP_TEMPLATES_V2
-            if t.content_key == "property_goals_and_market"
-        )
+        template = _v2_template("property_goals_and_market")
         assert template.step_number == 1
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("property_goals_and_market")
         # From old step 1
         assert any("must-have" in t for t in task_titles)
         assert any("budget" in t for t in task_titles)
@@ -2108,13 +2112,9 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_find_and_evaluate_merged(self) -> None:
         """Step 2 combines property search and evaluation tasks."""
-        template = next(
-            t
-            for t in BUYING_STEP_TEMPLATES_V2
-            if t.content_key == "find_and_evaluate_property"
-        )
+        template = _v2_template("find_and_evaluate_property")
         assert template.step_number == 2
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("find_and_evaluate_property")
         # From old step 3
         assert any("ImmoScout24" in t for t in task_titles)
         assert any("Energieausweis" in t for t in task_titles)
@@ -2125,12 +2125,10 @@ class TestBuyingStepTemplatesV2:
     def test_v2_secure_financing_merged(self) -> None:
         """Secure financing step (step 4, mortgage/mixed) merges finance check,
         pre-approval, and comparison tasks."""
-        template = next(
-            t for t in BUYING_STEP_TEMPLATES_V2 if t.content_key == "secure_financing"
-        )
+        template = _v2_template("secure_financing")
         assert template.step_number == 4
         assert template.conditions == {"financing_type": ["mortgage", "mixed"]}
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("secure_financing")
         # From old step 6 (finance check)
         assert any("SCHUFA" in t for t in task_titles)
         # From old step 7 (pre-approval)
@@ -2140,13 +2138,9 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_due_diligence_and_offer_merged(self) -> None:
         """Step 9 merges due diligence and make-offer tasks."""
-        template = next(
-            t
-            for t in BUYING_STEP_TEMPLATES_V2
-            if t.content_key == "due_diligence_and_offer"
-        )
+        template = _v2_template("due_diligence_and_offer")
         assert template.step_number == 9
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("due_diligence_and_offer")
         # From old step 10 (due diligence)
         assert any("Grundbuchauszug" in t for t in task_titles)
         assert any("encumbrances" in t for t in task_titles)
@@ -2156,13 +2150,9 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_notary_and_contract_merged(self) -> None:
         """Step 11 merges notary selection and contract review tasks."""
-        template = next(
-            t
-            for t in BUYING_STEP_TEMPLATES_V2
-            if t.content_key == "notary_and_contract"
-        )
+        template = _v2_template("notary_and_contract")
         assert template.step_number == 11
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("notary_and_contract")
         # From old step 12 (choose notary)
         assert any("Research local notaries" in t for t in task_titles)
         # From old step 13 (review contract)
@@ -2170,13 +2160,9 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_payment_and_transfer_tax_merged(self) -> None:
         """Step 14 merges payment and transfer tax tasks."""
-        template = next(
-            t
-            for t in BUYING_STEP_TEMPLATES_V2
-            if t.content_key == "payment_and_transfer_tax"
-        )
+        template = _v2_template("payment_and_transfer_tax")
         assert template.step_number == 14
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("payment_and_transfer_tax")
         # From old step 15 (payment)
         assert any("Auflassungsvormerkung" in t for t in task_titles)
         assert any("Transfer purchase price" in t for t in task_titles)
@@ -2186,13 +2172,9 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_registration_and_insurance_merged(self) -> None:
         """Step 16 merges registration and insurance tasks."""
-        template = next(
-            t
-            for t in BUYING_STEP_TEMPLATES_V2
-            if t.content_key == "registration_and_insurance"
-        )
+        template = _v2_template("registration_and_insurance")
         assert template.step_number == 16
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("registration_and_insurance")
         # From old step 25 (registration)
         assert any("Grundbuch" in t for t in task_titles)
         assert any("utilities" in t for t in task_titles)
@@ -2201,13 +2183,9 @@ class TestBuyingStepTemplatesV2:
 
     def test_v2_management_and_finance_merged(self) -> None:
         """Step 17 merges property management and tax/finance tasks."""
-        template = next(
-            t
-            for t in BUYING_STEP_TEMPLATES_V2
-            if t.content_key == "management_and_finance_setup"
-        )
+        template = _v2_template("management_and_finance_setup")
         assert template.step_number == 17
-        task_titles = [t["title"] for t in template.tasks]
+        task_titles = _v2_task_titles("management_and_finance_setup")
         # From old step 27 (management)
         assert any("Müllabfuhr" in t for t in task_titles)
         # From old step 28 (tax/finance)

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -18,6 +18,7 @@ from app.models.journey import (
 )
 from app.schemas.journey import QuestionnaireAnswers
 from app.services.journey_service import (
+    BUYING_STEP_TEMPLATES_V2,
     STEP_TEMPLATES,
     JourneyNotFoundError,
     StepNotFoundError,
@@ -1527,9 +1528,14 @@ class TestRentalInvestorSteps:
     def test_rental_setup_after_ownership_in_generated_journey(
         self, rent_out_answers: QuestionnaireAnswers
     ) -> None:
-        """Test that Set Up Rental Operations comes after Complete Property Registration."""
+        """Test that Set Up Rental Operations comes after the ownership registration step."""
         steps = _generate_steps(rent_out_answers)
-        reg_step = next(s for s in steps if s.title == "Complete Property Registration")
+        # v2 merges registration + insurance into one step
+        reg_step = next(
+            s
+            for s in steps
+            if s.content_key in ("registration_and_insurance", "ownership_registration")
+        )
         rental_step = next(s for s in steps if s.title == "Set Up Rental Operations")
         assert rental_step.step_number > reg_step.step_number
 
@@ -1750,35 +1756,30 @@ class TestOwnershipPhaseSteps:
     def test_ownership_steps_included_for_live_in(
         self, live_in_apartment_answers: QuestionnaireAnswers
     ) -> None:
-        """Test that ownership steps are included for live-in buyers."""
+        """Test that v2 ownership steps are included for live-in buyers."""
         steps = _generate_steps(live_in_apartment_answers)
         step_titles = [s.title for s in steps]
-        assert "Complete Property Registration" in step_titles
-        assert "Arrange Property Insurance" in step_titles
-        assert "Set Up Property Management" in step_titles
-        assert "Handle Property Tax & Finance" in step_titles
+        # v2 merged steps
+        assert "Register Property & Arrange Insurance" in step_titles
+        assert "Set Up Property Management & Finance" in step_titles
 
     def test_ownership_steps_included_for_rent_out(
         self, rent_out_house_answers: QuestionnaireAnswers
     ) -> None:
-        """Test that ownership steps are included for rent-out buyers."""
+        """Test that v2 ownership steps are included for rent-out buyers."""
         steps = _generate_steps(rent_out_house_answers)
         step_titles = [s.title for s in steps]
-        assert "Complete Property Registration" in step_titles
-        assert "Arrange Property Insurance" in step_titles
-        assert "Set Up Property Management" in step_titles
-        assert "Handle Property Tax & Finance" in step_titles
+        assert "Register Property & Arrange Insurance" in step_titles
+        assert "Set Up Property Management & Finance" in step_titles
 
     def test_ownership_steps_included_when_property_use_none(
         self, sample_answers: QuestionnaireAnswers
     ) -> None:
-        """Test that ownership steps are included when property_use is None (backward compat)."""
+        """Test that v2 ownership steps are included when property_use is None."""
         steps = _generate_steps(sample_answers)
         step_titles = [s.title for s in steps]
-        assert "Complete Property Registration" in step_titles
-        assert "Arrange Property Insurance" in step_titles
-        assert "Set Up Property Management" in step_titles
-        assert "Handle Property Tax & Finance" in step_titles
+        assert "Register Property & Arrange Insurance" in step_titles
+        assert "Set Up Property Management & Finance" in step_titles
 
     # --- Phase ordering tests ---
 
@@ -1797,8 +1798,9 @@ class TestOwnershipPhaseSteps:
         steps = _generate_steps(rent_out_house_answers)
         ownership_steps = [s for s in steps if s.phase == JourneyPhase.OWNERSHIP]
         rental_steps = [s for s in steps if s.phase == JourneyPhase.RENTAL_SETUP]
-        # 5 ownership steps: 4 base + investor "Plan Property Management"
-        assert len(ownership_steps) == 5
+        # v2 ownership steps: "Plan Property Management" (investor) +
+        # "Register Property & Arrange Insurance" + "Set Up Property Management & Finance"
+        assert len(ownership_steps) == 3
         # 3 rental_setup steps: "Understand Landlord Obligations", "Analyze Rental Yield",
         # and "Set Up Rental Operations"
         assert len(rental_steps) == 3
@@ -1831,7 +1833,9 @@ class TestOwnershipPhaseSteps:
         closing_steps = [s for s in steps if s.phase == JourneyPhase.CLOSING]
         ownership_steps = [s for s in steps if s.phase == JourneyPhase.OWNERSHIP]
         assert len(closing_steps) > 0
-        assert len(ownership_steps) == 4
+        # v2 ownership steps for live-in: "Register Property & Arrange Insurance"
+        # + "Set Up Property Management & Finance"
+        assert len(ownership_steps) == 2
         max_closing_num = max(s.step_number for s in closing_steps)
         min_ownership_num = min(s.step_number for s in ownership_steps)
         assert max_closing_num < min_ownership_num
@@ -1849,9 +1853,9 @@ class TestOwnershipPhaseSteps:
     def test_anmeldung_task_included_for_live_in(
         self, live_in_apartment_answers: QuestionnaireAnswers
     ) -> None:
-        """Test that Anmeldung task is included for live-in buyers."""
+        """Test that Anmeldung task is included for live-in buyers (in merged reg+insurance step)."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
-        reg_tasks = steps_with_tasks["Complete Property Registration"]
+        reg_tasks = steps_with_tasks["Register Property & Arrange Insurance"]
         task_titles = [t.title for t in reg_tasks]
         assert "Register new address at Bürgeramt (Anmeldung)" in task_titles
 
@@ -1860,7 +1864,7 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that Anmeldung task is excluded for rent-out buyers."""
         steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
-        reg_tasks = steps_with_tasks["Complete Property Registration"]
+        reg_tasks = steps_with_tasks["Register Property & Arrange Insurance"]
         task_titles = [t.title for t in reg_tasks]
         assert "Register new address at Bürgeramt (Anmeldung)" not in task_titles
 
@@ -1869,8 +1873,8 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that Hausratversicherung task is included for live-in buyers."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
-        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
-        task_titles = [t.title for t in ins_tasks]
+        reg_ins_tasks = steps_with_tasks["Register Property & Arrange Insurance"]
+        task_titles = [t.title for t in reg_ins_tasks]
         assert "Set up Hausratversicherung (contents insurance)" in task_titles
 
     def test_contents_insurance_excluded_for_rent_out(
@@ -1878,8 +1882,8 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that Hausratversicherung task is excluded for rent-out buyers."""
         steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
-        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
-        task_titles = [t.title for t in ins_tasks]
+        reg_ins_tasks = steps_with_tasks["Register Property & Arrange Insurance"]
+        task_titles = [t.title for t in reg_ins_tasks]
         assert "Set up Hausratversicherung (contents insurance)" not in task_titles
 
     def test_weg_tasks_included_for_apartment(
@@ -1887,7 +1891,7 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that WEG/Hausgeld tasks are included for apartment buyers."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
-        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
         task_titles = [t.title for t in mgmt_tasks]
         assert "Contact WEG-Verwaltung and register as new owner" in task_titles
         assert "Set up Hausgeld (condo fees) payment via Dauerauftrag" in task_titles
@@ -1897,7 +1901,7 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that WEG/Hausgeld tasks are excluded for house buyers."""
         steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
-        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
         task_titles = [t.title for t in mgmt_tasks]
         assert "Contact WEG-Verwaltung and register as new owner" not in task_titles
         assert (
@@ -1909,7 +1913,7 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that house maintenance tasks are included for house buyers."""
         steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
-        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
         task_titles = [t.title for t in mgmt_tasks]
         assert "Plan annual maintenance budget (Instandhaltungsrücklage)" in task_titles
 
@@ -1918,7 +1922,7 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that house maintenance tasks are excluded for apartment buyers."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
-        mgmt_tasks = steps_with_tasks["Set Up Property Management"]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
         task_titles = [t.title for t in mgmt_tasks]
         assert (
             "Plan annual maintenance budget (Instandhaltungsrücklage)"
@@ -1930,8 +1934,8 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that WEG insurance verification task is included for apartment buyers."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
-        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
-        task_titles = [t.title for t in ins_tasks]
+        reg_ins_tasks = steps_with_tasks["Register Property & Arrange Insurance"]
+        task_titles = [t.title for t in reg_ins_tasks]
         assert "Verify WEG building insurance policy covers your unit" in task_titles
 
     def test_weg_insurance_excluded_for_house(
@@ -1939,8 +1943,8 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that WEG insurance verification task is excluded for house buyers."""
         steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
-        ins_tasks = steps_with_tasks["Arrange Property Insurance"]
-        task_titles = [t.title for t in ins_tasks]
+        reg_ins_tasks = steps_with_tasks["Register Property & Arrange Insurance"]
+        task_titles = [t.title for t in reg_ins_tasks]
         assert (
             "Verify WEG building insurance policy covers your unit" not in task_titles
         )
@@ -1950,8 +1954,8 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that mortgage tracking task is included for mortgage buyers."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
-        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
-        task_titles = [t.title for t in tax_tasks]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
+        task_titles = [t.title for t in mgmt_tasks]
         assert (
             "Track mortgage payments and request annual interest statement"
             in task_titles
@@ -1962,8 +1966,8 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that mortgage tracking task is excluded for cash buyers."""
         steps_with_tasks = _generate_steps_with_tasks(rent_out_apartment_cash_answers)
-        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
-        task_titles = [t.title for t in tax_tasks]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
+        task_titles = [t.title for t in mgmt_tasks]
         assert (
             "Track mortgage payments and request annual interest statement"
             not in task_titles
@@ -1974,8 +1978,8 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that Anlage V task is included for rent-out buyers."""
         steps_with_tasks = _generate_steps_with_tasks(rent_out_house_answers)
-        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
-        task_titles = [t.title for t in tax_tasks]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
+        task_titles = [t.title for t in mgmt_tasks]
         assert "Prepare for Anlage V rental income tax filing" in task_titles
 
     def test_anlage_v_excluded_for_live_in(
@@ -1983,19 +1987,19 @@ class TestOwnershipPhaseSteps:
     ) -> None:
         """Test that Anlage V task is excluded for live-in buyers."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
-        tax_tasks = steps_with_tasks["Handle Property Tax & Finance"]
-        task_titles = [t.title for t in tax_tasks]
+        mgmt_tasks = steps_with_tasks["Set Up Property Management & Finance"]
+        task_titles = [t.title for t in mgmt_tasks]
         assert "Prepare for Anlage V rental income tax filing" not in task_titles
 
     def test_universal_tasks_always_present(
         self, live_in_apartment_answers: QuestionnaireAnswers
     ) -> None:
-        """Test that unconditional tasks are always present in ownership steps."""
+        """Test that unconditional tasks are always present in v2 ownership steps."""
         steps_with_tasks = _generate_steps_with_tasks(live_in_apartment_answers)
 
-        # Registration universal tasks
+        # Registration+Insurance universal tasks
         reg_titles = [
-            t.title for t in steps_with_tasks["Complete Property Registration"]
+            t.title for t in steps_with_tasks["Register Property & Arrange Insurance"]
         ]
         assert (
             "Confirm Grundbuch (land register) transfer is complete with notary"
@@ -2006,18 +2010,15 @@ class TestOwnershipPhaseSteps:
             in reg_titles
         )
 
-        # Management universal tasks
-        mgmt_titles = [t.title for t in steps_with_tasks["Set Up Property Management"]]
-        assert "Register for waste collection (Müllabfuhr) service" in mgmt_titles
-
-        # Tax universal tasks
-        tax_titles = [
-            t.title for t in steps_with_tasks["Handle Property Tax & Finance"]
+        # Management+Finance universal tasks
+        mgmt_titles = [
+            t.title for t in steps_with_tasks["Set Up Property Management & Finance"]
         ]
+        assert "Register for waste collection (Müllabfuhr) service" in mgmt_titles
         assert (
-            "Register for Grundsteuer (property tax) at local Finanzamt" in tax_titles
+            "Register for Grundsteuer (property tax) at local Finanzamt" in mgmt_titles
         )
-        assert "Keep records of all property expenses for tax deduction" in tax_titles
+        assert "Keep records of all property expenses for tax deduction" in mgmt_titles
 
     def test_step17_utility_task_distinct_from_step25(self) -> None:
         """Test that Step 17 and Step 25 utility tasks have distinct wording."""
@@ -2062,3 +2063,256 @@ class TestOwnershipPhaseSteps:
             t for t in STEP_TEMPLATES if t.content_key == "ownership_tax_finance"
         )
         assert template.prerequisites == [25]
+
+
+class TestBuyingStepTemplatesV2:
+    """Tests for the consolidated v2 buying journey templates.
+
+    V2 merges 28 legacy templates (~22 active for mortgage buyer) down to 18
+    templates. These tests verify structure, task content, and generation.
+    """
+
+    def test_v2_template_count(self) -> None:
+        """V2 list has 19 templates (step_numbers 1-18, with step 4 appearing twice
+        for the mutually-exclusive secure_financing/proof_of_funds branches)."""
+        assert len(BUYING_STEP_TEMPLATES_V2) == 19
+
+    def test_v2_buying_costs_is_step_3(self) -> None:
+        """Buying costs step retains same content_key and is step 3 in v2."""
+        template = next(
+            t for t in BUYING_STEP_TEMPLATES_V2 if t.content_key == "buying_costs"
+        )
+        assert template.step_number == 3
+        assert template.phase == JourneyPhase.RESEARCH
+        # task order must be preserved for _personalize_buying_costs()
+        assert template.tasks[0]["title"].startswith("Calculate Grunderwerbsteuer")
+        assert "notary fees" in template.tasks[1]["title"]
+        assert "land registry" in template.tasks[2]["title"]
+        assert "agent commission" in template.tasks[3]["title"]
+
+    def test_v2_goals_and_market_merged(self) -> None:
+        """Step 1 combines goals and market research tasks."""
+        template = next(
+            t
+            for t in BUYING_STEP_TEMPLATES_V2
+            if t.content_key == "property_goals_and_market"
+        )
+        assert template.step_number == 1
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 1
+        assert any("must-have" in t for t in task_titles)
+        assert any("budget" in t for t in task_titles)
+        # From old step 2
+        assert any("Grunderwerbsteuer" in t for t in task_titles)
+        assert any("price per sqm" in t for t in task_titles)
+
+    def test_v2_find_and_evaluate_merged(self) -> None:
+        """Step 2 combines property search and evaluation tasks."""
+        template = next(
+            t
+            for t in BUYING_STEP_TEMPLATES_V2
+            if t.content_key == "find_and_evaluate_property"
+        )
+        assert template.step_number == 2
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 3
+        assert any("ImmoScout24" in t for t in task_titles)
+        assert any("Energieausweis" in t for t in task_titles)
+        # From old step 4
+        assert any("evaluation calculator" in t for t in task_titles)
+        assert any("cashflow" in t for t in task_titles)
+
+    def test_v2_secure_financing_merged(self) -> None:
+        """Secure financing step (step 4, mortgage/mixed) merges finance check,
+        pre-approval, and comparison tasks."""
+        template = next(
+            t for t in BUYING_STEP_TEMPLATES_V2 if t.content_key == "secure_financing"
+        )
+        assert template.step_number == 4
+        assert template.conditions == {"financing_type": ["mortgage", "mixed"]}
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 6 (finance check)
+        assert any("SCHUFA" in t for t in task_titles)
+        # From old step 7 (pre-approval)
+        assert any("Finanzierungsbestätigung" in t for t in task_titles)
+        # From old step 8 (comparison)
+        assert any("interest rates" in t for t in task_titles)
+
+    def test_v2_due_diligence_and_offer_merged(self) -> None:
+        """Step 9 merges due diligence and make-offer tasks."""
+        template = next(
+            t
+            for t in BUYING_STEP_TEMPLATES_V2
+            if t.content_key == "due_diligence_and_offer"
+        )
+        assert template.step_number == 9
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 10 (due diligence)
+        assert any("Grundbuchauszug" in t for t in task_titles)
+        assert any("encumbrances" in t for t in task_titles)
+        # From old step 11 (make offer)
+        assert any("Kaufangebot" in t for t in task_titles)
+        assert any("seller acceptance" in t for t in task_titles)
+
+    def test_v2_notary_and_contract_merged(self) -> None:
+        """Step 11 merges notary selection and contract review tasks."""
+        template = next(
+            t
+            for t in BUYING_STEP_TEMPLATES_V2
+            if t.content_key == "notary_and_contract"
+        )
+        assert template.step_number == 11
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 12 (choose notary)
+        assert any("Research local notaries" in t for t in task_titles)
+        # From old step 13 (review contract)
+        assert any("Kaufvertrag" in t for t in task_titles)
+
+    def test_v2_payment_and_transfer_tax_merged(self) -> None:
+        """Step 14 merges payment and transfer tax tasks."""
+        template = next(
+            t
+            for t in BUYING_STEP_TEMPLATES_V2
+            if t.content_key == "payment_and_transfer_tax"
+        )
+        assert template.step_number == 14
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 15 (payment)
+        assert any("Auflassungsvormerkung" in t for t in task_titles)
+        assert any("Transfer purchase price" in t for t in task_titles)
+        # From old step 16 (transfer tax)
+        assert any("Grunderwerbsteuer" in t for t in task_titles)
+        assert any("Unbedenklichkeitsbescheinigung" in t for t in task_titles)
+
+    def test_v2_registration_and_insurance_merged(self) -> None:
+        """Step 16 merges registration and insurance tasks."""
+        template = next(
+            t
+            for t in BUYING_STEP_TEMPLATES_V2
+            if t.content_key == "registration_and_insurance"
+        )
+        assert template.step_number == 16
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 25 (registration)
+        assert any("Grundbuch" in t for t in task_titles)
+        assert any("utilities" in t for t in task_titles)
+        # From old step 26 (insurance)
+        assert any("Wohngebäudeversicherung" in t for t in task_titles)
+
+    def test_v2_management_and_finance_merged(self) -> None:
+        """Step 17 merges property management and tax/finance tasks."""
+        template = next(
+            t
+            for t in BUYING_STEP_TEMPLATES_V2
+            if t.content_key == "management_and_finance_setup"
+        )
+        assert template.step_number == 17
+        task_titles = [t["title"] for t in template.tasks]
+        # From old step 27 (management)
+        assert any("Müllabfuhr" in t for t in task_titles)
+        # From old step 28 (tax/finance)
+        assert any("Grundsteuer" in t for t in task_titles)
+
+    def test_v2_generation_mortgage_buyer_step_count(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """A mortgage buyer living-in generates the correct number of v2 steps."""
+        steps = _generate_steps(sample_answers)
+        step_titles = [s.title for s in steps]
+        # Verify merged steps are present
+        assert "Set Your Goals & Explore the Market" in step_titles
+        assert "Find & Evaluate Properties" in step_titles
+        assert "Secure Your Financing" in step_titles
+        assert "Inspect, Evaluate & Make an Offer" in step_titles
+        assert "Notary Selection & Contract Review" in step_titles
+        assert "Complete Payment & Transfer Tax" in step_titles
+        assert "Register Property & Arrange Insurance" in step_titles
+        assert "Set Up Property Management & Finance" in step_titles
+        # Verify old split steps are NOT present
+        assert "Define Your Property Goals" not in step_titles
+        assert "Understand the German Property Market" not in step_titles
+        assert "Check Your Finances" not in step_titles
+        assert "Get Mortgage Pre-Approval" not in step_titles
+        assert "Compare Mortgage Offers" not in step_titles
+        assert "Property Due Diligence" not in step_titles
+        assert "Make an Offer" not in step_titles
+        assert "Choose a Notar" not in step_titles
+        assert "Review Purchase Contract" not in step_titles
+        assert "Complete Payment" not in step_titles
+        assert "Pay Transfer Tax" not in step_titles
+        assert "Complete Property Registration" not in step_titles
+        assert "Arrange Property Insurance" not in step_titles
+
+    def test_v2_generation_cash_buyer_excludes_secure_financing(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """Cash buyer v2 journey includes Prepare Proof of Funds, not Secure Your Financing."""
+        steps = _generate_steps(cash_buyer_answers)
+        titles = [s.title for s in steps]
+        assert "Prepare Proof of Funds" in titles
+        assert "Secure Your Financing" not in titles
+        assert "Secure Final Loan Commitment" not in titles
+
+    def test_v2_generation_mortgage_buyer_excludes_proof_of_funds(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """Mortgage buyer v2 journey excludes Prepare Proof of Funds."""
+        steps = _generate_steps(sample_answers)
+        titles = [s.title for s in steps]
+        assert "Prepare Proof of Funds" not in titles
+        assert "Secure Your Financing" in titles
+        assert "Secure Final Loan Commitment" in titles
+
+    def test_v2_notary_signing_prerequisite_excludes_loan_commitment_for_cash(
+        self, cash_buyer_answers: QuestionnaireAnswers
+    ) -> None:
+        """For a cash buyer, Sign at the Notary has only one prerequisite (not loan commitment)."""
+        steps = _generate_steps(cash_buyer_answers)
+        signing_step = next(
+            (s for s in steps if s.content_key == "notary_signing"), None
+        )
+        assert signing_step is not None
+        # Loan commitment is not generated for cash buyers, so only one prereq remains
+        assert signing_step.prerequisites is not None
+        assert len(signing_step.prerequisites) == 1
+
+    def test_v2_buying_costs_is_personalized(self) -> None:
+        """_personalize_buying_costs() is applied to the buying_costs step in v2.
+
+        Uses state code "BE" (Berlin) so STATE_RATES lookup succeeds.
+        """
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="BE",  # Berlin — must be a state code key in STATE_RATES
+            financing_type=FinancingType.MORTGAGE,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+            budget_euros=300_000,
+        )
+        steps_with_tasks = _generate_steps_with_tasks(answers)
+        buying_costs_tasks = steps_with_tasks.get("Learn About Buying Costs")
+        assert buying_costs_tasks is not None
+        # Personalization adds state-specific tax rate to the title
+        first_task_title = buying_costs_tasks[0].title
+        assert "6.0%" in first_task_title  # Berlin state rate
+
+    def test_v2_journey_version_set_to_2(
+        self, sample_answers: QuestionnaireAnswers
+    ) -> None:
+        """New buying journeys are created with journey_version=2."""
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = None
+
+        generate_journey(
+            session=mock_session,
+            user_id=uuid.uuid4(),
+            title="Test Journey",
+            answers=sample_answers,
+        )
+
+        journey_obj = next(
+            call.args[0]
+            for call in mock_session.add.call_args_list
+            if isinstance(call.args[0], Journey)
+        )
+        assert journey_obj.journey_version == 2

--- a/backend/tests/services/test_journey_service.py
+++ b/backend/tests/services/test_journey_service.py
@@ -2276,6 +2276,28 @@ class TestBuyingStepTemplatesV2:
         assert signing_step.prerequisites is not None
         assert len(signing_step.prerequisites) == 1
 
+    def test_v2_financing_type_none_skips_both_step4_branches(self) -> None:
+        """When financing_type is None, both step-4 branches are excluded.
+
+        Neither 'Secure Your Financing' nor 'Prepare Proof of Funds' should
+        appear, and downstream steps (notary, signing) must still generate.
+        """
+        answers = QuestionnaireAnswers(
+            property_type=PropertyType.APARTMENT,
+            property_location="BE",
+            financing_type=None,
+            is_first_time_buyer=True,
+            has_german_residency=True,
+        )
+        steps = _generate_steps(answers)
+        titles = [s.title for s in steps]
+        assert "Secure Your Financing" not in titles
+        assert "Prepare Proof of Funds" not in titles
+        assert "Secure Final Loan Commitment" not in titles
+        # Core buying steps must still be generated
+        assert "Notary Selection & Contract Review" in titles
+        assert "Sign at the Notary" in titles
+
     def test_v2_buying_costs_is_personalized(self) -> None:
         """_personalize_buying_costs() is applied to the buying_costs step in v2.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,11 @@ sonar.organization=sojisoyoye
 sonar.sources=backend/app,frontend/src
 sonar.tests=backend/tests
 sonar.exclusions=backend/app/alembic/**,frontend/src/client/**,frontend/node_modules/**,**/__pycache__/**,**/*.pyc,frontend/src/routeTree.gen.ts
-sonar.cpd.exclusions=frontend/src/routeTree.gen.ts
+# journey_service.py contains large static data dictionaries (STEP_TEMPLATES,
+# BUYING_STEP_TEMPLATES_V2, RENTAL_STEP_TEMPLATES) whose task-dict structure
+# is intentionally uniform. CPD would otherwise flag them as duplicates of each
+# other despite having entirely different string content.
+sonar.cpd.exclusions=frontend/src/routeTree.gen.ts,backend/app/services/journey_service.py
 
 # Coverage is only measured for Python backend — no JS/TS test coverage exists
 # Seed files excluded: mostly static data dictionaries, not business logic


### PR DESCRIPTION
## Summary

- Introduces `journey_version` column on `Journey` model (server_default=1 for existing rows, 2 for all new buying journeys)
- Adds `BUYING_STEP_TEMPLATES_V2` with ~18 effective steps per journey, merging 8 pairs of tightly related steps into unified phases
- Existing v1 journeys are completely untouched; template selection branches on `journey.journey_version`
- Includes additive-only Alembic migration (`i5j6k7l8m9n0`)

**Step merges (v1 → v2):**
| Merged | V2 step | Content key |
|--------|---------|-------------|
| Goals + Market exploration | 1 | `property_goals_and_market` |
| Find + Evaluate property | 2 | `find_and_evaluate_property` |
| Secure financing (×3) | 4 | `secure_financing` |
| Due diligence + Offer | 9 | `due_diligence_and_offer` |
| Notary selection + Contract review | 11 | `notary_and_contract` |
| Payment + Transfer tax | 14 | `payment_and_transfer_tax` |
| Registration + Insurance | 16 | `registration_and_insurance` |
| Property management + Finance setup | 17 | `management_and_finance_setup` |

## Test plan

- [ ] `TestBuyingStepTemplatesV2` — 16 new tests covering template structure, merged content, mortgage/cash path generation, and v2 flag
- [ ] All existing `TestOwnershipPhaseSteps` tests updated for v2 consolidated titles
- [ ] `TestRentalInvestorSteps` updated to use content_key match (v1/v2 compatible)
- [ ] 128 tests pass locally