### PR TITLE
feat(infra): add DATABASE_USE_SSL flag and host-gateway for self-hosted Postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
               "EMAILS_FROM_EMAIL=info@example.com" \
               "SENTRY_DSN=" \
               "REDIS_PASSWORD=$(openssl rand -hex 16)" \
+              "DATABASE_USE_SSL=false" \
               > .env
 
       - run:

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,9 @@ POSTGRES_PORT=5432
 POSTGRES_DB=app
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=changethis
+# Set to false when connecting to a self-hosted Postgres on the same host
+# (e.g. Hetzner VPS after Neon migration). Neon and any remote Postgres: true.
+DATABASE_USE_SSL=true
 
 # Sentry (optional, leave empty to disable)
 SENTRY_DSN=

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -78,6 +78,7 @@ jobs:
         echo "EMAILS_FROM_EMAIL=info@example.com" >> .env
         echo "SENTRY_DSN=" >> .env
         echo "REDIS_PASSWORD=$(openssl rand -hex 16)" >> .env
+        echo "DATABASE_USE_SSL=false" >> .env
     - uses: oven-sh/setup-bun@v2
     - uses: actions/setup-python@v6
       with:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -43,6 +43,7 @@ jobs:
           echo "EMAILS_FROM_EMAIL=info@example.com" >> .env
           echo "SENTRY_DSN=" >> .env
           echo "REDIS_PASSWORD=$(openssl rand -hex 16)" >> .env
+          echo "DATABASE_USE_SSL=false" >> .env
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -59,6 +59,9 @@ class Settings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str = ""
     POSTGRES_DB: str = ""
+    # Set to false when connecting to a self-hosted Postgres on localhost
+    # (e.g. the Hetzner VPS) where TLS is not configured.
+    DATABASE_USE_SSL: bool = True
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -73,8 +76,8 @@ class Settings(BaseSettings):
                 path=self.POSTGRES_DB,
             )
         )
-        if self.ENVIRONMENT != "local":
-            base_url += "?sslmode=require&channel_binding=require"
+        if self.DATABASE_USE_SSL:
+            base_url += "?sslmode=require"
         return base_url
 
     @computed_field  # type: ignore[prop-decorator]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -59,8 +59,9 @@ class Settings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str = ""
     POSTGRES_DB: str = ""
-    # Set to false when connecting to a self-hosted Postgres on localhost
-    # (e.g. the Hetzner VPS) where TLS is not configured.
+    # Set to false when connecting to a Postgres that has no TLS configured —
+    # e.g. self-hosted Postgres on the Hetzner VPS, or a local dev Postgres.
+    # Neon and any remote/cloud Postgres: keep true (default).
     DATABASE_USE_SSL: bool = True
 
     @computed_field  # type: ignore[prop-decorator]

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -11,7 +11,7 @@ from app.core.config import settings
 _async_connect_args: dict[str, object] = {
     "server_settings": {"statement_timeout": str(settings.DB_STATEMENT_TIMEOUT_MS)},
 }
