### PR TITLE
feat(journey): add v2 buying journey step content renderers

### DIFF
--- a/frontend/src/components/Journey/StepContent/BuyingCostsGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/BuyingCostsGuide.tsx
@@ -1,0 +1,69 @@
+/**
+ * Buying Costs Guide Step Content
+ * Overview of German property purchase costs and budgeting guidance
+ */
+
+import { Euro, PiggyBank, Receipt, Scale } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function BuyingCostsGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Purchase Cost Breakdown"
+        description="German property purchases carry significant mandatory costs on top of the asking price."
+        items={[
+          {
+            icon: Receipt,
+            label: "Grunderwerbsteuer (Transfer Tax)",
+            detail:
+              "Ranges from 3.5% to 6.5% of the purchase price depending on the federal state (Bundesland). Payable within 4 weeks of the Grundbucheintrag.",
+          },
+          {
+            icon: Scale,
+            label: "Notar und Grundbuch (Notary & Registry)",
+            detail:
+              "Typically 1.5–2% of the purchase price. Covers notary fees for the Kaufvertrag and the Grundbuch entry registration.",
+          },
+          {
+            icon: Euro,
+            label: "Maklerprovision (Agent Commission)",
+            detail:
+              "If a buyer's agent is involved, commission is now legally split between buyer and seller (max 3.57% each incl. VAT since 2020).",
+          },
+        ]}
+        tip="Budget 7–12% of the purchase price for total Kaufnebenkosten (ancillary purchase costs) in addition to the property price."
+      />
+      <GuidanceCard
+        title="Plan Your Full Budget"
+        description="Account for all costs before committing to a purchase."
+        items={[
+          {
+            icon: PiggyBank,
+            label: "Equity Requirement",
+            detail:
+              "German banks typically require 20–30% equity. The Kaufnebenkosten must usually be covered entirely from equity — they cannot be financed.",
+          },
+        ]}
+        ctaLabel="Open Cost Calculator"
+        ctaHref="/calculators/buying-costs"
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { BuyingCostsGuide }

