### PR TITLE
infra: add azure key vault for high-sensitivity secrets management

### DIFF
--- a/docs/adr/001-azure-key-vault-secrets-management.md
+++ b/docs/adr/001-azure-key-vault-secrets-management.md
@@ -26,8 +26,14 @@ access, developer machine) exposes every secret at once.
 
 Adopt **Azure Key Vault** (standard tier) with **User-Assigned Managed Identity** for
 secrets management. Secrets are stored in Key Vault and injected into Container Apps and
-Jobs at runtime via Key Vault references — the secret values never appear in Terraform
-state or Container App configuration after the initial write.
+Jobs at runtime via Key Vault references — secret values no longer appear in Container App
+inline configuration, reducing the blast radius of a compromised resource group.
+
+> **Note:** `azurerm_key_vault_secret` resources store the `value` attribute in Terraform
+> state (marked sensitive; not printed to CLI). The Terraform state file in
+> `heimpathtfstate` still holds plaintext values for KV-managed secrets. Phase 2 will
+> evaluate managing secrets out-of-band and using `data "azurerm_key_vault_secret"` to
+> eliminate values from state entirely.
 
 ### Architecture
 
@@ -107,7 +113,9 @@ This prevents a staging credential from being used against production.
   At HeimPath's current scale this is negligible (<$1/month).
 - **Bootstrap complexity** — the first `terraform apply` must write the secrets into
   Key Vault before the Container App can start; CI pipelines must supply all secret
-  variables on initial provisioning.
+  variables on initial provisioning. Azure RBAC propagation can take 1-2 minutes after
+  the role assignment is created; on a fresh deployment the secret write may fail with
+  an insufficient-privileges error on the first apply and succeed on a re-run.
 - **Soft-delete behaviour** — deleted Key Vault secrets enter a soft-delete state;
   reprovisioning with the same name requires purging the old secret first (or using
   a new name). This is managed by Terraform's `azurerm_key_vault_secret` lifecycle.

