### PR TITLE
feat(journey): extract composite v2 step renderers to dedicated components

### DIFF
--- a/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
@@ -1,10 +1,11 @@
 /**
  * Find And Evaluate Guide Step Content
- * Guidance for searching and evaluating German properties
+ * Tabbed guidance for searching and evaluating German properties
  */
 
 import { BarChart2, Building2, MapPin, Search } from "lucide-react"
 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { GuidanceCard } from "./GuidanceCard"
 import { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
 
@@ -21,47 +22,54 @@ function FindAndEvaluateGuide(props: Readonly<IProps>) {
   const { journeyId, stepId } = props
 
   return (
-    <div className="space-y-4">
-      <GuidanceCard
-        title="Finding Properties in Germany"
-        description="Use the right platforms and criteria to narrow your search efficiently."
-        items={[
-          {
-            icon: Search,
-            label: "Major Listing Portals",
-            detail:
-              "Search on Immobilienscout24, Immowelt, and Kleinanzeigen. Set up alerts for your target location, size, and budget to catch new listings early.",
-          },
-          {
-            icon: MapPin,
-            label: "Location Research",
-            detail:
-              "Evaluate the Lage (location) carefully — proximity to transport, schools, amenities, and future development plans all affect value and rental demand.",
-          },
-          {
-            icon: Building2,
-            label: "Property Types to Compare",
-            detail:
-              "Compare Eigentumswohnung (flat), Reihenhaus (terraced house), and Einfamilienhaus (detached). Each has different cost structures and maintenance obligations.",
-          },
-        ]}
-        tip="The first 48 hours after a listing goes live are critical. Properties in high-demand areas often receive multiple offers within days."
-      />
-      <GuidanceCard
-        title="Evaluating Properties"
-        description="Assess each property beyond the asking price before committing."
-        items={[
-          {
-            icon: BarChart2,
-            label: "Price Per Square Metre",
-            detail:
-              "Compare the €/m² against recent sales in the same postcode using the Kaufpreissammlung or local Gutachterausschuss reports.",
-          },
-        ]}
-        tip="Use the property evaluation calculator below to model purchase costs and projected rental yield for each property you're serious about."
-      />
-      <PropertyEvaluationSummary journeyId={journeyId} stepId={stepId} />
-    </div>
+    <Tabs defaultValue="find">
+      <TabsList className="grid w-full grid-cols-2">
+        <TabsTrigger value="find">Find Properties</TabsTrigger>
+        <TabsTrigger value="evaluate">Evaluate & Calculate</TabsTrigger>
+      </TabsList>
+      <TabsContent value="find" className="mt-4 space-y-4">
+        <GuidanceCard
+          title="Finding Properties in Germany"
+          description="Use the right platforms and criteria to narrow your search efficiently."
+          items={[
+            {
+              icon: Search,
+              label: "Major Listing Portals",
+              detail:
+                "Search on Immobilienscout24, Immowelt, and Kleinanzeigen. Set up alerts for your target location, size, and budget to catch new listings early.",
+            },
+            {
+              icon: MapPin,
+              label: "Location Research",
+              detail:
+                "Evaluate the Lage (location) carefully — proximity to transport, schools, amenities, and future development plans all affect value and rental demand.",
+            },
+            {
+              icon: Building2,
+              label: "Property Types to Compare",
+              detail:
+                "Compare Eigentumswohnung (flat), Reihenhaus (terraced house), and Einfamilienhaus (detached). Each has different cost structures and maintenance obligations.",
+            },
+          ]}
+          tip="The first 48 hours after a listing goes live are critical. Properties in high-demand areas often receive multiple offers within days."
+        />
+        <GuidanceCard
+          title="Evaluating Properties"
+          description="Assess each property beyond the asking price before committing."
+          items={[
+            {
+              icon: BarChart2,
+              label: "Price Per Square Metre",
+              detail:
+                "Compare the €/m² against recent sales in the same postcode using the Kaufpreissammlung or local Gutachterausschuss reports.",
+            },
+          ]}
+        />
+      </TabsContent>
+      <TabsContent value="evaluate" className="mt-4">
+        <PropertyEvaluationSummary journeyId={journeyId} stepId={stepId} />
+      </TabsContent>
+    </Tabs>
   )
 }
 

--- a/frontend/src/components/Journey/StepContent/ManagementAndFinanceSetup.tsx
+++ b/frontend/src/components/Journey/StepContent/ManagementAndFinanceSetup.tsx
@@ -1,0 +1,34 @@
+/**
+ * Management and Finance Setup Step Content
+ * Combines ongoing property management guidance with tax and finance setup
+ */
+
+import type { JourneyStep } from "@/models/journey"
+import { OwnershipManagement } from "./OwnershipManagement"
+import { OwnershipTaxFinance } from "./OwnershipTaxFinance"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Renders property management guide followed by tax and finance setup. */
+function ManagementAndFinanceSetup(props: Readonly<IProps>) {
+  const { step } = props
+
+  return (
+    <div className="space-y-4">
+      <OwnershipManagement step={step} />
+      <OwnershipTaxFinance step={step} />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ManagementAndFinanceSetup }

--- a/frontend/src/components/Journey/StepContent/PropertyGoalsAndMarket.tsx
+++ b/frontend/src/components/Journey/StepContent/PropertyGoalsAndMarket.tsx
@@ -1,0 +1,56 @@
+/**
+ * Property Goals and Market Step Content
+ * Combines goal-setting form with local market insights in one step
+ */
+
+import type { MarketInsightsData, PropertyGoals } from "@/models/journey"
+import { MarketInsights } from "./MarketInsights"
+import { PropertyGoalsForm } from "./PropertyGoalsForm"
+
+interface IProps {
+  journeyId: string
+  propertyLocation?: string
+  propertyType?: string
+  budgetEuros?: number
+  propertyGoals?: PropertyGoals
+  marketInsights?: MarketInsightsData
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Renders property goals form followed by market insights for the user's target location. */
+function PropertyGoalsAndMarket(props: Readonly<IProps>) {
+  const {
+    journeyId,
+    propertyLocation,
+    propertyType,
+    budgetEuros,
+    propertyGoals,
+    marketInsights,
+  } = props
+
+  return (
+    <div className="space-y-4">
+      <PropertyGoalsForm
+        journeyId={journeyId}
+        initialGoals={propertyGoals}
+        propertyLocation={propertyLocation}
+      />
+      <MarketInsights
+        propertyLocation={propertyLocation}
+        propertyType={propertyType}
+        budgetEuros={budgetEuros}
+        propertyGoals={propertyGoals}
+        marketInsights={marketInsights}
+      />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { PropertyGoalsAndMarket }

--- a/frontend/src/components/Journey/StepContent/RegistrationAndInsurance.tsx
+++ b/frontend/src/components/Journey/StepContent/RegistrationAndInsurance.tsx
@@ -1,0 +1,34 @@
+/**
+ * Registration and Insurance Step Content
+ * Combines Grundbuch registration guidance with property insurance overview
+ */
+
+import type { JourneyStep } from "@/models/journey"
+import { OwnershipInsurance } from "./OwnershipInsurance"
+import { OwnershipRegistration } from "./OwnershipRegistration"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Renders ownership registration steps followed by insurance guidance. */
+function RegistrationAndInsurance(props: Readonly<IProps>) {
+  const { step } = props
+
+  return (
+    <div className="space-y-4">
+      <OwnershipRegistration step={step} />
+      <OwnershipInsurance step={step} />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { RegistrationAndInsurance }

--- a/frontend/src/components/Journey/StepContent/SecureFinancing.tsx
+++ b/frontend/src/components/Journey/StepContent/SecureFinancing.tsx
@@ -1,0 +1,68 @@
+/**
+ * Secure Financing Step Content
+ * Three-tab financing guide: finances check → pre-approval → offer comparison.
+ * Only renders substantive content for mortgage or mixed financing journeys.
+ */
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { JourneyStep } from "@/models/journey"
+import { useJourneyContext } from "../JourneyContext"
+import { FinanceCheck } from "./FinanceCheck"
+import { GuidanceCard } from "./GuidanceCard"
+import { MortgageComparison } from "./MortgageComparison"
+import { MortgagePreapproval } from "./MortgagePreapproval"
+
+interface IProps {
+  step: JourneyStep
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Shown for cash buyers in place of the full mortgage guide. */
+function CashBuyerNotice() {
+  return (
+    <GuidanceCard
+      title="Paying in Cash"
+      description="Your journey is set up for a cash purchase — no mortgage financing required."
+      items={[]}
+      tip="You can still use the financing calculators to model scenarios or compare with a mortgage purchase."
+    />
+  )
+}
+
+/** Three-tab mortgage guide: check finances, get pre-approved, compare offers. */
+function SecureFinancing(props: Readonly<IProps>) {
+  const { step } = props
+  const { journey } = useJourneyContext()
+
+  if (journey.financing_type === "cash") {
+    return <CashBuyerNotice />
+  }
+
+  return (
+    <Tabs defaultValue="check">
+      <TabsList className="grid w-full grid-cols-3">
+        <TabsTrigger value="check">1. Finances</TabsTrigger>
+        <TabsTrigger value="preapproval">2. Pre-Approval</TabsTrigger>
+        <TabsTrigger value="compare">3. Compare Offers</TabsTrigger>
+      </TabsList>
+      <TabsContent value="check" className="mt-4">
+        <FinanceCheck step={step} />
+      </TabsContent>
+      <TabsContent value="preapproval" className="mt-4">
+        <MortgagePreapproval step={step} />
+      </TabsContent>
+      <TabsContent value="compare" className="mt-4">
+        <MortgageComparison step={step} />
+      </TabsContent>
+    </Tabs>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { SecureFinancing }

--- a/frontend/src/components/Journey/StepContent/StepBody.tsx
+++ b/frontend/src/components/Journey/StepContent/StepBody.tsx
@@ -25,6 +25,7 @@ import { DueDiligenceAndOffer } from "./DueDiligenceAndOffer"
 import { FinanceCheck } from "./FinanceCheck"
 import { FindAndEvaluateGuide } from "./FindAndEvaluateGuide"
 import { LoanCommitmentGuide } from "./LoanCommitmentGuide"
+import { ManagementAndFinanceSetup } from "./ManagementAndFinanceSetup"
 import { MarketInsights } from "./MarketInsights"
 import { MortgageComparison } from "./MortgageComparison"
 import { MortgagePreapproval } from "./MortgagePreapproval"
@@ -38,7 +39,9 @@ import { OwnershipTransferGuide } from "./OwnershipTransferGuide"
 import { PaymentAndTransferTaxGuide } from "./PaymentAndTransferTaxGuide"
 import { ProofOfFundsGuide } from "./ProofOfFundsGuide"
 import { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
+import { PropertyGoalsAndMarket } from "./PropertyGoalsAndMarket"
 import { PropertyGoalsForm } from "./PropertyGoalsForm"
+import { RegistrationAndInsurance } from "./RegistrationAndInsurance"
 import { RentalApplicationGuide } from "./RentalApplicationGuide"
 import { RentalContractReview } from "./RentalContractReview"
 import { RentalLandlordLaw } from "./RentalLandlordLaw"
@@ -48,6 +51,7 @@ import { RentalPropertyManagement } from "./RentalPropertyManagement"
 import { RentalSearchGuide } from "./RentalSearchGuide"
 import { RentalTaxStrategy } from "./RentalTaxStrategy"
 import { RentalYieldAnalysis } from "./RentalYieldAnalysis"
+import { SecureFinancing } from "./SecureFinancing"
 import { StepDocumentReview } from "./StepDocumentReview"
 
 interface IProps {
@@ -70,10 +74,13 @@ interface IStepContentProps {
   marketInsights?: MarketInsightsData
 }
 
+// v1 legacy keys — kept for backwards compatibility with existing journeys
+// v2 merged keys use dedicated composite components
 const STEP_CONTENT_REGISTRY: Record<
   string,
   (props: IStepContentProps) => ReactNode
 > = {
+  // v1 individual step keys
   finance_check: (p) => <FinanceCheck step={p.step} />,
   mortgage_preapproval: (p) => <MortgagePreapproval step={p.step} />,
   mortgage_comparison: (p) => <MortgageComparison step={p.step} />,
@@ -111,40 +118,21 @@ const STEP_CONTENT_REGISTRY: Record<
   rental_application_documents: (p) => <RentalApplicationGuide step={p.step} />,
   rental_contract_review: (p) => <RentalContractReview step={p.step} />,
   rental_move_in_checklist: (p) => <RentalMoveInGuide step={p.step} />,
+  // v2 merged keys
   property_goals_and_market: (p) => (
-    <div className="space-y-4">
-      <PropertyGoalsForm
-        journeyId={p.journeyId}
-        initialGoals={p.propertyGoals}
-        propertyLocation={p.propertyLocation}
-      />
-      <MarketInsights
-        propertyLocation={p.propertyLocation}
-        propertyType={p.propertyType}
-        budgetEuros={p.budgetEuros}
-        propertyGoals={p.propertyGoals}
-        marketInsights={p.marketInsights}
-      />
-    </div>
+    <PropertyGoalsAndMarket
+      journeyId={p.journeyId}
+      propertyLocation={p.propertyLocation}
+      propertyType={p.propertyType}
+      budgetEuros={p.budgetEuros}
+      propertyGoals={p.propertyGoals}
+      marketInsights={p.marketInsights}
+    />
   ),
-  secure_financing: (p) => (
-    <div className="space-y-4">
-      <FinanceCheck step={p.step} />
-      <MortgagePreapproval step={p.step} />
-      <MortgageComparison step={p.step} />
-    </div>
-  ),
-  registration_and_insurance: (p) => (
-    <div className="space-y-4">
-      <OwnershipRegistration step={p.step} />
-      <OwnershipInsurance step={p.step} />
-    </div>
-  ),
+  secure_financing: (p) => <SecureFinancing step={p.step} />,
+  registration_and_insurance: (p) => <RegistrationAndInsurance step={p.step} />,
   management_and_finance_setup: (p) => (
-    <div className="space-y-4">
-      <OwnershipManagement step={p.step} />
-      <OwnershipTaxFinance step={p.step} />
-    </div>
+    <ManagementAndFinanceSetup step={p.step} />
   ),
   find_and_evaluate_property: (p) => (
     <FindAndEvaluateGuide journeyId={p.journeyId} stepId={p.step.id} />


### PR DESCRIPTION
## Summary

- Resolves task 268: all 4 inline JSX composite renderers in `StepBody.tsx` are now extracted to dedicated component files, making the registry consistent and `StepBody` easier to maintain
- `PropertyGoalsAndMarket` — goals form followed by market insights
- `SecureFinancing` — 3-tab guide (Finances / Pre-Approval / Compare Offers) with a `CashBuyerNotice` shown when `financing_type === "cash"` (reads from JourneyContext)
- `RegistrationAndInsurance` — combines `OwnershipRegistration` + `OwnershipInsurance`
- `ManagementAndFinanceSetup` — combines `OwnershipManagement` + `OwnershipTaxFinance`
- `FindAndEvaluateGuide` upgraded from stacked layout to **tabbed** layout: "Find Properties" tab shows guidance cards; "Evaluate & Calculate" tab shows `PropertyEvaluationSummary`
- All v1 legacy `content_key` entries remain untouched in the registry for backwards compatibility

## Test plan

- [ ] Navigate to a v2 buying journey: `property_goals_and_market` step renders goals form + market insights in sequence
- [ ] `secure_financing` step: renders 3 tabs (Finances, Pre-Approval, Compare Offers); switching tabs shows the correct component; on a cash journey it shows the CashBuyerNotice instead
- [ ] `registration_and_insurance` step: renders registration guide then insurance guide stacked
- [ ] `management_and_finance_setup` step: renders management guide then tax/finance guide stacked
- [ ] `find_and_evaluate_property` step: renders with two tabs; "Find Properties" tab shows guidance cards; "Evaluate & Calculate" tab shows the property evaluation summary
- [ ] Verify a v1 journey still renders correctly (legacy keys like `finance_check`, `market_research`, `ownership_registration` etc. use their original components)
- [ ] `bunx tsc --noEmit` passes
- [ ] `pre-commit run --all-files` passes