-if settings.ENVIRONMENT != "local":
+if settings.DATABASE_USE_SSL:
     _async_connect_args["ssl"] = True
 
 async_engine = create_async_engine(

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -70,3 +70,25 @@ def test_secret_key_missing_raises_validation_error(
     kwargs = {k: v for k, v in _base_settings_kwargs().items() if k != "SECRET_KEY"}
     with pytest.raises(ValidationError):
         Settings(**kwargs, ENVIRONMENT="local", _env_file=None)
+
+
+# ── DATABASE_USE_SSL ───────────────────────────────────────────────────────
+
+
+def test_database_use_ssl_true_appends_sslmode() -> None:
+    """DATABASE_USE_SSL=True must append ?sslmode=require to SQLALCHEMY_DATABASE_URI."""
+    s = Settings(**_base_settings_kwargs(), DATABASE_USE_SSL=True, _env_file=None)
+    assert "sslmode=require" in s.SQLALCHEMY_DATABASE_URI
+
+
+def test_database_use_ssl_false_omits_sslmode() -> None:
+    """DATABASE_USE_SSL=False must not include sslmode in SQLALCHEMY_DATABASE_URI."""
+    s = Settings(**_base_settings_kwargs(), DATABASE_USE_SSL=False, _env_file=None)
+    assert "sslmode" not in s.SQLALCHEMY_DATABASE_URI
+
+
+def test_database_use_ssl_default_is_true() -> None:
+    """DATABASE_USE_SSL defaults to True — SSL on unless explicitly disabled."""
+    s = Settings(**_base_settings_kwargs(), _env_file=None)
+    assert s.DATABASE_USE_SSL is True
+    assert "sslmode=require" in s.SQLALCHEMY_DATABASE_URI

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,8 @@ services:
     command: bash scripts/prestart.sh
     env_file:
       - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       redis:
         condition: service_healthy
@@ -44,6 +46,8 @@ services:
       - "8000:8000"
     env_file:
       - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/utils/health-check/"]
       interval: 10s
@@ -66,6 +70,8 @@ services:
     command: celery -A app.worker.celery_app worker --loglevel=info --concurrency=2 --hostname=worker@%h
     env_file:
       - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - ENVIRONMENT=${ENVIRONMENT}
       - PROJECT_NAME=${PROJECT_NAME}
@@ -99,6 +105,8 @@ services:
     command: celery -A app.worker.celery_app beat --loglevel=info
     env_file:
       - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - ENVIRONMENT=${ENVIRONMENT}
       - PROJECT_NAME=${PROJECT_NAME}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -29,6 +29,8 @@ services:
     command: bash scripts/prestart.sh
     env_file:
       - .env.staging
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - REDIS_URL=redis://:${REDIS_PASSWORD}@redis-staging:6379
     depends_on:
@@ -47,6 +49,8 @@ services:
       - "8001:8000"
     env_file:
       - .env.staging
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - REDIS_URL=redis://:${REDIS_PASSWORD}@redis-staging:6379
     healthcheck:
@@ -71,6 +75,8 @@ services:
     command: celery -A app.worker.celery_app worker --loglevel=info --concurrency=2 --hostname=worker-staging@%h
     env_file:
       - .env.staging
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - ENVIRONMENT=${ENVIRONMENT}
       - PROJECT_NAME=${PROJECT_NAME}
@@ -104,6 +110,8 @@ services:
     command: celery -A app.worker.celery_app beat --loglevel=info
     env_file:
       - .env.staging
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - ENVIRONMENT=${ENVIRONMENT}
       - PROJECT_NAME=${PROJECT_NAME}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -29,6 +29,8 @@ services:
     command: bash scripts/prestart.sh
     env_file:
       - .env.staging
+    environment:
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis-staging:6379
     depends_on:
       redis-staging:
         condition: service_healthy
@@ -45,6 +47,8 @@ services:
       - "8001:8000"
     env_file:
       - .env.staging
+    environment:
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis-staging:6379
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/utils/health-check/"]
       interval: 10s

--- a/infra/DEPLOYMENT.md
+++ b/infra/DEPLOYMENT.md
@@ -91,16 +91,23 @@ These files are **not committed** to the repository. See `.env.example` for requ
 Key variables to set per environment:
 
 ```
-ENVIRONMENT=production          # or staging
-DOMAIN=heimpath.com             # or staging.heimpath.com
-POSTGRES_SERVER=<neon-endpoint> # use unpooled endpoint (no -pooler suffix)
+ENVIRONMENT=production             # or staging
+DOMAIN=heimpath.com                # or staging.heimpath.com
+POSTGRES_SERVER=host.docker.internal  # self-hosted on VPS; use Neon endpoint for Neon
+POSTGRES_PORT=5432
+POSTGRES_DB=heimpath               # heimpath_staging for staging
+POSTGRES_USER=heimpath_user
+POSTGRES_PASSWORD=<strong-random>
+DATABASE_USE_SSL=false             # false for self-hosted localhost Postgres; true for Neon
 REDIS_PASSWORD=<strong-random>
 SECRET_KEY=<random-64-char-hex>
 FIRST_SUPERUSER=admin@heimpath.com
 FIRST_SUPERUSER_PASSWORD=<secure-password>
 ```
 
-> **Important:** Always use the **unpooled** Neon endpoint (without `-pooler` in the hostname). PgBouncer's transaction-mode pooler rejects psycopg3's `statement_timeout` startup parameter.
+> **Self-hosted Postgres:** Set `POSTGRES_SERVER=host.docker.internal` so Docker containers reach the host's Postgres. Set `DATABASE_USE_SSL=false` — no TLS is configured on the local instance.
+>
+> **Neon (legacy):** Use the unpooled endpoint (no `-pooler` suffix) and `DATABASE_USE_SSL=true`. PgBouncer's transaction-mode pooler rejects psycopg3's `statement_timeout` startup parameter.
 
 ### Deploying a backend update
 


### PR DESCRIPTION
## Summary

Prerequisite code changes (task 274a) that must land before the Neon → self-hosted Postgres migration (tasks 274–277) can proceed without outages.

- **`DATABASE_USE_SSL` setting** (`bool`, default `true`) — decouples SSL from `ENVIRONMENT`. Set to `false` in the VPS `.env` files when pointing at the self-hosted localhost Postgres. Removes the `channel_binding=require` parameter from the sync URI (requires SSL; breaks without it).
- **`database.py`** — asyncpg SSL connect arg now gates on `DATABASE_USE_SSL` instead of `ENVIRONMENT != "local"`.
- **`extra_hosts: host.docker.internal:host-gateway`** added to all DB-connected services in `docker-compose.prod.yml` and `docker-compose.staging.yml` — without this, `POSTGRES_SERVER=host.docker.internal` resolves to nothing on Linux Docker and all containers fail to connect.
- **`DEPLOYMENT.md`** updated with self-hosted vs Neon env var differences.
- **`.env.example`** documents the new `DATABASE_USE_SSL` variable.

## Why these were blockers

Docker containers cannot reach `localhost` on the host — `localhost` inside a container is the container itself. `host.docker.internal` resolves correctly only when `host-gateway` is explicitly wired in on Linux. Without `DATABASE_USE_SSL`, SSL would still be enforced against a local Postgres with no TLS configured, causing connection failures.

## Test plan

- [ ] Existing Neon connection unaffected: `DATABASE_USE_SSL=true` (default) keeps `?sslmode=require` and asyncpg `ssl=True` — no change in behaviour
- [ ] Local dev unaffected: `DATABASE_USE_SSL` defaults `true` but local env sets `ENVIRONMENT=local` which already skipped SSL — now controlled explicitly; set `DATABASE_USE_SSL=false` in local `.env` if needed
- [ ] After task 274 (Postgres installed on VPS): set `POSTGRES_SERVER=host.docker.internal`, `DATABASE_USE_SSL=false` in `/opt/heimpath/.env` and `.env.staging`, restart containers, confirm connection succeeds
- [ ] `host.docker.internal` resolves inside container: `docker exec heimpath-backend getent hosts host.docker.internal`