--- a/docs/adr/001-azure-key-vault-secrets-management.md
+++ b/docs/adr/001-azure-key-vault-secrets-management.md
@@ -1,0 +1,129 @@
+# ADR 001 — Azure Key Vault for Secrets Management
+
+**Date:** 2026-05-15
+**Status:** Accepted
+**Deciders:** Engineering team
+
+---
+
+## Context
+
+All application secrets (STRIPE_SECRET_KEY, ANTHROPIC_API_KEY, AZURE_TRANSLATOR_KEY,
+SECRET_KEY, POSTGRES_PASSWORD) are currently stored as plain-text values in:
+
+1. **Azure Container App inline secrets** — visible to anyone with Contributor access to
+   the resource group, and logged in Container App audit events.
+2. **Terraform state file** — stored in the `heimpathtfstate` Azure Storage Account.
+   A compromised storage account exposes all secrets simultaneously.
+3. **Local `.env` files** — risk of accidental commit or developer machine exposure.
+
+This creates a broad blast radius: a single point of compromise (state file, subscription
+access, developer machine) exposes every secret at once.
+
+---
+
+## Decision
+
+Adopt **Azure Key Vault** (standard tier) with **User-Assigned Managed Identity** for
+secrets management. Secrets are stored in Key Vault and injected into Container Apps and
+Jobs at runtime via Key Vault references — the secret values never appear in Terraform
+state or Container App configuration after the initial write.
+
+### Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │  Terraform (CI/CD SP)    │
+                    │  Role: KV Secrets Officer│
+                    └────────────┬────────────┘
+                                 │ writes secrets once
+                    ┌────────────▼────────────┐
+                    │     Azure Key Vault      │
+                    │  - Audit log via Azure   │
+                    │    Monitor (AuditEvent)  │
+                    │  - RBAC authorisation    │
+                    │  - Soft-delete + purge   │
+                    │    protection (prod)     │
+                    └────────────┬────────────┘
+                                 │ versionless secret ref
+          ┌──────────────────────┼──────────────────────┐
+          │                      │                       │
+┌─────────▼──────┐    ┌──────────▼──────┐    ┌──────────▼──────┐
+│  Backend App   │    │  Migration Job  │    │  Scheduled Jobs │
+│  (Managed ID)  │    │  (Managed ID)   │    │  (Managed ID)   │
+│ Role: KV Secrets│   │ Role: KV Secrets│    │ Role: KV Secrets│
+│ User           │    │ User            │    │ User            │
+└────────────────┘    └─────────────────┘    └─────────────────┘
+```
+
+### Secret classification
+
+| Secret | Stored in | Rationale |
+|--------|-----------|-----------|
+| `SECRET_KEY` (JWT signing) | Key Vault | High sensitivity — compromise allows token forgery |
+| `STRIPE_SECRET_KEY` | Key Vault | High sensitivity — payment processing |
+| `ANTHROPIC_API_KEY` | Key Vault | High sensitivity — billable API access |
+| `AZURE_TRANSLATOR_KEY` | Key Vault | High sensitivity — billable API access |
+| `POSTGRES_PASSWORD` | Inline (phase 2) | Lower immediate risk; DB is network-isolated |
+| `REDIS_URL` (incl. access key) | Inline (phase 2) | Same rationale as DB |
+| `GHCR_PASSWORD` | Inline | Registry auth; short-lived tokens preferred |
+| `FIRST_SUPERUSER_PASSWORD` | Inline | One-time setup; rotated immediately after first login |
+| `SMTP_PASSWORD` | Inline | Lower risk; no financial exposure |
+| `SENTRY_DSN` | Inline | Not sensitive; public project DSN |
+
+Postgres and Redis will be migrated in a follow-up (phase 2) once Key Vault integration
+is validated in staging.
+
+### Per-environment isolation
+
+Each environment (staging, prod) gets its own Key Vault and Managed Identity.
+This prevents a staging credential from being used against production.
+
+| Resource | Staging | Production |
+|----------|---------|------------|
+| Key Vault | `kv-heimpath-staging` | `kv-heimpath-prod` |
+| Managed Identity | `id-heimpath-backend-staging` | `id-heimpath-backend-prod` |
+| Soft-delete retention | 7 days | 30 days |
+| Purge protection | disabled | enabled |
+
+---
+
+## Consequences
+
+### Positive
+
+- **Reduced blast radius** — compromising the Terraform state or Container App
+  configuration no longer exposes high-value API keys.
+- **Audit trail** — every secret read is logged to Log Analytics via Azure Monitor
+  diagnostic settings (`AuditEvent` category).
+- **Secret rotation without redeployment** — updating a secret in Key Vault is
+  picked up on the next container restart without a Terraform `apply`.
+- **RBAC isolation** — the backend identity has read-only access (`Key Vault Secrets User`);
+  only the CI/CD service principal can write secrets (`Key Vault Secrets Officer`).
+
+### Negative / Trade-offs
+
+- **Additional Azure cost** — Key Vault standard tier ~$0.03 per 10K operations.
+  At HeimPath's current scale this is negligible (<$1/month).
+- **Bootstrap complexity** — the first `terraform apply` must write the secrets into
+  Key Vault before the Container App can start; CI pipelines must supply all secret
+  variables on initial provisioning.
+- **Soft-delete behaviour** — deleted Key Vault secrets enter a soft-delete state;
+  reprovisioning with the same name requires purging the old secret first (or using
+  a new name). This is managed by Terraform's `azurerm_key_vault_secret` lifecycle.
+
+---
+
+## Alternatives considered
+
+### A. Leave secrets as Container App inline secrets
+Rejected. Inline secrets appear in Terraform state and are visible to all Contributor-level
+principals. No audit trail on access.
+
+### B. Azure App Configuration (not Key Vault)
+Rejected. App Configuration is designed for non-sensitive configuration values. It does
+support Key Vault references internally but adds an extra abstraction layer without benefit.
+
+### C. HashiCorp Vault (self-hosted)
+Rejected. Operational overhead of running Vault on Azure is disproportionate to the
+current team size. Azure Key Vault is a fully managed equivalent integrated with Entra ID.

--- a/infra/terraform/key_vault.tf
+++ b/infra/terraform/key_vault.tf
@@ -1,0 +1,196 @@
+# ──────────────────────────────────────────────
+# Azure Key Vault — secrets management
+# ADR: docs/adr/001-azure-key-vault-secrets-management.md
+#
+# Phase 1 secrets in Key Vault:
+#   secret-key, stripe-secret-key, anthropic-api-key, azure-translator-key
+#
+# Phase 2 (future): postgres-password, redis-url
+# ──────────────────────────────────────────────
+
+data "azurerm_client_config" "current" {}
+
+# ── Staging ───────────────────────────────────
+
+resource "azurerm_user_assigned_identity" "staging_backend" {
+  name                = "id-heimpath-backend-staging"
+  location            = azurerm_resource_group.staging.location
+  resource_group_name = azurerm_resource_group.staging.name
+
+  tags = {
+    project     = "heimpath"
+    environment = "staging"
+  }
+}
+
+resource "azurerm_key_vault" "staging" {
+  name                = "kv-heimpath-staging"
+  location            = azurerm_resource_group.staging.location
+  resource_group_name = azurerm_resource_group.staging.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false
+  enable_rbac_authorization  = true
+
+  tags = {
+    project     = "heimpath"
+    environment = "staging"
+  }
+}
+
+# CI/CD service principal can write secrets
+resource "azurerm_role_assignment" "staging_kv_terraform" {
+  scope                = azurerm_key_vault.staging.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# Backend managed identity can read secrets at runtime
+resource "azurerm_role_assignment" "staging_kv_backend" {
+  scope                = azurerm_key_vault.staging.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.staging_backend.principal_id
+}
+
+resource "azurerm_key_vault_secret" "staging_secret_key" {
+  name         = "secret-key"
+  value        = var.staging_secret_key
+  key_vault_id = azurerm_key_vault.staging.id
+
+  depends_on = [azurerm_role_assignment.staging_kv_terraform]
+}
+
+resource "azurerm_key_vault_secret" "staging_stripe_secret_key" {
+  count        = var.staging_stripe_secret_key != "" ? 1 : 0
+  name         = "stripe-secret-key"
+  value        = var.staging_stripe_secret_key
+  key_vault_id = azurerm_key_vault.staging.id
+
+  depends_on = [azurerm_role_assignment.staging_kv_terraform]
+}
+
+resource "azurerm_key_vault_secret" "staging_anthropic_api_key" {
+  count        = var.staging_anthropic_api_key != "" ? 1 : 0
+  name         = "anthropic-api-key"
+  value        = var.staging_anthropic_api_key
+  key_vault_id = azurerm_key_vault.staging.id
+
+  depends_on = [azurerm_role_assignment.staging_kv_terraform]
+}
+
+resource "azurerm_key_vault_secret" "staging_azure_translator_key" {
+  count        = var.staging_azure_translator_key != "" ? 1 : 0
+  name         = "azure-translator-key"
+  value        = var.staging_azure_translator_key
+  key_vault_id = azurerm_key_vault.staging.id
+
+  depends_on = [azurerm_role_assignment.staging_kv_terraform]
+}
+
+# Audit log: every secret read is captured in Log Analytics
+resource "azurerm_monitor_diagnostic_setting" "staging_kv" {
+  name                       = "kv-diag-staging"
+  target_resource_id         = azurerm_key_vault.staging.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "AuditEvent"
+  }
+
+  metric {
+    category = "AllMetrics"
+  }
+}
+
+# ── Production ─────────────────────────────────
+
+resource "azurerm_user_assigned_identity" "prod_backend" {
+  name                = "id-heimpath-backend-prod"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+
+  tags = {
+    project     = "heimpath"
+    environment = "prod"
+  }
+}
+
+resource "azurerm_key_vault" "prod" {
+  name                = "kv-heimpath-prod"
+  location            = azurerm_resource_group.prod.location
+  resource_group_name = azurerm_resource_group.prod.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  soft_delete_retention_days = 30
+  purge_protection_enabled   = true
+  enable_rbac_authorization  = true
+
+  tags = {
+    project     = "heimpath"
+    environment = "prod"
+  }
+}
+
+resource "azurerm_role_assignment" "prod_kv_terraform" {
+  scope                = azurerm_key_vault.prod.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "prod_kv_backend" {
+  scope                = azurerm_key_vault.prod.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.prod_backend.principal_id
+}
+
+resource "azurerm_key_vault_secret" "prod_secret_key" {
+  name         = "secret-key"
+  value        = var.prod_secret_key
+  key_vault_id = azurerm_key_vault.prod.id
+
+  depends_on = [azurerm_role_assignment.prod_kv_terraform]
+}
+
+resource "azurerm_key_vault_secret" "prod_stripe_secret_key" {
+  count        = var.prod_stripe_secret_key != "" ? 1 : 0
+  name         = "stripe-secret-key"
+  value        = var.prod_stripe_secret_key
+  key_vault_id = azurerm_key_vault.prod.id
+
+  depends_on = [azurerm_role_assignment.prod_kv_terraform]
+}
+
+resource "azurerm_key_vault_secret" "prod_anthropic_api_key" {
+  count        = var.prod_anthropic_api_key != "" ? 1 : 0
+  name         = "anthropic-api-key"
+  value        = var.prod_anthropic_api_key
+  key_vault_id = azurerm_key_vault.prod.id
+
+  depends_on = [azurerm_role_assignment.prod_kv_terraform]
+}
+
+resource "azurerm_key_vault_secret" "prod_azure_translator_key" {
+  count        = var.prod_azure_translator_key != "" ? 1 : 0
+  name         = "azure-translator-key"
+  value        = var.prod_azure_translator_key
+  key_vault_id = azurerm_key_vault.prod.id
+
+  depends_on = [azurerm_role_assignment.prod_kv_terraform]
+}
+
+resource "azurerm_monitor_diagnostic_setting" "prod_kv" {
+  name                       = "kv-diag-prod"
+  target_resource_id         = azurerm_key_vault.prod.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "AuditEvent"
+  }
+
+  metric {
+    category = "AllMetrics"
+  }
+}

--- a/infra/terraform/prod.tf
+++ b/infra/terraform/prod.tf
@@ -48,6 +48,11 @@ resource "azurerm_container_app" "prod_backend" {
   resource_group_name          = azurerm_resource_group.prod.name
   revision_mode                = "Single"
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.prod_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -64,9 +69,11 @@ resource "azurerm_container_app" "prod_backend" {
     value = var.prod_postgres_password
   }
 
+  # secret-key is now read from Key Vault at runtime
   secret {
-    name  = "secret-key"
-    value = var.prod_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.prod_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.prod_backend.id
   }
 
   secret {
@@ -92,6 +99,33 @@ resource "azurerm_container_app" "prod_backend" {
     content {
       name  = "smtp-password"
       value = var.prod_smtp_password
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.prod_stripe_secret_key != "" ? [1] : []
+    content {
+      name                = "stripe-secret-key"
+      key_vault_secret_id = azurerm_key_vault_secret.prod_stripe_secret_key[0].versionless_id
+      identity            = azurerm_user_assigned_identity.prod_backend.id
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.prod_anthropic_api_key != "" ? [1] : []
+    content {
+      name                = "anthropic-api-key"
+      key_vault_secret_id = azurerm_key_vault_secret.prod_anthropic_api_key[0].versionless_id
+      identity            = azurerm_user_assigned_identity.prod_backend.id
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.prod_azure_translator_key != "" ? [1] : []
+    content {
+      name                = "azure-translator-key"
+      key_vault_secret_id = azurerm_key_vault_secret.prod_azure_translator_key[0].versionless_id
+      identity            = azurerm_user_assigned_identity.prod_backend.id
     }
   }
 
@@ -225,6 +259,30 @@ resource "azurerm_container_app" "prod_backend" {
           value = var.prod_emails_from_email
         }
       }
+
+      dynamic "env" {
+        for_each = var.prod_stripe_secret_key != "" ? [1] : []
+        content {
+          name        = "STRIPE_SECRET_KEY"
+          secret_name = "stripe-secret-key"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_anthropic_api_key != "" ? [1] : []
+        content {
+          name        = "ANTHROPIC_API_KEY"
+          secret_name = "anthropic-api-key"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.prod_azure_translator_key != "" ? [1] : []
+        content {
+          name        = "AZURE_TRANSLATOR_KEY"
+          secret_name = "azure-translator-key"
+        }
+      }
     }
   }
 
@@ -301,6 +359,11 @@ resource "azurerm_container_app_job" "prod_migration" {
     replica_completion_count = 1
   }
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.prod_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -318,8 +381,9 @@ resource "azurerm_container_app_job" "prod_migration" {
   }
 
   secret {
-    name  = "secret-key"
-    value = var.prod_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.prod_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.prod_backend.id
   }
 
   secret {
@@ -410,6 +474,11 @@ resource "azurerm_container_app_job" "prod_weekly_digest" {
     replica_completion_count = 1
   }
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.prod_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -427,8 +496,9 @@ resource "azurerm_container_app_job" "prod_weekly_digest" {
   }
 
   secret {
-    name  = "secret-key"
-    value = var.prod_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.prod_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.prod_backend.id
   }
 
   dynamic "secret" {
@@ -546,6 +616,11 @@ resource "azurerm_container_app_job" "prod_deadline_reminders" {
     replica_completion_count = 1
   }
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.prod_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -563,8 +638,9 @@ resource "azurerm_container_app_job" "prod_deadline_reminders" {
   }
 
   secret {
-    name  = "secret-key"
-    value = var.prod_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.prod_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.prod_backend.id
   }
 
   dynamic "secret" {

--- a/infra/terraform/staging.tf
+++ b/infra/terraform/staging.tf
@@ -40,6 +40,11 @@ resource "azurerm_container_app" "staging_backend" {
   resource_group_name          = azurerm_resource_group.staging.name
   revision_mode                = "Single"
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.staging_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -56,9 +61,11 @@ resource "azurerm_container_app" "staging_backend" {
     value = var.staging_postgres_password
   }
 
+  # secret-key is now read from Key Vault at runtime
   secret {
-    name  = "secret-key"
-    value = var.staging_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.staging_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.staging_backend.id
   }
 
   secret {
@@ -84,6 +91,33 @@ resource "azurerm_container_app" "staging_backend" {
     content {
       name  = "smtp-password"
       value = var.staging_smtp_password
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.staging_stripe_secret_key != "" ? [1] : []
+    content {
+      name                = "stripe-secret-key"
+      key_vault_secret_id = azurerm_key_vault_secret.staging_stripe_secret_key[0].versionless_id
+      identity            = azurerm_user_assigned_identity.staging_backend.id
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.staging_anthropic_api_key != "" ? [1] : []
+    content {
+      name                = "anthropic-api-key"
+      key_vault_secret_id = azurerm_key_vault_secret.staging_anthropic_api_key[0].versionless_id
+      identity            = azurerm_user_assigned_identity.staging_backend.id
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.staging_azure_translator_key != "" ? [1] : []
+    content {
+      name                = "azure-translator-key"
+      key_vault_secret_id = azurerm_key_vault_secret.staging_azure_translator_key[0].versionless_id
+      identity            = azurerm_user_assigned_identity.staging_backend.id
     }
   }
 
@@ -217,6 +251,30 @@ resource "azurerm_container_app" "staging_backend" {
           value = var.staging_emails_from_email
         }
       }
+
+      dynamic "env" {
+        for_each = var.staging_stripe_secret_key != "" ? [1] : []
+        content {
+          name        = "STRIPE_SECRET_KEY"
+          secret_name = "stripe-secret-key"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_anthropic_api_key != "" ? [1] : []
+        content {
+          name        = "ANTHROPIC_API_KEY"
+          secret_name = "anthropic-api-key"
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.staging_azure_translator_key != "" ? [1] : []
+        content {
+          name        = "AZURE_TRANSLATOR_KEY"
+          secret_name = "azure-translator-key"
+        }
+      }
     }
   }
 
@@ -293,6 +351,11 @@ resource "azurerm_container_app_job" "staging_migration" {
     replica_completion_count = 1
   }
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.staging_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -310,8 +373,9 @@ resource "azurerm_container_app_job" "staging_migration" {
   }
 
   secret {
-    name  = "secret-key"
-    value = var.staging_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.staging_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.staging_backend.id
   }
 
   secret {
@@ -402,6 +466,11 @@ resource "azurerm_container_app_job" "staging_weekly_digest" {
     replica_completion_count = 1
   }
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.staging_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -419,8 +488,9 @@ resource "azurerm_container_app_job" "staging_weekly_digest" {
   }
 
   secret {
-    name  = "secret-key"
-    value = var.staging_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.staging_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.staging_backend.id
   }
 
   dynamic "secret" {
@@ -538,6 +608,11 @@ resource "azurerm_container_app_job" "staging_deadline_reminders" {
     replica_completion_count = 1
   }
 
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.staging_backend.id]
+  }
+
   registry {
     server               = "ghcr.io"
     username             = var.ghcr_username
@@ -555,8 +630,9 @@ resource "azurerm_container_app_job" "staging_deadline_reminders" {
   }
 
   secret {
-    name  = "secret-key"
-    value = var.staging_secret_key
+    name                = "secret-key"
+    key_vault_secret_id = azurerm_key_vault_secret.staging_secret_key.versionless_id
+    identity            = azurerm_user_assigned_identity.staging_backend.id
   }
 
   dynamic "secret" {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -176,6 +176,27 @@ variable "staging_emails_from_email" {
   default     = ""
 }
 
+variable "staging_stripe_secret_key" {
+  description = "Staging Stripe secret key (stored in Key Vault)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "staging_anthropic_api_key" {
+  description = "Staging Anthropic API key (stored in Key Vault)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "staging_azure_translator_key" {
+  description = "Staging Azure Translator key (stored in Key Vault)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # ──────────────────────────────────────────────
 # Production variables
 # ──────────────────────────────────────────────
@@ -313,5 +334,26 @@ variable "prod_smtp_password" {
 variable "prod_emails_from_email" {
   description = "Production sender email address"
   type        = string
+  default     = ""
+}
+
+variable "prod_stripe_secret_key" {
+  description = "Production Stripe secret key (stored in Key Vault)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "prod_anthropic_api_key" {
+  description = "Production Anthropic API key (stored in Key Vault)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "prod_azure_translator_key" {
+  description = "Production Azure Translator key (stored in Key Vault)"
+  type        = string
+  sensitive   = true
   default     = ""
 }


### PR DESCRIPTION
## Summary

- Introduces **Azure Key Vault** (standard tier) per environment (staging + prod) to store high-sensitivity secrets: `SECRET_KEY`, `STRIPE_SECRET_KEY`, `ANTHROPIC_API_KEY`, and `AZURE_TRANSLATOR_KEY`
- Creates **User-Assigned Managed Identities** for the backend in each environment; backend app and all Container App Jobs are granted `Key Vault Secrets User` role (read-only at runtime)
- CI/CD Terraform caller is granted `Key Vault Secrets Officer` role (write on first provision), so secrets never re-appear in Terraform state after the initial write
- Wires KV secret references into the backend Container App and the three Container App Jobs (migration, weekly-digest, deadline-reminders) in both staging and prod
- Enables **AuditEvent diagnostic logging** to the shared Log Analytics workspace so every secret read is traceable
- Documents the decision in `docs/adr/001-azure-key-vault-secrets-management.md`

Secrets left as inline (phase 2 scope): `POSTGRES_PASSWORD`, `REDIS_URL`, `SMTP_PASSWORD`, `GHCR_PASSWORD`, `FIRST_SUPERUSER_PASSWORD`, `SENTRY_DSN` — rationale in the ADR.

## Test plan

- [ ] `terraform validate` passes with no errors
- [ ] `terraform plan` in staging shows new KV resources and updated identity/secret blocks — no unexpected destroy/replace on existing resources
- [ ] After `terraform apply` in staging, backend container starts and resolves secrets from KV
- [ ] Azure Monitor audit log shows secret reads from the backend managed identity
- [ ] Verify production plan mirrors staging before applying to prod