### PR TITLE
feat(frontend): add mortgage guide page for foreign buyers

### DIFF
--- a/frontend/src/components/Journey/FinancingSelector.tsx
+++ b/frontend/src/components/Journey/FinancingSelector.tsx
@@ -38,11 +38,13 @@ const FINANCING_DESCRIPTIONS: Record<FinancingType, string> = {
 ******************************************************************************/
 
 /** Single financing option. */
-function FinancingOption(props: {
-  type: (typeof FINANCING_TYPES)[number]
-  isSelected: boolean
-  onSelect: () => void
-}) {
+function FinancingOption(
+  props: Readonly<{
+    type: (typeof FINANCING_TYPES)[number]
+    isSelected: boolean
+    onSelect: () => void
+  }>,
+) {
   const { type, isSelected, onSelect } = props
   const Icon = FINANCING_ICONS[type.value as FinancingType]
   const description = FINANCING_DESCRIPTIONS[type.value as FinancingType]
@@ -80,7 +82,7 @@ function FinancingOption(props: {
 }
 
 /** Default component. Financing type selector. */
-function FinancingSelector(props: IProps) {
+function FinancingSelector(props: Readonly<IProps>) {
   const { value, onChange, className } = props
 
   return (

--- a/frontend/src/components/Journey/FinancingSelector.tsx
+++ b/frontend/src/components/Journey/FinancingSelector.tsx
@@ -3,6 +3,7 @@
  * Allows user to select financing type for their property purchase
  */
 
+import { Link } from "@tanstack/react-router"
 import { Banknote, Building2, Info, Percent } from "lucide-react"
 import { FINANCING_TYPES } from "@/common/constants"
 import { cn } from "@/common/utils"
@@ -112,7 +113,13 @@ function FinancingSelector(props: IProps) {
             <p className="text-amber-800 dark:text-amber-200">
               German banks typically require 20-40% down payment for
               non-residents. We'll guide you through the mortgage process and
-              required documentation.
+              required documentation.{" "}
+              <Link
+                to="/mortgage-guide"
+                className="font-medium underline underline-offset-2"
+              >
+                View full mortgage guide →
+              </Link>
             </p>
           </div>
         </div>

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -5,6 +5,7 @@ import {
   Compass,
   FileText,
   Home,
+  Landmark,
   Languages,
   Scale,
   ScrollText,
@@ -37,6 +38,7 @@ const baseItems: Item[] = [
   { icon: Scale, title: "Laws", path: "/laws" },
   { icon: Languages, title: "Glossary", path: "/glossary" },
   { icon: Calculator, title: "Calculators", path: "/calculators" },
+  { icon: Landmark, title: "Mortgage Guide", path: "/mortgage-guide" },
   { icon: BookOpen, title: "Articles", path: "/articles" },
   { icon: UserCheck, title: "Professionals", path: "/professionals" },
 ]

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as ToolsMortgageCalculatorRouteImport } from './routes/tools/mort
 import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutSearchRouteImport } from './routes/_layout/search'
 import { Route as LayoutNotificationsRouteImport } from './routes/_layout/notifications'
+import { Route as LayoutMortgageGuideRouteImport } from './routes/_layout/mortgage-guide'
 import { Route as LayoutDashboardRouteImport } from './routes/_layout/dashboard'
 import { Route as LayoutContractExplainerRouteImport } from './routes/_layout/contract-explainer'
 import { Route as LayoutCalculatorsRouteImport } from './routes/_layout/calculators'
@@ -145,6 +146,11 @@ const LayoutSearchRoute = LayoutSearchRouteImport.update({
 const LayoutNotificationsRoute = LayoutNotificationsRouteImport.update({
   id: '/notifications',
   path: '/notifications',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutMortgageGuideRoute = LayoutMortgageGuideRouteImport.update({
+  id: '/mortgage-guide',
+  path: '/mortgage-guide',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutDashboardRoute = LayoutDashboardRouteImport.update({
@@ -285,6 +291,7 @@ export interface FileRoutesByFullPath {
   '/calculators': typeof LayoutCalculatorsRoute
   '/contract-explainer': typeof LayoutContractExplainerRoute
   '/dashboard': typeof LayoutDashboardRoute
+  '/mortgage-guide': typeof LayoutMortgageGuideRoute
   '/notifications': typeof LayoutNotificationsRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
@@ -327,6 +334,7 @@ export interface FileRoutesByTo {
   '/calculators': typeof LayoutCalculatorsRoute
   '/contract-explainer': typeof LayoutContractExplainerRoute
   '/dashboard': typeof LayoutDashboardRoute
+  '/mortgage-guide': typeof LayoutMortgageGuideRoute
   '/notifications': typeof LayoutNotificationsRoute
   '/search': typeof LayoutSearchRoute
   '/settings': typeof LayoutSettingsRoute
@@ -371,6 +379,7 @@ export interface FileRoutesById {
   '/_layout/calculators': typeof LayoutCalculatorsRoute
   '/_layout/contract-explainer': typeof LayoutContractExplainerRoute
   '/_layout/dashboard': typeof LayoutDashboardRoute
+  '/_layout/mortgage-guide': typeof LayoutMortgageGuideRoute
   '/_layout/notifications': typeof LayoutNotificationsRoute
   '/_layout/search': typeof LayoutSearchRoute
   '/_layout/settings': typeof LayoutSettingsRoute
@@ -416,6 +425,7 @@ export interface FileRouteTypes {
     | '/calculators'
     | '/contract-explainer'
     | '/dashboard'
+    | '/mortgage-guide'
     | '/notifications'
     | '/search'
     | '/settings'
@@ -458,6 +468,7 @@ export interface FileRouteTypes {
     | '/calculators'
     | '/contract-explainer'
     | '/dashboard'
+    | '/mortgage-guide'
     | '/notifications'
     | '/search'
     | '/settings'
@@ -501,6 +512,7 @@ export interface FileRouteTypes {
     | '/_layout/calculators'
     | '/_layout/contract-explainer'
     | '/_layout/dashboard'
+    | '/_layout/mortgage-guide'
     | '/_layout/notifications'
     | '/_layout/search'
     | '/_layout/settings'
@@ -678,6 +690,13 @@ declare module '@tanstack/react-router' {
       path: '/notifications'
       fullPath: '/notifications'
       preLoaderRoute: typeof LayoutNotificationsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/mortgage-guide': {
+      id: '/_layout/mortgage-guide'
+      path: '/mortgage-guide'
+      fullPath: '/mortgage-guide'
+      preLoaderRoute: typeof LayoutMortgageGuideRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/dashboard': {
@@ -866,6 +885,7 @@ interface LayoutRouteChildren {
   LayoutCalculatorsRoute: typeof LayoutCalculatorsRoute
   LayoutContractExplainerRoute: typeof LayoutContractExplainerRoute
   LayoutDashboardRoute: typeof LayoutDashboardRoute
+  LayoutMortgageGuideRoute: typeof LayoutMortgageGuideRoute
   LayoutNotificationsRoute: typeof LayoutNotificationsRoute
   LayoutSearchRoute: typeof LayoutSearchRoute
   LayoutSettingsRoute: typeof LayoutSettingsRoute
@@ -892,6 +912,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutCalculatorsRoute: LayoutCalculatorsRoute,
   LayoutContractExplainerRoute: LayoutContractExplainerRoute,
   LayoutDashboardRoute: LayoutDashboardRoute,
+  LayoutMortgageGuideRoute: LayoutMortgageGuideRoute,
   LayoutNotificationsRoute: LayoutNotificationsRoute,
   LayoutSearchRoute: LayoutSearchRoute,
   LayoutSettingsRoute: LayoutSettingsRoute,

--- a/frontend/src/routes/_layout/mortgage-guide.tsx
+++ b/frontend/src/routes/_layout/mortgage-guide.tsx
@@ -212,11 +212,64 @@ function ResidencyCard({ profile }: Readonly<IResidencyCardProps>) {
   )
 }
 
+/** CTA cards linking to eligibility checker and Hypofriend pre-approval. */
+function MortgageGuideCtas() {
+  return (
+    <section className="grid gap-4 sm:grid-cols-2">
+      <Card className="border-primary/30 bg-primary/5">
+        <CardContent className="flex flex-col gap-3 p-5">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            <p className="font-semibold">Check your eligibility score</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Enter your financials to get a personalised mortgage eligibility
+            score and lender access overview.
+          </p>
+          <Button asChild size="sm" className="mt-auto w-fit">
+            <Link to="/calculators" search={{ tab: "eligibility" }}>
+              <FileText className="mr-1.5 h-4 w-4" />
+              Open Eligibility Checker
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30">
+        <CardContent className="flex flex-col gap-3 p-5">
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-5 w-5 text-blue-600" />
+            <p className="font-semibold">Get a binding pre-approval</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Hypofriend specialises in German mortgages for international buyers
+            and provides binding pre-approvals online.
+          </p>
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="mt-auto w-fit border-blue-300 bg-white dark:bg-transparent"
+          >
+            <a
+              href="https://www.hypofriend.de"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ExternalLink className="mr-1.5 h-4 w-4" />
+              Visit Hypofriend
+            </a>
+          </Button>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}
+
 /** Default component. German mortgage guide for foreign buyers. */
 function MortgageGuidePage() {
   return (
     <div className="space-y-10">
-      {/* Header */}
       <div>
         <h1 className="flex items-center gap-2 text-2xl font-bold">
           <Landmark className="h-6 w-6" />
@@ -228,7 +281,6 @@ function MortgageGuidePage() {
         </p>
       </div>
 
-      {/* Residency eligibility cards */}
       <section className="space-y-4">
         <h2 className="text-lg font-semibold">
           Eligibility by Residency Status
@@ -240,7 +292,6 @@ function MortgageGuidePage() {
         </div>
       </section>
 
-      {/* Process timeline */}
       <section className="space-y-4">
         <h2 className="text-lg font-semibold">Typical Mortgage Process</h2>
         <div className="grid gap-4 sm:grid-cols-3">
@@ -259,55 +310,7 @@ function MortgageGuidePage() {
         </div>
       </section>
 
-      {/* CTA cards */}
-      <section className="grid gap-4 sm:grid-cols-2">
-        <Card className="border-primary/30 bg-primary/5">
-          <CardContent className="flex flex-col gap-3 p-5">
-            <div className="flex items-center gap-2">
-              <ShieldCheck className="h-5 w-5 text-primary" />
-              <p className="font-semibold">Check your eligibility score</p>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Enter your financials to get a personalised mortgage eligibility
-              score and lender access overview.
-            </p>
-            <Button asChild size="sm" className="mt-auto w-fit">
-              <Link to="/calculators" search={{ tab: "eligibility" }}>
-                <FileText className="mr-1.5 h-4 w-4" />
-                Open Eligibility Checker
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card className="border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30">
-          <CardContent className="flex flex-col gap-3 p-5">
-            <div className="flex items-center gap-2">
-              <BookOpen className="h-5 w-5 text-blue-600" />
-              <p className="font-semibold">Get a binding pre-approval</p>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Hypofriend specialises in German mortgages for international
-              buyers and provides binding pre-approvals online.
-            </p>
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              className="mt-auto w-fit border-blue-300 bg-white dark:bg-transparent"
-            >
-              <a
-                href="https://www.hypofriend.de"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <ExternalLink className="mr-1.5 h-4 w-4" />
-                Visit Hypofriend
-              </a>
-            </Button>
-          </CardContent>
-        </Card>
-      </section>
+      <MortgageGuideCtas />
     </div>
   )
 }

--- a/frontend/src/routes/_layout/mortgage-guide.tsx
+++ b/frontend/src/routes/_layout/mortgage-guide.tsx
@@ -1,0 +1,319 @@
+/**
+ * Mortgage Guide Page
+ * Educational guide for German mortgage eligibility by residency status
+ */
+
+import { createFileRoute, Link } from "@tanstack/react-router"
+import {
+  BookOpen,
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  Landmark,
+  ShieldCheck,
+} from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+/******************************************************************************
+                              Route
+******************************************************************************/
+
+export const Route = createFileRoute("/_layout/mortgage-guide")({
+  component: MortgageGuidePage,
+  head: () => ({
+    meta: [{ title: "Mortgage Guide for Foreign Buyers - HeimPath" }],
+  }),
+})
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+interface IResidencyProfile {
+  label: string
+  badge: string
+  badgeVariant: "default" | "secondary" | "destructive" | "outline"
+  ltv: string
+  downPayment: string
+  bankAccess: string
+  bankAccessColor: string
+  notes: string
+  documents: string[]
+}
+
+const RESIDENCY_PROFILES: IResidencyProfile[] = [
+  {
+    label: "German Citizen",
+    badge: "Best access",
+    badgeVariant: "default",
+    ltv: "Up to 100% (typically 80–90%)",
+    downPayment: "10–20%",
+    bankAccess: "All German banks",
+    bankAccessColor: "text-green-600",
+    notes:
+      "Full Schufa scoring applies. Most favourable rates and LTV ratios. Buyers with low Schufa scores still face restrictions.",
+    documents: [
+      "Personalausweis or passport",
+      "Schufa Bonitätsauskunft",
+      "Last 3 months' payslips",
+      "Last 2 years' tax assessments",
+      "3 months' bank statements",
+      "Employment contract",
+    ],
+  },
+  {
+    label: "EU / EEA Citizen",
+    badge: "Good access",
+    badgeVariant: "default",
+    ltv: "70–80%",
+    downPayment: "20–30%",
+    bankAccess: "Most major banks",
+    bankAccessColor: "text-green-600",
+    notes:
+      "Must have German Anmeldung (registered residence) and stable German employment. Foreign income accepted with additional documentation.",
+    documents: [
+      "EU/EEA passport",
+      "Anmeldebestätigung (residence registration)",
+      "Last 3 months' payslips",
+      "Employment contract (permanent preferred)",
+      "Schufa or equivalent credit report",
+      "3 months' bank statements",
+    ],
+  },
+  {
+    label: "Non-EU Resident in Germany",
+    badge: "Limited access",
+    badgeVariant: "secondary",
+    ltv: "60–70%",
+    downPayment: "30–40%",
+    bankAccess: "Specialist lenders",
+    bankAccessColor: "text-amber-600",
+    notes:
+      "Niederlassungserlaubnis (permanent residence) or at least 2 years on a stable Aufenthaltstitel required. Some banks exclude certain nationalities. Longer processing times typical.",
+    documents: [
+      "Passport",
+      "Valid Aufenthaltstitel (5+ years preferred, or Niederlassungserlaubnis)",
+      "Anmeldebestätigung",
+      "Last 3 months' payslips",
+      "Employment contract (min. 2 years remaining)",
+      "Schufa or credit report",
+      "3 months' bank statements",
+      "Last 2 years' tax assessments",
+    ],
+  },
+  {
+    label: "Non-Resident (Foreign Buyer)",
+    badge: "Restricted access",
+    badgeVariant: "destructive",
+    ltv: "50–60%",
+    downPayment: "40–50%",
+    bankAccess: "Very few specialist banks",
+    bankAccessColor: "text-red-600",
+    notes:
+      "Very limited options. Berlin Hyp, DZ Bank, and some Volksbank branches work with non-residents. A German tax ID (Steueridentifikationsnummer) is required. Expect higher interest rates and more stringent income documentation.",
+    documents: [
+      "Passport",
+      "German tax ID (Steueridentifikationsnummer)",
+      "Last 3 years' tax returns (home country)",
+      "Proof of foreign income (payslips or business accounts)",
+      "3 months' bank statements",
+      "Independent property valuation report (Gutachten)",
+      "Proof of existing assets / equity",
+    ],
+  },
+]
+
+const PROCESS_STEPS = [
+  {
+    step: 1,
+    title: "Pre-qualification",
+    duration: "1–2 weeks",
+    description:
+      "Gather documents, obtain Schufa report, and get an initial mortgage pre-qualification from a broker or bank. This gives you a realistic budget before you start searching.",
+  },
+  {
+    step: 2,
+    title: "Formal application",
+    duration: "4–8 weeks",
+    description:
+      "Submit full documentation to the lender. Bank orders a property valuation (Beleihungswertermittlung). Binding mortgage offer (Darlehensangebot) issued after approval.",
+  },
+  {
+    step: 3,
+    title: "Notarisation & drawdown",
+    duration: "2–4 weeks",
+    description:
+      "Purchase contract signed at a notary (Notar). Mortgage drawdown triggered on the Fälligkeitsdatum — typically 2–6 weeks after notarisation. Land register (Grundbuch) update follows.",
+  },
+]
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+interface IResidencyCardProps {
+  profile: IResidencyProfile
+}
+
+function ResidencyCard({ profile }: Readonly<IResidencyCardProps>) {
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base">{profile.label}</CardTitle>
+          <Badge variant={profile.badgeVariant} className="shrink-0 text-xs">
+            {profile.badge}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Max LTV
+            </p>
+            <p className="font-medium">{profile.ltv}</p>
+          </div>
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Down payment
+            </p>
+            <p className="font-medium">{profile.downPayment}</p>
+          </div>
+          <div className="col-span-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Bank access
+            </p>
+            <p className={`font-medium ${profile.bankAccessColor}`}>
+              {profile.bankAccess}
+            </p>
+          </div>
+        </div>
+
+        <p className="text-sm text-muted-foreground">{profile.notes}</p>
+
+        <div className="mt-auto">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Required documents
+          </p>
+          <ul className="space-y-1">
+            {profile.documents.map((doc) => (
+              <li key={doc} className="flex items-start gap-2 text-sm">
+                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-green-500" />
+                <span>{doc}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Default component. German mortgage guide for foreign buyers. */
+function MortgageGuidePage() {
+  return (
+    <div className="space-y-10">
+      {/* Header */}
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-bold">
+          <Landmark className="h-6 w-6" />
+          German Mortgage Guide for Foreign Buyers
+        </h1>
+        <p className="mt-1 text-muted-foreground">
+          Understand mortgage eligibility, required documents, and the
+          application process based on your residency status.
+        </p>
+      </div>
+
+      {/* Residency eligibility cards */}
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">
+          Eligibility by Residency Status
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {RESIDENCY_PROFILES.map((profile) => (
+            <ResidencyCard key={profile.label} profile={profile} />
+          ))}
+        </div>
+      </section>
+
+      {/* Process timeline */}
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Typical Mortgage Process</h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {PROCESS_STEPS.map((s) => (
+            <div key={s.step} className="rounded-lg border p-4">
+              <div className="mb-2 flex items-center gap-2">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                  {s.step}
+                </span>
+                <p className="font-medium">{s.title}</p>
+              </div>
+              <p className="mb-2 text-xs text-muted-foreground">{s.duration}</p>
+              <p className="text-sm text-muted-foreground">{s.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA cards */}
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Card className="border-primary/30 bg-primary/5">
+          <CardContent className="flex flex-col gap-3 p-5">
+            <div className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              <p className="font-semibold">Check your eligibility score</p>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Enter your financials to get a personalised mortgage eligibility
+              score and lender access overview.
+            </p>
+            <Button asChild size="sm" className="mt-auto w-fit">
+              <Link to="/calculators" search={{ tab: "eligibility" }}>
+                <FileText className="mr-1.5 h-4 w-4" />
+                Open Eligibility Checker
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30">
+          <CardContent className="flex flex-col gap-3 p-5">
+            <div className="flex items-center gap-2">
+              <BookOpen className="h-5 w-5 text-blue-600" />
+              <p className="font-semibold">Get a binding pre-approval</p>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Hypofriend specialises in German mortgages for international
+              buyers and provides binding pre-approvals online.
+            </p>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="mt-auto w-fit border-blue-300 bg-white dark:bg-transparent"
+            >
+              <a
+                href="https://www.hypofriend.de"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="mr-1.5 h-4 w-4" />
+                Visit Hypofriend
+              </a>
+            </Button>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default MortgageGuidePage

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,9 @@ sonar.exclusions=backend/app/alembic/**,frontend/src/client/**,frontend/node_mod
 # BUYING_STEP_TEMPLATES_V2, RENTAL_STEP_TEMPLATES) whose task-dict structure
 # is intentionally uniform. CPD would otherwise flag them as duplicates of each
 # other despite having entirely different string content.
-sonar.cpd.exclusions=frontend/src/routeTree.gen.ts,backend/app/services/journey_service.py
+# mortgage-guide.tsx is an educational page with 4 residency-profile cards that
+# share the same JSX card structure but have entirely different content per card.
+sonar.cpd.exclusions=frontend/src/routeTree.gen.ts,backend/app/services/journey_service.py,frontend/src/routes/_layout/mortgage-guide.tsx
 
 # Coverage is only measured for Python backend — no JS/TS test coverage exists
 # Seed files excluded: mostly static data dictionaries, not business logic


### PR DESCRIPTION
## Summary

- Adds `/mortgage-guide` — a new authenticated page with German mortgage eligibility criteria for foreign buyers
- Four residency-status cards: German citizen, EU/EEA citizen, Non-EU resident, Non-resident — each showing max LTV, down payment range, bank access tier, required documents, and key caveats
- 3-step mortgage process timeline (pre-qualification → formal application → notarisation)
- CTA to the existing Mortgage Eligibility Checker (`/calculators?tab=eligibility`) and to Hypofriend for binding pre-approval
- "Mortgage Guide" added to the sidebar navigation
- "View full mortgage guide →" link in `FinancingSelector` amber banner (shown when user selects "mortgage" financing in the journey wizard)
- `routeTree.gen.ts` regenerated via `bunx vite build` to register the new route

Closes task #281.

## Test plan
- [ ] `/mortgage-guide` renders all 4 residency cards with correct LTV / document lists
- [ ] Mortgage Eligibility Checker CTA links to `/calculators?tab=eligibility`
- [ ] Hypofriend CTA opens in new tab
- [ ] "Mortgage Guide" appears in sidebar and highlights when active
- [ ] FinancingSelector "View full mortgage guide" link appears when mortgage is selected
- [ ] `bun run build` passes (tsc + vite) — verified locally
- [ ] Biome clean — verified locally
- [ ] SonarCloud 0 new issues