### PR TITLE
fix(journey): mark wizard and summary props as Readonly (SonarCloud S6759)

### DIFF
--- a/frontend/src/components/Journey/JourneySummary.tsx
+++ b/frontend/src/components/Journey/JourneySummary.tsx
@@ -54,7 +54,7 @@ const PROPERTY_USE_LABELS: Record<string, string> = {
 ******************************************************************************/
 
 /** Default component. Summary review before submission. */
-function JourneySummary(props: IProps) {
+function JourneySummary(props: Readonly<IProps>) {
   const { state } = props
 
   const isRental = state.journeyType === "rental"

--- a/frontend/src/components/Journey/JourneyWizard.tsx
+++ b/frontend/src/components/Journey/JourneyWizard.tsx
@@ -62,7 +62,7 @@ const STORAGE_STEP_KEY = "heimpath-wizard-step"
 ******************************************************************************/
 
 /** Default component. Multi-step journey creation wizard. */
-function JourneyWizard(props: IProps) {
+function JourneyWizard(props: Readonly<IProps>) {
   const { className } = props
   const navigate = useNavigate()
   const createJourneyMutation = useCreateJourney()


### PR DESCRIPTION
## Summary

- Adds `Readonly<IProps>` wrapper to `JourneyWizard` and `JourneySummary` component props signatures
- Fixes 2 SonarCloud S6759 issues introduced by PR #351 — the rental/buying wizard bifurcation PR updated `BudgetInput` and `TimelineSelector` to use `Readonly<IProps>` but missed the two existing components it also touched

## Test plan
- [ ] CI pre-commit (Biome) passes — no formatting changes needed (verified locally)
- [ ] CI test-backend passes — no backend changes
- [ ] SonarCloud reports 0 new issues