### PR TITLE
feat(infra): add vps pg_dump backup and disk monitoring cron scripts

### DIFF
--- a/scripts/vps/disk-check.sh
+++ b/scripts/vps/disk-check.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Daily VPS health check: disk, swap, and PostgreSQL process.
+# Intended path: /usr/local/bin/disk-check.sh
+# Cron (root): 0 8 * * * /usr/local/bin/disk-check.sh
+set -euo pipefail
+
+LOG_FILE="/var/log/disk-alert.log"
+DISK_THRESHOLD=70
+SWAP_THRESHOLD=90
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+# --- Root filesystem ---
+DISK_PCT=$(df / --output=pcent | tail -1 | tr -dc '0-9')
+if [ "$DISK_PCT" -ge "$DISK_THRESHOLD" ]; then
+  log "ALERT: root filesystem at ${DISK_PCT}% (threshold: ${DISK_THRESHOLD}%)"
+  log "  Run: docker image prune -a   # to recover space"
+  log "  Check: du -sh /backups/postgres/*"
+else
+  log "OK: root filesystem at ${DISK_PCT}%"
+fi
+
+# --- Swap ---
+SWAP_TOTAL=$(awk '/^SwapTotal:/ {print $2}' /proc/meminfo)
+if [ "${SWAP_TOTAL:-0}" -gt 0 ]; then
+  SWAP_FREE=$(awk '/^SwapFree:/ {print $2}' /proc/meminfo)
+  SWAP_USED=$(( SWAP_TOTAL - SWAP_FREE ))
+  SWAP_PCT=$(( SWAP_USED * 100 / SWAP_TOTAL ))
+  if [ "$SWAP_PCT" -ge "$SWAP_THRESHOLD" ]; then
+    log "ALERT: swap at ${SWAP_PCT}% used (threshold: ${SWAP_THRESHOLD}%)"
+  else
+    log "OK: swap at ${SWAP_PCT}% used"
+  fi
+fi
+
+# --- PostgreSQL process ---
+if systemctl is-active --quiet postgresql; then
+  log "OK: postgresql is active"
+else
+  log "ALERT: postgresql is NOT active — check: systemctl status postgresql"
+fi

--- a/scripts/vps/logrotate-heimpath-postgres.conf
+++ b/scripts/vps/logrotate-heimpath-postgres.conf
@@ -1,0 +1,11 @@
+/var/log/pg-backup.log
+/var/log/disk-alert.log
+/var/log/pg-health.log
+{
+    weekly
+    rotate 8
+    compress
+    missingok
+    notifempty
+    create 0640 root adm
+}

--- a/scripts/vps/pg-backup.sh
+++ b/scripts/vps/pg-backup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Nightly PostgreSQL backup for both prod and staging databases.
+# Intended path: /usr/local/bin/pg-backup.sh
+# Run as: sudo -u postgres /usr/local/bin/pg-backup.sh
+# Cron (postgres user): 0 2 * * * /usr/local/bin/pg-backup.sh
+set -euo pipefail
+
+BACKUP_DIR="/backups/postgres"
+LOG_FILE="/var/log/pg-backup.log"
+RETENTION_DAYS=7
+DATE=$(date +%F)
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+mkdir -p "$BACKUP_DIR"
+
+for DB in heimpath heimpath_staging; do
+  DEST="${BACKUP_DIR}/${DB}_${DATE}.sql.gz"
+  log "Backing up ${DB}..."
+  if pg_dump -q "$DB" | gzip > "$DEST"; then
+    SIZE=$(du -sh "$DEST" | cut -f1)
+    log "OK — ${DB} backed up to ${DEST} (${SIZE})"
+  else
+    log "ERROR — ${DB} backup failed"
+    exit 1
+  fi
+done
+
+# Prune backups older than RETENTION_DAYS days
+find "$BACKUP_DIR" -name "*.sql.gz" -mtime +"$RETENTION_DAYS" -delete
+log "Pruned backups older than ${RETENTION_DAYS} days"

--- a/scripts/vps/pg-backup.sh
+++ b/scripts/vps/pg-backup.sh
@@ -23,7 +23,8 @@ for DB in heimpath heimpath_staging; do
     SIZE=$(du -sh "$DEST" | cut -f1)
     log "OK — ${DB} backed up to ${DEST} (${SIZE})"
   else
-    log "ERROR — ${DB} backup failed"
+    rm -f "$DEST"
+    log "ERROR — ${DB} backup failed; partial file removed"
     exit 1
   fi
 done