--- a/frontend/src/components/Journey/StepContent/DocumentsPrep.tsx
+++ b/frontend/src/components/Journey/StepContent/DocumentsPrep.tsx
@@ -1,0 +1,67 @@
+/**
+ * Documents Preparation Step Content
+ * Guidance on gathering all personal and financial documents before making an offer
+ */
+
+import { Briefcase, CreditCard, Euro, FileText } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function DocumentsPrep(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Personal Identity Documents"
+        description="All parties purchasing the property must provide valid identification."
+        items={[
+          {
+            icon: CreditCard,
+            label: "Passport or National ID",
+            detail:
+              "Both buyer and co-buyers need a valid passport or EU national ID card. Non-EU buyers should also have their residence permit (Aufenthaltstitel) ready.",
+          },
+          {
+            icon: FileText,
+            label: "Marital Status Certificate",
+            detail:
+              "Married buyers may need a Heiratsurkunde (marriage certificate). If purchasing jointly, both partners must be present at the notary signing.",
+          },
+        ]}
+        tip="Have certified German translations ready for any documents not in German. The notary may require Apostille-certified copies for non-EU documents."
+      />
+      <GuidanceCard
+        title="Financial Documents"
+        description="Lenders and the notary will request evidence of your financial position."
+        items={[
+          {
+            icon: Euro,
+            label: "Bank Statements",
+            detail:
+              "Provide statements from the last 3 months showing your equity and regular income. Unusual large deposits may need an explanation letter (Herkunftsnachweis).",
+          },
+          {
+            icon: Briefcase,
+            label: "Income and Tax Documents",
+            detail:
+              "Last 3 payslips (Gehaltsabrechnungen), most recent Steuerbescheid, and employment contract. Self-employed: 2 years of BWA and tax returns. Freelancers: client contracts and income statements.",
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { DocumentsPrep }

--- a/frontend/src/components/Journey/StepContent/DueDiligenceAndOffer.tsx
+++ b/frontend/src/components/Journey/StepContent/DueDiligenceAndOffer.tsx
@@ -1,0 +1,59 @@
+/**
+ * Due Diligence and Offer Step Content
+ * Document review zone + guidance on checks before submitting an offer
+ */
+
+import { FileSearch, Scale, ShieldCheck } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+import { StepDocumentReview } from "./StepDocumentReview"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function DueDiligenceAndOffer(props: Readonly<IProps>) {
+  const { step } = props
+
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Key Checks Before Making an Offer"
+        description="Carry out these checks on any property you are seriously considering."
+        items={[
+          {
+            icon: FileSearch,
+            label: "Grundbuch Extract",
+            detail:
+              "Request a current Grundbuchauszug from the seller or via your notary. Check for Grundschulden (land charges), easements (Dienstbarkeiten), or third-party rights that could affect your ownership.",
+          },
+          {
+            icon: Scale,
+            label: "Teilungserklärung for Condos (ETW)",
+            detail:
+              "For apartments, review the Teilungserklärung and Gemeinschaftsordnung. These set the rules for shared costs, parking, and structural changes. Check the Instandhaltungsrücklage balance.",
+          },
+          {
+            icon: ShieldCheck,
+            label: "Building Permits and Alterations",
+            detail:
+              "Ask the seller for all Baugenehmigungen. Unpermitted alterations (Schwarzbauten) transfer liability to the buyer. Request a Baulastenauskunft from the local building authority.",
+          },
+        ]}
+        tip="Upload the Grundbuch extract, Exposé, and any floor plans below to get an AI-assisted translation and risk summary."
+      />
+      <StepDocumentReview stepId={step.id} />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { DueDiligenceAndOffer }

--- a/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
@@ -1,0 +1,72 @@
+/**
+ * Find And Evaluate Guide Step Content
+ * Guidance for searching and evaluating German properties
+ */
+
+import { BarChart2, Building2, MapPin, Search } from "lucide-react"
+
+import { GuidanceCard } from "./GuidanceCard"
+import { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
+
+interface IProps {
+  journeyId: string
+  stepId: string
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function FindAndEvaluateGuide(props: Readonly<IProps>) {
+  const { journeyId, stepId } = props
+
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Finding Properties in Germany"
+        description="Use the right platforms and criteria to narrow your search efficiently."
+        items={[
+          {
+            icon: Search,
+            label: "Major Listing Portals",
+            detail:
+              "Search on Immobilienscout24, Immowelt, and Kleinanzeigen. Set up alerts for your target location, size, and budget to catch new listings early.",
+          },
+          {
+            icon: MapPin,
+            label: "Location Research",
+            detail:
+              "Evaluate the Lage (location) carefully — proximity to transport, schools, amenities, and future development plans all affect value and rental demand.",
+          },
+          {
+            icon: Building2,
+            label: "Property Types to Compare",
+            detail:
+              "Compare Eigentumswohnung (flat), Reihenhaus (terraced house), and Einfamilienhaus (detached). Each has different cost structures and maintenance obligations.",
+          },
+        ]}
+        tip="The first 48 hours after a listing goes live are critical. Properties in high-demand areas often receive multiple offers within days."
+      />
+      <GuidanceCard
+        title="Evaluating Properties"
+        description="Assess each property beyond the asking price before committing."
+        items={[
+          {
+            icon: BarChart2,
+            label: "Price Per Square Metre",
+            detail:
+              "Compare the €/m² against recent sales in the same postcode using the Kaufpreissammlung or local Gutachterausschuss reports.",
+          },
+        ]}
+        tip="Use the property evaluation calculator below to model purchase costs and projected rental yield for each property you're serious about."
+      />
+      <PropertyEvaluationSummary journeyId={journeyId} stepId={stepId} />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { FindAndEvaluateGuide }

--- a/frontend/src/components/Journey/StepContent/LoanCommitmentGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/LoanCommitmentGuide.tsx
@@ -1,0 +1,67 @@
+/**
+ * Loan Commitment Step Content
+ * Guidance on securing a binding mortgage offer (Darlehenszusage)
+ */
+
+import { BadgeEuro, FileCheck, Percent, TrendingDown } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function LoanCommitmentGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="From Confirmation to Binding Offer"
+        description="A Finanzierungsbestätigung is not a legally binding commitment — get the full Darlehenszusage before signing."
+        items={[
+          {
+            icon: FileCheck,
+            label: "Submit the Final Loan Application",
+            detail:
+              "Provide the signed Kaufvertragsentwurf, current property Exposé, Grundbuchauszug, and your income documents. The bank will commission a property valuation (Beleihungswertermittlung).",
+          },
+          {
+            icon: BadgeEuro,
+            label: "Darlehenszusage (Binding Offer)",
+            detail:
+              "Once approved, you'll receive the loan agreement. You have a 14-day statutory withdrawal period (Widerrufsrecht) after signing — use this time for a final legal review.",
+          },
+        ]}
+        tip="Lock in your interest rate with a Zinsbindungsfrist. Rates fixed for 10–15 years offer planning security; shorter terms have lower rates but expose you to refinancing risk."
+      />
+      <GuidanceCard
+        title="Rate and Repayment Choices"
+        description="Structuring your mortgage well saves tens of thousands over the loan term."
+        items={[
+          {
+            icon: Percent,
+            label: "Fixed vs. Variable Rate",
+            detail:
+              "Fixed rates (Festzins) dominate the German market. Variable rates (variable Zinsen) are rare and risky. Most buyers fix for 10 years and reassess at Anschlussfinanzierung.",
+          },
+          {
+            icon: TrendingDown,
+            label: "Tilgung (Repayment Rate)",
+            detail:
+              "A minimum 2–3% Tilgung is recommended. At 1% you'd take ~40 years to repay. Higher Tilgung reduces total interest significantly — model scenarios with your bank before signing.",
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { LoanCommitmentGuide }

--- a/frontend/src/components/Journey/StepContent/NotaryAndContract.tsx
+++ b/frontend/src/components/Journey/StepContent/NotaryAndContract.tsx
@@ -1,0 +1,62 @@
+/**
+ * Notary and Contract Step Content
+ * Guidance on reviewing the Kaufvertrag and working with the notary
+ */
+
+import { Clock, HelpCircle, UserCheck } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+import { StepDocumentReview } from "./StepDocumentReview"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function NotaryAndContract(props: Readonly<IProps>) {
+  const { step } = props
+
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Reviewing the Kaufvertragsentwurf"
+        description="You are legally entitled to review the draft purchase contract for at least 14 days before signing."
+        items={[
+          {
+            icon: Clock,
+            label: "14-Day Review Period",
+            detail:
+              "Request the Kaufvertragsentwurf from the notary as early as possible. The 14-day minimum is a legal right in Germany — no seller can pressure you to waive it.",
+          },
+          {
+            icon: HelpCircle,
+            label: "What to Check",
+            detail:
+              "Verify purchase price, payment schedule, Auflassungsvormerkung (priority notice) commitment, included fixtures (Inventar), and handover date. Have a bilingual lawyer review unfamiliar clauses.",
+          },
+          {
+            icon: UserCheck,
+            label: "The Notary's Role",
+            detail:
+              "The Notar is a neutral party — their fee is fixed by law and they are not your advocate. You can ask them to explain clauses, but engage your own lawyer for advice on negotiating terms.",
+          },
+        ]}
+        tip="Upload the Kaufvertragsentwurf below to get a translated summary and flag any unusual clauses for review."
+        ctaLabel="Find a Real Estate Lawyer"
+        ctaHref="/professionals"
+        ctaSearch={{ type: "lawyer" }}
+      />
+      <StepDocumentReview stepId={step.id} />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { NotaryAndContract }

--- a/frontend/src/components/Journey/StepContent/NotarySigningGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/NotarySigningGuide.tsx
@@ -1,0 +1,72 @@
+/**
+ * Notary Signing Step Content
+ * Guidance on what to expect at the Notartermin (notary appointment)
+ */
+
+import {
+  BookMarked,
+  MessageCircleQuestion,
+  Shield,
+  UserCheck,
+} from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function NotarySigningGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="At the Notartermin"
+        description="The signing appointment is a formal legal act — being well prepared prevents delays."
+        items={[
+          {
+            icon: UserCheck,
+            label: "Bring Valid Photo ID",
+            detail:
+              "Every party named in the contract must appear in person with a valid passport or national ID, or send an authorised representative with a notarised power of attorney (Vollmacht).",
+          },
+          {
+            icon: BookMarked,
+            label: "The Notar Reads the Contract Aloud",
+            detail:
+              "The notary is legally required to read the entire Kaufvertrag aloud. This takes 30–90 minutes. Bring an interpreter if you are not fluent in German, or ask the notary to arrange one in advance.",
+          },
+          {
+            icon: MessageCircleQuestion,
+            label: "Ask All Questions Before Signing",
+            detail:
+              "Once signed, the contract is binding. The notary can clarify the meaning of clauses but cannot give legal advice. Raise any unresolved points before the appointment.",
+          },
+        ]}
+        tip="After signing, the notary immediately applies for an Auflassungsvormerkung (priority notice) in the Grundbuch. This protects your purchase while the full transfer is processed."
+      />
+      <GuidanceCard
+        title="After Signing"
+        description="Several actions happen automatically after the notary appointment."
+        items={[
+          {
+            icon: Shield,
+            label: "Auflassungsvormerkung Entered",
+            detail:
+              "The priority notice blocks the seller from selling to anyone else or placing new liens on the property. It is replaced by full ownership entry once all conditions are met.",
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { NotarySigningGuide }

--- a/frontend/src/components/Journey/StepContent/OwnershipTransferGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/OwnershipTransferGuide.tsx
@@ -1,0 +1,67 @@
+/**
+ * Ownership Transfer Step Content
+ * Guidance on the final Grundbuch transfer and property handover
+ */
+
+import { ClipboardCheck, Home, KeyRound, ScrollText } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function OwnershipTransferGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Grundbuch Ownership Entry"
+        description="Legal ownership transfers when you are entered as Eigentümer in the Grundbuch — not at the moment of signing."
+        items={[
+          {
+            icon: ScrollText,
+            label: "Auflassung → Eigentumsumschreibung",
+            detail:
+              "The notary submits the Auflassung (conveyance declaration) once all conditions are met. The Grundbuch office processes this and replaces the priority notice with full ownership. This takes 4–8 weeks.",
+          },
+          {
+            icon: Home,
+            label: "Confirm the Entry",
+            detail:
+              "Ask your notary to provide a copy of the updated Grundbuchauszug once the entry is complete. This is your definitive proof of ownership — keep it permanently.",
+          },
+        ]}
+        tip="Even before the Grundbuch entry, you are the economic owner from the Übergabe (handover) date once full payment is confirmed. Insurance and running costs shift to you from that date."
+      />
+      <GuidanceCard
+        title="Property Handover (Übergabe)"
+        description="Document the handover carefully to protect yourself from disputes over pre-existing defects."
+        items={[
+          {
+            icon: KeyRound,
+            label: "Key Handover and Meter Readings",
+            detail:
+              "Collect all keys and codes. Record gas, electricity, water, and heat meter readings in the Übergabeprotokoll. Both buyer and seller should sign the protocol.",
+          },
+          {
+            icon: ClipboardCheck,
+            label: "Document Defects",
+            detail:
+              "Note any defects visible during handover in the protocol. Defects discovered after signing that are not in the protocol are harder to claim against the seller once ownership transfers.",
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { OwnershipTransferGuide }

--- a/frontend/src/components/Journey/StepContent/PaymentAndTransferTaxGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/PaymentAndTransferTaxGuide.tsx
@@ -1,0 +1,67 @@
+/**
+ * Payment and Transfer Tax Step Content
+ * Guidance on settling Grunderwerbsteuer and the purchase price payment
+ */
+
+import { BadgeCheck, Banknote, Clock, Receipt } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function PaymentAndTransferTaxGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Grunderwerbsteuer (Property Transfer Tax)"
+        description="This tax must be paid before you can be entered into the Grundbuch as the owner."
+        items={[
+          {
+            icon: Clock,
+            label: "Payment Deadline",
+            detail:
+              "The tax office (Finanzamt) sends the Grunderwerbsteuerbescheid within a few weeks of signing. You must pay within 4 weeks of the assessment date — late payment incurs interest charges.",
+          },
+          {
+            icon: BadgeCheck,
+            label: "Unbedenklichkeitsbescheinigung",
+            detail:
+              "Once the tax is paid, the Finanzamt issues this clearance certificate. The notary needs this before submitting the full Grundbuch transfer application — keep it safe.",
+          },
+        ]}
+        tip="The tax rate depends on the federal state (Bundesland) — it ranges from 3.5% (Bavaria) to 6.5% (Brandenburg, NRW). Check your state's rate when budgeting."
+      />
+      <GuidanceCard
+        title="Purchase Price Payment"
+        description="The purchase price is typically paid via bank transfer after specific conditions are met."
+        items={[
+          {
+            icon: Banknote,
+            label: "Fälligkeit (Payment Trigger)",
+            detail:
+              "The notary sends a Fälligkeitsmitteilung when all conditions are satisfied: Auflassungsvormerkung entered, Grunderwerbsteuer cleared, any existing loans released (Löschungsbewilligung). Do not pay before this notice.",
+          },
+          {
+            icon: Receipt,
+            label: "Keep All Receipts",
+            detail:
+              "Retain bank transfer confirmations, tax assessments, and the Unbedenklichkeitsbescheinigung. These documents are needed for your tax return and any future sale of the property.",
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { PaymentAndTransferTaxGuide }

--- a/frontend/src/components/Journey/StepContent/ProofOfFundsGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/ProofOfFundsGuide.tsx
@@ -1,0 +1,67 @@
+/**
+ * Proof of Funds Step Content
+ * Guidance on preparing financial evidence for sellers and lenders
+ */
+
+import { BadgeCheck, Banknote, FileSearch, PiggyBank } from "lucide-react"
+
+import type { JourneyStep } from "@/models/journey"
+import { GuidanceCard } from "./GuidanceCard"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function ProofOfFundsGuide(_props: Readonly<IProps>) {
+  return (
+    <div className="space-y-4">
+      <GuidanceCard
+        title="Equity and Liquid Assets"
+        description="German lenders typically require 20–30% equity plus enough to cover all closing costs."
+        items={[
+          {
+            icon: PiggyBank,
+            label: "Eigenkapital (Equity)",
+            detail:
+              "Show recent bank statements (last 3 months) demonstrating you hold the required equity. Savings accounts, securities, and existing property equity all count.",
+          },
+          {
+            icon: Banknote,
+            label: "Closing Cost Reserve",
+            detail:
+              "Keep an additional 8–12% of the purchase price liquid for Grunderwerbsteuer, notary, and Makler fees. This must come from your own funds — it cannot be financed.",
+          },
+        ]}
+        tip="Some sellers request a Finanzierungsbestätigung (financing confirmation letter) from your bank before accepting an offer. Request this early."
+      />
+      <GuidanceCard
+        title="Credit and Income Documents"
+        description="Lenders and sellers need confidence in your financial standing and repayment ability."
+        items={[
+          {
+            icon: BadgeCheck,
+            label: "Schufa Credit Report",
+            detail:
+              "Obtain a free annual Schufa report at meineschufa.de. Address any errors before applying for a mortgage — banks will check this automatically.",
+          },
+          {
+            icon: FileSearch,
+            label: "Proof of Income",
+            detail:
+              "Prepare the last 3 Gehaltsabrechnungen (payslips), your most recent Steuerbescheid (tax assessment), and employment contract. Self-employed buyers need 2 years of Gewinn-und-Verlustrechnung.",
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ProofOfFundsGuide }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -19,14 +19,24 @@ import { ProgressBar } from "../ProgressBar"
 import { ResourceCard } from "../ResourceCard"
 import { TaskCheckbox } from "../TaskCheckbox"
 import { WarningCallout } from "../WarningCallout"
+import { BuyingCostsGuide } from "./BuyingCostsGuide"
+import { DocumentsPrep } from "./DocumentsPrep"
+import { DueDiligenceAndOffer } from "./DueDiligenceAndOffer"
 import { FinanceCheck } from "./FinanceCheck"
+import { FindAndEvaluateGuide } from "./FindAndEvaluateGuide"
+import { LoanCommitmentGuide } from "./LoanCommitmentGuide"
 import { MarketInsights } from "./MarketInsights"
 import { MortgageComparison } from "./MortgageComparison"
 import { MortgagePreapproval } from "./MortgagePreapproval"
+import { NotaryAndContract } from "./NotaryAndContract"
+import { NotarySigningGuide } from "./NotarySigningGuide"
 import { OwnershipInsurance } from "./OwnershipInsurance"
 import { OwnershipManagement } from "./OwnershipManagement"
 import { OwnershipRegistration } from "./OwnershipRegistration"
 import { OwnershipTaxFinance } from "./OwnershipTaxFinance"
+import { OwnershipTransferGuide } from "./OwnershipTransferGuide"
+import { PaymentAndTransferTaxGuide } from "./PaymentAndTransferTaxGuide"
+import { ProofOfFundsGuide } from "./ProofOfFundsGuide"
 import { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
 import { PropertyGoalsForm } from "./PropertyGoalsForm"
 import { RentalApplicationGuide } from "./RentalApplicationGuide"
@@ -101,6 +111,53 @@ const STEP_CONTENT_REGISTRY: Record<
   rental_application_documents: (p) => <RentalApplicationGuide step={p.step} />,
   rental_contract_review: (p) => <RentalContractReview step={p.step} />,
   rental_move_in_checklist: (p) => <RentalMoveInGuide step={p.step} />,
+  property_goals_and_market: (p) => (
+    <div className="space-y-4">
+      <PropertyGoalsForm
+        journeyId={p.journeyId}
+        initialGoals={p.propertyGoals}
+        propertyLocation={p.propertyLocation}
+      />
+      <MarketInsights
+        propertyLocation={p.propertyLocation}
+        propertyType={p.propertyType}
+        budgetEuros={p.budgetEuros}
+        propertyGoals={p.propertyGoals}
+        marketInsights={p.marketInsights}
+      />
+    </div>
+  ),
+  secure_financing: (p) => (
+    <div className="space-y-4">
+      <FinanceCheck step={p.step} />
+      <MortgagePreapproval step={p.step} />
+      <MortgageComparison step={p.step} />
+    </div>
+  ),
+  registration_and_insurance: (p) => (
+    <div className="space-y-4">
+      <OwnershipRegistration step={p.step} />
+      <OwnershipInsurance step={p.step} />
+    </div>
+  ),
+  management_and_finance_setup: (p) => (
+    <div className="space-y-4">
+      <OwnershipManagement step={p.step} />
+      <OwnershipTaxFinance step={p.step} />
+    </div>
+  ),
+  find_and_evaluate_property: (p) => (
+    <FindAndEvaluateGuide journeyId={p.journeyId} stepId={p.step.id} />
+  ),
+  buying_costs: (p) => <BuyingCostsGuide step={p.step} />,
+  proof_of_funds: (p) => <ProofOfFundsGuide step={p.step} />,
+  documents_prep: (p) => <DocumentsPrep step={p.step} />,
+  due_diligence_and_offer: (p) => <DueDiligenceAndOffer step={p.step} />,
+  notary_and_contract: (p) => <NotaryAndContract step={p.step} />,
+  loan_commitment: (p) => <LoanCommitmentGuide step={p.step} />,
+  notary_signing: (p) => <NotarySigningGuide step={p.step} />,
+  payment_and_transfer_tax: (p) => <PaymentAndTransferTaxGuide step={p.step} />,
+  ownership_transfer: (p) => <OwnershipTransferGuide step={p.step} />,
 }
 
 /******************************************************************************


### PR DESCRIPTION
## Summary

- Adds 10 new step content renderer components for the v2 consolidated buying journey: `BuyingCostsGuide`, `DocumentsPrep`, `DueDiligenceAndOffer`, `FindAndEvaluateGuide`, `LoanCommitmentGuide`, `NotaryAndContract`, `NotarySigningGuide`, `OwnershipTransferGuide`, `PaymentAndTransferTaxGuide`, `ProofOfFundsGuide`
- Each component provides rich inline guidance (using `GuidanceCard`) covering German-specific legal and financial context for that buying step — costs breakdown, document requirements, due diligence checks, notary process, loan commitment, payment flow, and ownership transfer
- Registers all 10 new renderers in `StepBody`'s `STEP_CONTENT_REGISTRY` so each v2 buying step key maps to its corresponding guidance component

## Test plan

- [ ] Open a buying journey and navigate to each step: Buying Costs, Documents Prep, Due Diligence & Offer, Find & Evaluate, Loan Commitment, Notary & Contract, Notary Signing, Ownership Transfer, Payment & Transfer Tax, Proof of Funds
- [ ] Confirm the correct `GuidanceCard` content renders inline alongside the step tasks
- [ ] Verify document upload zone appears in `DueDiligenceAndOffer` and `NotaryAndContract` (uses `StepDocumentReview`)
- [ ] Verify `FindAndEvaluateGuide` renders the property evaluation calculator below the guidance cards
- [ ] Confirm TypeScript builds clean (`bunx tsc --noEmit`)
- [ ] Confirm pre-commit passes (biome, ruff, SDK gen)