--- a/scripts/vps/setup-crons.sh
+++ b/scripts/vps/setup-crons.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Idempotent installer for HeimPath VPS cron jobs and supporting scripts.
+# Run once on the Hetzner VPS as root:
+#   bash scripts/vps/setup-crons.sh
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "==> Installing backup script"
+install -m 0750 -o root -g postgres "$REPO_DIR/scripts/vps/pg-backup.sh" /usr/local/bin/pg-backup.sh
+
+echo "==> Installing disk-check script"
+install -m 0755 "$REPO_DIR/scripts/vps/disk-check.sh" /usr/local/bin/disk-check.sh
+
+echo "==> Creating backup output directory"
+mkdir -p /backups/postgres
+chown postgres:postgres /backups/postgres
+chmod 750 /backups/postgres
+
+echo "==> Creating log files (if absent)"
+for LOG_FILE in /var/log/pg-backup.log /var/log/disk-alert.log /var/log/pg-health.log; do
+  touch "$LOG_FILE"
+  chown root:adm "$LOG_FILE"
+  chmod 0640 "$LOG_FILE"
+done
+
+echo "==> Installing logrotate config"
+install -m 0644 "$REPO_DIR/scripts/vps/logrotate-heimpath-postgres.conf" \
+  /etc/logrotate.d/heimpath-postgres
+
+echo "==> Adding postgres cron: pg-backup at 02:00"
+BACKUP_CRON="0 2 * * * /usr/local/bin/pg-backup.sh"
+if sudo -u postgres crontab -l 2>/dev/null | grep -qF "pg-backup.sh"; then
+  echo "     already present — skipping"
+else
+  (sudo -u postgres crontab -l 2>/dev/null; echo "$BACKUP_CRON") | sudo -u postgres crontab -
+  echo "     added"
+fi
+
+echo "==> Adding root cron: disk-check at 08:00"
+DISK_CRON="0 8 * * * /usr/local/bin/disk-check.sh"
+if crontab -l 2>/dev/null | grep -qF "disk-check.sh"; then
+  echo "     already present — skipping"
+else
+  (crontab -l 2>/dev/null; echo "$DISK_CRON") | crontab -
+  echo "     added"
+fi
+
+echo "==> Setup complete. Run a manual test:"
+echo "     sudo -u postgres /usr/local/bin/pg-backup.sh"
+echo "     /usr/local/bin/disk-check.sh"

--- a/scripts/vps/setup-crons.sh
+++ b/scripts/vps/setup-crons.sh
@@ -18,7 +18,13 @@ chown postgres:postgres /backups/postgres
 chmod 750 /backups/postgres
 
 echo "==> Creating log files (if absent)"
-for LOG_FILE in /var/log/pg-backup.log /var/log/disk-alert.log /var/log/pg-health.log; do
+# pg-backup.sh runs as the postgres user, so it must own its log file
+touch /var/log/pg-backup.log
+chown postgres:postgres /var/log/pg-backup.log
+chmod 0640 /var/log/pg-backup.log
+
+# disk-check.sh and pg-health run as root — standard root:adm ownership
+for LOG_FILE in /var/log/disk-alert.log /var/log/pg-health.log; do
   touch "$LOG_FILE"
   chown root:adm "$LOG_FILE"
   chmod 0640 "$LOG_FILE"


### PR DESCRIPTION
## Summary

- Adds `scripts/vps/pg-backup.sh` — nightly compressed `pg_dump` for both `heimpath` and `heimpath_staging` databases, 7-day local retention, logs to `/var/log/pg-backup.log`
- Adds `scripts/vps/disk-check.sh` — daily health check alerting on root disk ≥70%, swap ≥90%, or PostgreSQL process down, logs to `/var/log/disk-alert.log`
- Adds `scripts/vps/logrotate-heimpath-postgres.conf` — weekly rotation, 8 weeks retention for all VPS ops logs
- Adds `scripts/vps/setup-crons.sh` — idempotent installer: copies scripts to `/usr/local/bin/`, creates `/backups/postgres/`, creates log files, installs logrotate config, and wires both cron entries

Closes tasks #278 and #279. The DEPLOYMENT.md in PR #350 already documents these scripts; this PR provides the implementations.

## VPS Installation (run once after merge)

```bash
ssh -i ~/.ssh/hetzner_modish root@178.104.122.53
cd /opt/heimpath
bash scripts/vps/setup-crons.sh
# Then verify:
sudo -u postgres /usr/local/bin/pg-backup.sh
/usr/local/bin/disk-check.sh
```

## Test plan
- [ ] Bash syntax check passes for all 3 scripts (verified locally with `bash -n`)
- [ ] CI pre-commit passes (no frontend/backend changes)
- [ ] After VPS install: `sudo -u postgres /usr/local/bin/pg-backup.sh` produces `.sql.gz` files in `/backups/postgres/`
- [ ] After VPS install: `/usr/local/bin/disk-check.sh` logs to `/var/log/disk-alert.log`
- [ ] `sudo -u postgres crontab -l` shows the 02:00 backup entry
- [ ] `crontab -l` (root) shows the 08:00 disk-check entry