### PR TITLE
feat(frontend): rent vs. buy decision calculator for Germany

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -10,7 +10,7 @@
   "master": {
     "tasks": [
       {
-        "id": 1,
+        "id": "1",
         "title": "Project Setup and Development Environment",
         "description": "Initialize the project structure, set up development environment, and configure essential tools for both frontend and backend development",
         "details": "Create project repositories with proper folder structure. Set up React 18.2+ with Vite, Tailwind CSS 3.3+, and React Router v6 for frontend. Initialize FastAPI 0.104+ with Python 3.11+, SQLAlchemy 2.0, and Alembic for backend. Configure Docker Compose for local development with PostgreSQL 15+ and Redis 7+. Set up GitHub Actions for CI/CD pipeline. Install and configure essential development tools: ESLint, Prettier, pytest, pre-commit hooks. Create environment configuration files (.env templates) for different environments.",
@@ -22,7 +22,7 @@
         "updatedAt": "2026-04-09T15:09:27.757Z"
       },
       {
-        "id": 2,
+        "id": "2",
         "title": "Database Schema Implementation",
         "description": "Create comprehensive PostgreSQL database schema with all required tables, relationships, indexes, and constraints as specified in the PRD",
         "details": "Implement all database tables using SQLAlchemy models: users, user_profiles, subscriptions, user_journeys, journey_steps, user_step_progress, step_tasks, user_task_completion, laws, law_content, law_relationships, law_state_variations, court_rulings, user_law_bookmarks, documents, document_translations, saved_calculations, articles, faqs, glossary_terms, notifications, user_activity_log. Create Alembic migration scripts. Add proper indexes for performance (email unique, law_code unique, full-text search indexes). Implement foreign key constraints with appropriate CASCADE rules. Add CHECK constraints for data validation (progress_percent between 0-100, etc.). Set up connection pooling and database session management.",
@@ -36,7 +36,7 @@
         "updatedAt": "2026-04-09T15:09:27.786Z"
       },
       {
-        "id": 3,
+        "id": "3",
         "title": "User Authentication System",
         "description": "Implement secure user registration, login, password reset, and JWT-based authentication with proper security measures",
         "details": "Create FastAPI authentication endpoints: POST /api/v1/auth/register, POST /api/v1/auth/login, POST /api/v1/auth/refresh, POST /api/v1/auth/password-reset. Implement bcrypt password hashing with cost factor 12. Set up JWT token generation and validation using python-jose. Create email verification system with SendGrid integration. Implement rate limiting (5 failed attempts = 15min lockout). Add OAuth support for Google Sign-In using google-auth library. Create password strength validation (min 8 chars, 1 uppercase, 1 number). Implement secure session management with refresh tokens. Add CORS configuration for frontend domains.",
@@ -50,7 +50,7 @@
         "updatedAt": "2026-04-09T15:09:27.810Z"
       },
       {
-        "id": 4,
+        "id": "4",
         "title": "User Profile and Account Management",
         "description": "Build user profile management, subscription handling, and GDPR-compliant account operations",
         "details": "Create user profile endpoints: GET/PATCH /api/v1/users/me, DELETE /api/v1/users/me. Implement profile fields: name, email, location_state, preferred_language, investment_status, interests. Add email change functionality with re-verification. Create password change endpoint with current password validation. Implement GDPR-compliant data export (JSON format with all user data). Add account deletion with 30-day soft delete period. Integrate Stripe for subscription management: create customer, handle webhooks, manage subscription lifecycle. Create subscription endpoints for viewing current plan, upgrading, and canceling. Implement usage tracking for document translations per tier.",
@@ -64,7 +64,7 @@
         "updatedAt": "2026-04-02T21:28:58.265Z"
       },
       {
-        "id": 5,
+        "id": "5",
         "title": "Journey System Core Logic",
         "description": "Implement the guided journey system with questionnaire, journey generation, and step management",
         "details": "Create journey questionnaire with 7 questions: situation, property type, location, use case, budget, citizenship, concerns. Implement journey generation algorithm that creates personalized 8-15 step journeys based on user answers. Create journey data structure with 4 phases: Preparation, Property Search, Legal Process, Ownership Transfer. Build step management system with task completion tracking. Implement journey endpoints: GET /api/v1/journey, POST /api/v1/journey/initialize, GET/PATCH /api/v1/journey/steps/{step_id}. Add progress calculation and persistence (auto-save every 30 seconds). Create deadline tracking and reminder system. Implement cost tracking across journey steps.",
@@ -78,7 +78,7 @@
         "updatedAt": "2026-04-09T15:09:27.818Z"
       },
       {
-        "id": 6,
+        "id": "6",
         "title": "Legal Knowledge Base Implementation",
         "description": "Build the comprehensive German real estate laws database with 50+ laws, translations, and search functionality",
         "details": "Create law content management system with 50+ German real estate laws across 5 categories: Buying Process (12), Costs & Taxes (10), Rental & Landlord Law (15), Condominium Ownership (8), Agent Regulations (5). Implement law data structure: law_code, category, title, summaries (one-line, short, detailed), original German text, English explanations, real-world examples, common disputes, court rulings. Add state variation support for location-dependent laws (e.g., land transfer tax rates by state). Create law endpoints: GET /api/v1/laws, GET /api/v1/laws/{law_code}, GET /api/v1/laws/search. Implement full-text search across law content using PostgreSQL. Add bookmark functionality for logged-in users. Create law relationship mapping for related laws.",
@@ -92,7 +92,7 @@
         "updatedAt": "2026-04-09T15:09:27.823Z"
       },
       {
-        "id": 7,
+        "id": "7",
         "title": "Document Translation Engine",
         "description": "Build AI-powered document translation service with DeepL integration, clause detection, and risk warnings",
         "details": "Integrate DeepL API using deepl-python SDK for German to English translation. Create document upload system supporting PDF files up to 10MB (free) / 20MB (premium). Implement PDF text extraction using pdfplumber library. Build async document processing with Celery background tasks. Create document type detection for: Kaufvertrag, Mietvertrag, Exposé, Nebenkostenabrechnung, Grundbuchauszug, Teilungserklärung, Hausgeldabrechnung, Wohnungsgeberbestätigung. Implement key clause detection using regex patterns for financial terms, dates, warranties, special conditions. Add risk warning system for high-risk clauses. Create document storage in AWS S3 with AES-256 encryption. Implement usage limits per subscription tier (5 free, 30 premium). Build document management endpoints: POST /api/v1/documents/upload, GET /api/v1/documents/{id}/translation.",
@@ -106,7 +106,7 @@
         "updatedAt": "2026-04-09T15:09:27.828Z"
       },
       {
-        "id": 8,
+        "id": "8",
         "title": "Financial Calculators Implementation",
         "description": "Build hidden costs calculator, ROI calculator, and financing eligibility wizard with accurate German real estate calculations",
         "details": "Create hidden costs calculator with inputs: purchase price, property type, location, agent involvement. Implement accurate German cost calculations: land transfer tax (state-specific rates 3.5-6.5%), notary fees (GNotKG schedule ~1.5%), land registry fee (~0.5%), agent commission (~3.57%). Add state comparison feature with interactive map and savings calculations. Build ROI calculator with inputs: purchase price, down payment, interest rate, loan term, monthly rent, vacancy rate, expenses. Calculate key metrics: gross/net rental yield, cash-on-cash return, cap rate, monthly cash flow. Implement 10-year projection with equity buildup and property appreciation. Create financing eligibility wizard with 7-question assessment and scoring algorithm. Generate personalized results with likelihood score, strengths/weaknesses, required documents checklist. Add save/share functionality for all calculations.",
@@ -120,7 +120,7 @@
         "updatedAt": "2026-04-09T15:09:27.833Z"
       },
       {
-        "id": 9,
+        "id": "9",
         "title": "Frontend Core Components and Layout",
         "description": "Build reusable React components, layout system, and responsive design foundation using Tailwind CSS",
         "details": "Create component library with reusable UI components: Button (primary/secondary/tertiary variants), Input/Form components with validation, Card, Modal, Toast notifications, Loading states/skeleton loaders. Implement layout components: Header with navigation and user menu, Footer, Sidebar for dashboard, responsive grid system. Set up React Router v6 with protected routes for authenticated users. Implement responsive design with mobile-first approach using Tailwind breakpoints. Create design system with color palette, typography (Inter font), spacing, and component variants. Add accessibility features: keyboard navigation, ARIA labels, focus indicators, screen reader support. Implement dark mode support (future consideration). Set up React Context for global state management (user, auth, theme).",
@@ -134,7 +134,7 @@
         "updatedAt": "2026-04-09T15:09:27.838Z"
       },
       {
-        "id": 10,
+        "id": "10",
         "title": "User Dashboard and Journey Interface",
         "description": "Build the main user dashboard and journey step interface with progress tracking and navigation",
         "details": "Create dashboard page showing: overall journey progress, current phase/step, next recommended action, saved items (documents, calculations, bookmarked laws), recent activity timeline, usage stats for free users, quick action buttons. Build journey step detail pages with: step header (title, progress, time/cost estimates), task checklist with expandable details, relevant laws sidebar, helpful tools section, navigation footer (prev/next step). Implement progress persistence with auto-save every 30 seconds. Add step completion workflow with confirmation dialogs. Create journey navigation with phase accordion and step status indicators. Implement deadline tracking with visual indicators and reminders. Add budget tracking across journey steps with cost breakdown charts.",
@@ -149,7 +149,7 @@
         "updatedAt": "2026-04-09T15:09:27.841Z"
       },
       {
-        "id": 11,
+        "id": "11",
         "title": "Laws Browser and Search Interface",
         "description": "Build the legal knowledge base frontend with browsing, search, and detailed law pages",
         "details": "Create laws homepage with category cards, featured laws, most viewed, and recently updated sections. Build category pages with filtering (property type, user role) and sorting options. Implement law detail pages with: header (title, bookmark, share buttons), quick summary box, role-specific tabs (buyer/seller/landlord/tenant), real-world examples, detailed explanations, related laws sidebar, court rulings section, original German text (collapsible). Add bookmark functionality with heart icon toggle. Implement state variation display with interactive map and comparison table. Create search interface with auto-suggest dropdown and results page. Add full-text search across all law content with highlighted matches. Implement law update notifications for bookmarked laws.",
@@ -164,7 +164,7 @@
         "updatedAt": "2026-04-10T10:41:15.508Z"
       },
       {
-        "id": 12,
+        "id": "12",
         "title": "Document Translation Interface",
         "description": "Build the document upload, processing, and translation results interface with clause highlighting",
         "details": "Create document upload interface with drag-and-drop zone, file validation, and progress indicators. Build processing page with real-time status updates and animated progress bar. Implement translation results page with: side-by-side view toggle (German/English/both), key information summary box, color-coded clause highlighting (blue=financial, orange=dates, red=warnings, green=benefits), hover tooltips for clause explanations, warnings section with risk levels, download options (original, translated, side-by-side PDFs). Add document management page with list view, filtering, and quick actions. Implement usage limit display and upgrade prompts for free users. Create document sharing functionality with secure links.",
@@ -179,7 +179,7 @@
         "updatedAt": "2026-04-10T12:00:00.000Z"
       },
       {
-        "id": 13,
+        "id": "13",
         "title": "Calculator Interfaces and Results Pages",
         "description": "Build interactive calculator forms and results pages with charts and sharing functionality",
         "details": "Create hidden costs calculator with: input form (purchase price, property type, location dropdown, agent toggle), real-time calculation updates, results display with 'what agents tell you' vs 'real cost' comparison, itemized breakdown with explanations, visual pie chart, state comparison with interactive map and table. Build ROI calculator with: comprehensive input form, investment grade display (0-10 scale with color coding), key metrics cards, monthly cash flow breakdown, 10-year projection chart, break-even analysis scenarios. Implement financing eligibility wizard with: multi-step form with progress indicator, results page with likelihood score, strengths/weaknesses sections, required documents checklist, recommended next steps. Add save/share functionality for all calculators with PDF export and shareable links.",
@@ -194,7 +194,7 @@
         "updatedAt": "2026-04-10T10:41:15.612Z"
       },
       {
-        "id": 14,
+        "id": "14",
         "title": "Content Management and Article System",
         "description": "Build content library with articles, FAQs, and glossary with search and browsing capabilities",
         "details": "Create articles system with 12+ educational articles across 4 categories: Buying Process, Costs & Taxes, Regulations, Common Pitfalls. Implement article detail pages with: category badge, title, author, reading time, difficulty level, key takeaways box, table of contents, main content with internal links, related laws sidebar, related tools section, helpfulness rating widget, related articles footer. Build FAQ system with 30+ questions organized by category, accordion interface, search functionality, helpfulness ratings. Create glossary with 200+ German real estate terms, search functionality, alphabetical browsing, in-context tooltips throughout the app. Add content browsing with category pages, filtering, and sorting options. Implement SEO optimization with meta tags, schema markup, and internal linking.",
@@ -208,7 +208,7 @@
         "updatedAt": "2026-04-09T15:09:27.842Z"
       },
       {
-        "id": 15,
+        "id": "15",
         "title": "Notification System Implementation",
         "description": "Build comprehensive notification system with in-app notifications, email delivery, and user preferences",
         "details": "Create notification database table and management system. Implement in-app notifications with: bell icon with unread count badge, dropdown with recent notifications, notification center page with pagination and filtering, real-time delivery using WebSocket or polling. Build email notification system with SendGrid integration: professional HTML templates, transactional emails (verification, password reset, payment receipts), important notifications (deadlines, milestones), informational emails (weekly digest, tips), marketing emails (newsletter, offers). Create notification preferences page allowing users to control which notifications they receive and delivery method (in-app/email/both). Implement notification triggers: journey deadlines (1 week, 3 days, 1 day before), document translation complete, step completion, law updates for bookmarked laws, usage limit warnings, subscription expiration.",
@@ -223,7 +223,7 @@
         "updatedAt": "2026-04-09T15:09:27.844Z"
       },
       {
-        "id": 16,
+        "id": "16",
         "title": "Search and Discovery Features",
         "description": "Implement global search functionality across all content with auto-suggest and filtering",
         "details": "Build global search system with search bar in header accessible from all pages. Implement auto-suggest functionality showing top 5 results grouped by type (Laws, Articles, Journey Steps, FAQs) with 300ms response time. Create search results page with: query display, total count, filter sidebar (content type checkboxes), sort options, results grouped by type with highlighted matches. Add full-text search across laws, articles, journey steps, FAQs, and glossary terms. Implement fuzzy matching for typo tolerance and stemming for better results. Add zero results handling with 'did you mean' suggestions and popular searches. Create search analytics to track queries for improvement. Support both German and English search terms with proper indexing.",
@@ -238,7 +238,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 17,
+        "id": "17",
         "title": "Payment Integration and Subscription Management",
         "description": "Integrate Stripe for payment processing, subscription management, and billing workflows",
         "details": "Set up Stripe integration with stripe-python SDK. Create subscription plans: Free (5 translations/month), Premium (€19.90/month, 30 translations), Enterprise (€99/month, unlimited). Implement payment endpoints: create customer, create subscription, handle payment methods, process upgrades/downgrades. Build subscription management interface: view current plan, billing history, payment methods, upgrade/downgrade options, cancellation flow. Create Stripe webhook handler for: payment succeeded, subscription updated, subscription cancelled, invoice payment failed. Implement usage-based billing for individual document translations (€4.90 each). Add payment receipt generation and email delivery. Create customer portal integration for self-service billing management. Handle failed payments with retry logic and dunning management.",
@@ -252,7 +252,7 @@
         "updatedAt": "2026-04-09T15:09:27.846Z"
       },
       {
-        "id": 18,
+        "id": "18",
         "title": "Security and GDPR Compliance Implementation",
         "description": "Implement comprehensive security measures and GDPR compliance features",
         "details": "Implement security headers: CSP, HSTS, X-Frame-Options, X-Content-Type-Options. Add rate limiting to prevent brute force attacks and API abuse. Implement input validation and sanitization to prevent SQL injection and XSS attacks. Set up HTTPS everywhere with TLS 1.2+ using AWS Certificate Manager. Create GDPR compliance features: cookie consent banner, privacy policy and terms of service pages, data export functionality (JSON format), account deletion with 30-day retention, data retention policies. Implement audit logging for authentication events and sensitive operations. Add vulnerability scanning with Snyk or Dependabot for dependency updates. Create security monitoring with alerts for suspicious activity. Implement proper session management with secure JWT tokens.",
@@ -267,7 +267,7 @@
         "updatedAt": "2026-04-09T15:09:27.849Z"
       },
       {
-        "id": 19,
+        "id": "19",
         "title": "Performance Optimization and Monitoring",
         "description": "Implement performance optimizations, monitoring, and analytics for production readiness",
         "details": "Optimize frontend performance: code splitting with React.lazy, image optimization and lazy loading, bundle size optimization, service worker for caching (PWA preparation). Implement backend performance optimizations: database query optimization with proper indexes, Redis caching for frequently accessed data (laws, articles), connection pooling for database, async processing for heavy operations. Set up monitoring and alerting: uptime monitoring with Pingdom, error tracking with Sentry, performance monitoring with DataDog or New Relic, log aggregation with AWS CloudWatch. Implement analytics: Google Analytics 4 for web analytics, custom event tracking for user actions, conversion funnel analysis. Add health check endpoints for load balancers. Create performance budgets and monitoring dashboards.",
@@ -284,7 +284,7 @@
         "updatedAt": "2026-04-09T13:19:43.968Z"
       },
       {
-        "id": 20,
+        "id": "20",
         "title": "Testing, Documentation, and Deployment Pipeline",
         "description": "Implement comprehensive testing suite, API documentation, and production deployment pipeline",
         "details": "Create comprehensive test suite: unit tests for backend services (pytest, >80% coverage), unit tests for frontend components (Jest + React Testing Library, >70% coverage), integration tests for API endpoints, end-to-end tests for critical user flows (Playwright). Set up automated API documentation with FastAPI's built-in OpenAPI/Swagger generation. Create deployment pipeline with GitHub Actions: automated testing on PR, Docker image building, deployment to staging environment, manual approval gate, zero-downtime production deployment. Set up infrastructure with Terraform or AWS CDK: ECS Fargate services, RDS PostgreSQL, ElastiCache Redis, S3 buckets, CloudFront CDN, Application Load Balancer. Create monitoring and alerting for production environment. Implement backup and disaster recovery procedures. Create runbooks for common operational tasks.",
@@ -300,7 +300,7 @@
         "updatedAt": "2026-04-09T13:19:44.002Z"
       },
       {
-        "id": 21,
+        "id": "21",
         "title": "Audit and Prune Step 2 Task List for Relevance",
         "description": "Review the task list generated for Step 2 of a journey and remove any tasks that are irrelevant or out of place for a location/market research step.",
         "details": "Pull the default task list for Step 2 from the backend or seed data. Review each task for relevance to the 'Location' phase of property buying in Germany. Remove tasks that belong to other steps. Ensure remaining tasks are actionable and specific to location research.",
@@ -312,7 +312,7 @@
         "updatedAt": "2026-04-09T15:09:27.852Z"
       },
       {
-        "id": 22,
+        "id": "22",
         "title": "Disable Floor Field When House Property Type Is Selected",
         "description": "In Step 1 of the wizard (or wherever the floor field appears), the floor/storey field should be greyed out and disabled when 'House' is selected as the property type, since houses typically don't have a meaningful floor number.",
         "details": "Find the floor input field in the wizard or property form. Add conditional logic: if propertyType === 'house', set the floor field to disabled and visually grey it out (Tailwind: disabled:opacity-50 disabled:cursor-not-allowed). Clear the floor value when House is selected.",
@@ -325,7 +325,7 @@
         "subtasks": []
       },
       {
-        "id": 23,
+        "id": "23",
         "title": "Completed Step Capsule Turns Light Green",
         "description": "When all task checkboxes within a step are checked, the step capsule should visually turn light green to indicate completion.",
         "details": "Update the step capsule component styling. When completion status is 'completed' (all tasks checked), apply a light green background and border. Use Tailwind classes: bg-green-50 border-green-200 (or similar from the color tokens). The step title and icon should also reflect the completed state.",
@@ -339,7 +339,7 @@
         "updatedAt": "2026-04-10T09:56:57.121Z"
       },
       {
-        "id": 24,
+        "id": "24",
         "title": "Move Estimated Additional Cost from Step 1 to Step 2",
         "description": "The 'Estimated Additional Cost' section (showing transfer tax, notary fee, etc.) should be removed from Step 1 and placed in Step 2 under a 'Based on your budget' section.",
         "details": "The BudgetInput component in Step 4 shows cost breakdown. After removing BudgetInput from Step 1 (Task 13), verify no cost estimates appear in Step 1. In Step 2 (Location), add a 'Based on your budget' card that shows the estimated additional costs using the budgetMax from state and the selected state's transferTaxRate.",
@@ -352,7 +352,7 @@
         "subtasks": []
       },
       {
-        "id": 25,
+        "id": "25",
         "title": "Add Due Diligence Tasks to Step 4",
         "description": "Step 4 of a journey should include standard due diligence tasks such as 'Request property exposé' and other key pre-purchase checks.",
         "details": "Review the current Step 4 task list. Add missing due diligence tasks including at minimum: 'Request property exposé from agent', 'Commission independent building surveyor', 'Check land register (Grundbuch) extract', 'Verify planning permissions', 'Review HOA documents (Teilungserklärung)'. Update backend seed data or task generation logic.",
@@ -364,7 +364,7 @@
         "updatedAt": "2026-04-09T15:43:13.242Z"
       },
       {
-        "id": 26,
+        "id": "26",
         "title": "Fix Save Evaluation End-to-End",
         "description": "The 'Save Evaluation' feature is broken: saving fails or shows 'Something went wrong', and the notification link after saving does not work correctly.",
         "details": "Trace the full save evaluation flow: frontend form submission → API call → backend save → response → frontend notification. Identify where it breaks. Check for 422 validation errors, missing required fields, incorrect API path, or frontend error handling issues. Fix root cause. Ensure notification after save links to the saved evaluation correctly.",
@@ -376,7 +376,7 @@
         "updatedAt": "2026-04-10T08:41:55.505Z"
       },
       {
-        "id": 27,
+        "id": "27",
         "title": "Make Saved Evaluation Cards Clickable",
         "description": "Saved evaluation cards on the evaluations list page are not clickable. Each card should be clickable to open/view/edit that evaluation.",
         "details": "Find the saved evaluations list component. Add onClick handler or wrap card in a Link component navigating to /evaluations/:id or equivalent. Ensure the evaluation detail page exists and renders the correct data.",
@@ -390,7 +390,7 @@
         "updatedAt": "2026-04-10T09:56:57.174Z"
       },
       {
-        "id": 28,
+        "id": "28",
         "title": "Rename Export Button to 'Download as PDF' and Generate Branded PDF",
         "description": "The 'Export' button on the evaluation page should be renamed 'Download as PDF'. The downloaded file should be a branded Heimpath PDF with well-formatted evaluation content.",
         "details": "Rename button label to 'Download as PDF'. Implement PDF generation: use a library (e.g. jsPDF, react-pdf, or a backend PDF endpoint) to produce a PDF containing the evaluation title, property details, cost breakdown, and Heimpath branding (logo, colors). Output should be print-quality and readable.",
@@ -402,7 +402,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 29,
+        "id": "29",
         "title": "Fix Property Evaluation Page Scroll Position",
         "description": "The property evaluation page should load from the top on all devices. Currently it may load scrolled partway down.",
         "details": "Add scroll-to-top behavior on route mount for the evaluation page. Use useEffect with window.scrollTo(0, 0) on component mount, or configure TanStack Router's scrollRestoration to reset on navigation to this page.",
@@ -414,7 +414,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 30,
+        "id": "30",
         "title": "Mobile Layout: Evaluation Title and Subtitle Full-Width Rows",
         "description": "On mobile viewports, the evaluation page title and subtitle should each occupy a full-width row, not be truncated or wrapped awkwardly.",
         "details": "In the evaluation page component, ensure the title and subtitle elements have w-full and appropriate text sizing on mobile. Use Tailwind responsive classes: default (mobile-first) full-width, md: layout for larger screens.",
@@ -426,7 +426,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 31,
+        "id": "31",
         "title": "Mark Address as Optional and Living Space as Required on Evaluation Page",
         "description": "On the property evaluation form, the Address field should be visually marked as optional, and the Living Space field should be visually marked as required.",
         "details": "Update form field labels: add '(optional)' suffix to Address label, add '*' or 'required' indicator to Living Space label. Update Pydantic schema if needed to reflect that address is truly optional. Add frontend validation that blocks submission if Living Space is empty.",
@@ -438,7 +438,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 32,
+        "id": "32",
         "title": "Add Info Tooltips on Evaluation Field Labels and Fix Mobile Tooltip Bug",
         "description": "Evaluation form field labels should have info icons with tooltips explaining the field. Tooltips are currently broken on mobile; fix the mobile tooltip interaction.",
         "details": "Add an info icon (lucide-react Info) next to each field label that warrants explanation. Implement tooltip using Radix UI Tooltip or a similar accessible component. For mobile, use a tap-to-show interaction instead of hover. Fix any z-index or positioning issues causing tooltips to be hidden on mobile.",
@@ -450,7 +450,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 33,
+        "id": "33",
         "title": "Display Average Rent per sqm by Location on Evaluation Page",
         "description": "The rent suggestion card on the property evaluation page should display the average rent per square metre for the selected location.",
         "details": "Source average rent/sqm data for German cities/regions (static lookup table or external API). Display the figure in the rent suggestion card with the format '€X.XX / sqm (average for [location])'. Update when the location field changes.",
@@ -462,7 +462,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 34,
+        "id": "34",
         "title": "Financing Card: Account for 110% Financing Scenario",
         "description": "The financing card on the evaluation page should handle and display the 110% financing scenario, where the buyer finances not just the property price but also all acquisition costs (transfer tax, notary, agent fees).",
         "details": "Add a '110% financing' toggle or scenario to the financing card. When enabled, the total loan amount = property price + all additional acquisition costs. Update monthly payment and LTV calculations accordingly. Display a note explaining what 110% financing means.",
@@ -474,7 +474,7 @@
         "updatedAt": "2026-04-11T00:00:00.000Z"
       },
       {
-        "id": 35,
+        "id": "35",
         "title": "Fix Session/Auth Bug: Stale User Data After Login Switch",
         "description": "After logging out as User A and logging in as User B, the app still shows User A's profile for about 3 minutes before switching. User data must clear immediately on logout.",
         "details": "Investigate why user session data persists after logout. Check: localStorage/sessionStorage cleanup on logout, TanStack Query cache invalidation, auth context reset, stale query refetch on login. Ensure logout clears all cached user data and login fetches fresh data immediately.",
@@ -486,7 +486,7 @@
         "updatedAt": "2026-04-12T07:46:42.517Z"
       },
       {
-        "id": 36,
+        "id": "36",
         "title": "Fix Journey Progress Out of Sync on My Journeys Page",
         "description": "On the My Journeys list page, the progress bar and step count don't match the actual completed steps inside the journey.",
         "details": "Compare the progress value shown on the journey card with the actual step/task completion state. The progress calculation may be stale or computed differently on the list endpoint vs the detail endpoint. Fix so they are consistent.",
@@ -498,7 +498,7 @@
         "updatedAt": "2026-04-12T07:46:42.601Z"
       },
       {
-        "id": 37,
+        "id": "37",
         "title": "Fix Dashboard Evaluate Property Quick Action Link",
         "description": "The 'Evaluate Property' button under Quick Actions on the dashboard should navigate to the Property Evaluation Calculator page but currently doesn't work.",
         "details": "Find the Quick Actions section on the dashboard. Update the Evaluate Property button's link/route to point to the calculator page (/calculators/evaluation or equivalent).",
@@ -510,7 +510,7 @@
         "updatedAt": "2026-04-12T07:46:42.615Z"
       },
       {
-        "id": 38,
+        "id": "38",
         "title": "Hide or Replace 'Ready to Start' Section for Logged-In Users",
         "description": "The 'Ready to Start?' call-to-action section above the footer still shows when a user is logged in. Remove it or replace it with relevant content like 'Resume your journey' or recent activity.",
         "details": "Find the Ready to Start section (likely on the landing/home page near the footer). Add a conditional: if the user is authenticated, either hide it or replace with contextual content (e.g., link to their active journey, recent activity).",
@@ -522,7 +522,7 @@
         "updatedAt": "2026-04-12T07:46:42.645Z"
       },
       {
-        "id": 39,
+        "id": "39",
         "title": "Make Landing Page Buttons Context-Aware for Logged-In Users",
         "description": "When a user is logged in, the 'Get Started Free' and 'Sign in to Evaluate' buttons on the landing page property evaluation section should change to relevant actions like 'Go to Calculator'.",
         "details": "Find the property evaluation CTA section on the landing page. Check auth state and conditionally render appropriate button text and link: logged out → 'Get Started Free' / 'Sign in to Evaluate'; logged in → 'Go to Calculator' / 'Evaluate a Property' linking directly to the calculator.",
@@ -534,7 +534,7 @@
         "updatedAt": "2026-04-12T07:46:42.663Z"
       },
       {
-        "id": 40,
+        "id": "40",
         "title": "Add Property Research Tasks to Step 3",
         "description": "Step 3 should include all tasks a buyer needs to do when gathering information about a prospective property: request expose, check land register, review HOA documents, commission building survey, verify planning permissions, etc.",
         "details": "Update the step/task generation logic or seed data for Step 3 to include comprehensive property research tasks. Ensure tasks are relevant to the property type (e.g., HOA docs only for apartments).",
@@ -545,7 +545,7 @@
         "subtasks": []
       },
       {
-        "id": 41,
+        "id": "41",
         "title": "Step 5: Reference Buying Costs from Step 1",
         "description": "The cost breakdown already shown in Step 1 (transfer tax, notary, agent fees) should be displayed within each relevant task in Step 5, so the user doesn't have to go back and forth.",
         "details": "In Step 5 task details, pull the cost figures from the journey state (budget, state-specific transfer tax rate, notary/agent fees) and display them inline. Could be a small summary card within each task or expandable detail.",
@@ -556,7 +556,7 @@
         "subtasks": []
       },
       {
-        "id": 42,
+        "id": "42",
         "title": "Step 6: Tailor Required Documents to User Situation",
         "description": "Step 6 tasks (proof of address, etc.) should adapt based on the user's status: resident vs. living abroad, mortgage vs. outright purchase, and other relevant details.",
         "details": "Use journey questionnaire answers (citizenship, financing choice) to conditionally include or exclude tasks in Step 6. For example: non-residents need additional documents, mortgage buyers need bank approval letters, outright buyers don't need mortgage-related docs.",
@@ -567,7 +567,7 @@
         "subtasks": []
       },
       {
-        "id": 43,
+        "id": "43",
         "title": "Step 7: Change 'Request Expose' to 'Review Expose' and Add Lawyer Task",
         "description": "By Step 7, the user already has the expose. Change the task to 'Review property expose'. Also add a task suggesting the user can hire a lawyer if needed.",
         "details": "Update Step 7 task list: rename 'Request property expose' to 'Review property expose'. Add new task: 'Consider hiring a real estate lawyer (Immobilienanwalt)' with details on when this is recommended.",
@@ -578,7 +578,7 @@
         "subtasks": []
       },
       {
-        "id": 44,
+        "id": "44",
         "title": "Add Bank/Financing Step to Journey",
         "description": "There is no step covering bank interactions. Based on the user's payment plan (mortgage vs. outright), add relevant tasks around mortgage application, loan approval, and bank communication.",
         "details": "Add a journey step (or extend an existing one) for financing. For mortgage buyers: tasks for comparing mortgage offers, gathering bank documents, submitting application, getting loan approval letter. For cash buyers: tasks for proof of funds, transfer arrangements. This step should appear at the appropriate point in the journey flow.",
@@ -589,7 +589,7 @@
         "subtasks": []
       },
       {
-        "id": 45,
+        "id": "45",
         "title": "Add Document Upload to Review Steps",
         "description": "Any journey step that involves reviewing a document (expose, purchase contract, HOA rules) should let the user upload the document so the app can translate it, highlight key clauses, and give a plain-language summary.",
         "details": "For steps with document review tasks, add an upload button that sends the document through the existing translation pipeline. Display results inline: translated text, highlighted clauses (financial, legal, dates), and a plain-language summary of whether everything looks good or if there are things to watch out for.",
@@ -600,7 +600,7 @@
         "subtasks": []
       },
       {
-        "id": 46,
+        "id": "46",
         "title": "Ask User Intent: Live-In vs. Rent Out",
         "description": "Add a question in Step 1 or 2 asking whether the user plans to live in the property or rent it out. Use this to control what's shown in the Property Evaluation Calculator (hide Rent section if living in).",
         "details": "Add a 'property use' question to the journey questionnaire (Step 1 or 2): 'Will you live in this property or rent it out?'. Store the answer in journey state. When the evaluation calculator is opened from a journey, pass this value and conditionally hide or adjust the Rent, Taxes, Forecast section if the user plans to live there.",
@@ -612,7 +612,7 @@
         "updatedAt": "2026-04-12T20:11:13.046Z"
       },
       {
-        "id": 47,
+        "id": "47",
         "title": "Add Area/Neighborhood Selection by Zip Code or Name in Step 1",
         "description": "Let users pick preferred areas within their chosen state — by zip code or area name — so the journey and market data are more specific to their target location.",
         "details": "In Step 1 (or Step 2), after state selection, add an optional field for preferred area. Support zip code input or area name search with autocomplete. Store the selection and use it to refine market data shown throughout the journey.",
@@ -624,7 +624,7 @@
         "updatedAt": "2026-04-13T05:21:32.525Z"
       },
       {
-        "id": 48,
+        "id": "48",
         "title": "Add List vs. Tab View Toggle for Journey Steps",
         "description": "Give users the option to view their journey steps as a list (current default) or as tabs, so they can switch between steps more easily.",
         "details": "Add a view toggle (list/tab icons) to the journey detail page. List view: current vertical layout. Tab view: horizontal tabs or pills for each step, showing one step's content at a time. Persist the user's preference in localStorage.",
@@ -636,7 +636,7 @@
         "updatedAt": "2026-04-13T11:39:51.405Z"
       },
       {
-        "id": 49,
+        "id": "49",
         "title": "Shareable Evaluation Links (Public Read-Only)",
         "description": "Allow users to share saved property evaluations via a public read-only link, so they can send interactive evaluation results to partners, advisors, or family without requiring the recipient to log in.",
         "details": "Build on the existing share_id pattern (secrets.token_urlsafe(8)) already used for documents. Backend: add share_id column to saved evaluations table, create public GET /api/v1/evaluations/shared/{share_id} endpoint (no auth required), return evaluation data in read-only format. Frontend: add 'Share' button on evaluation detail page that generates a share link, copy-to-clipboard functionality, public evaluation view page at /shared/evaluations/{shareId} with HeimPath branding, no edit controls. Consider: OG meta tags for link previews, expiration option for shared links.",
@@ -648,7 +648,7 @@
         "updatedAt": "2026-04-15T20:34:11.714Z"
       },
       {
-        "id": 50,
+        "id": "50",
         "title": "Email Notifications and Weekly Journey Digest",
         "description": "Add email delivery for important notifications (step deadline reminders, journey nudges) and a weekly progress digest, so users who don't log in daily stay engaged with their property buying journey.",
         "details": "Backend: integrate an email provider (SendGrid or Azure Communication Services). Create HTML email templates for: step deadline reminders (1 week, 3 days, 1 day before), journey milestone notifications (step completed, phase transition), weekly progress digest (current step, % complete, next actions, tips). Add email_preferences to user profile (opt-in per category: deadlines, milestones, digest). Create a scheduled task (cron or Azure Functions timer) for weekly digest generation. Frontend: add email notification preferences UI in user settings/profile page with toggles per category. Include unsubscribe link in all emails.",
@@ -660,7 +660,7 @@
         "updatedAt": "2026-04-17T07:39:39.127Z"
       },
       {
-        "id": 51,
+        "id": "51",
         "title": "Post-Purchase Onboarding Journey Phase",
         "description": "Extend the journey system with a post-purchase phase covering everything a foreign owner needs to do after closing: property registration, insurance, Hausverwaltung setup, tax obligations, and first-year administrative tasks.",
         "details": "Backend: add a new journey phase OWNERSHIP (or extend CLOSING) with 3-4 steps covering post-purchase tasks. Steps should include: (1) Property Registration — Grundbuch transfer confirmation, address registration (Anmeldung) if moving in, utility transfers. (2) Insurance & Protection — building insurance (Wohngebäudeversicherung), liability insurance, contents insurance. (3) Property Management — Hausverwaltung selection for apartments, maintenance planning for houses, Hausgeld payment setup. (4) Tax & Finance — property tax (Grundsteuer) registration, first tax return considerations for investors, rental income reporting if renting out. Personalize tasks based on property_use (live-in vs rent-out) and property_type (apartment vs house). Frontend: journey UI already supports new steps — just ensure the new phase renders correctly in both list and tab views.",
@@ -672,7 +672,7 @@
         "updatedAt": "2026-04-18T10:19:51.398Z"
       },
       {
-        "id": 52,
+        "id": "52",
         "title": "City and Neighborhood Comparison Tool",
         "description": "Build a side-by-side comparison tool that lets users compare cities or neighborhoods by price per sqm, rental yield, infrastructure quality, and livability metrics to make informed location decisions.",
         "details": "Backend: create a comparison endpoint GET /api/v1/market/compare?areas=berlin,munich,hamburg (accepts 2-4 area codes). Return comparison data: avg price/sqm (buy), avg rent/sqm, gross rental yield, population, price trend (YoY %), infrastructure score. Source data from existing market_data module or extend with additional static datasets. Create area detail endpoint for drill-down. Frontend: create a comparison page accessible from the journey (Step 1/2 area selection) and from calculators. UI: area selector (add up to 4 areas), comparison table with key metrics, bar charts for visual comparison, highlight best/worst per metric. Mobile: stack cards vertically instead of table. Add link from journey Step 1 area selection to comparison tool.",
@@ -684,7 +684,7 @@
         "updatedAt": "2026-04-18T11:31:31.862Z"
       },
       {
-        "id": 53,
+        "id": "53",
         "title": "Verified Professional Network Directory",
         "description": "Build a directory of verified bilingual professionals (Makler, lawyers, tax advisors, notaries, mortgage brokers) that foreign buyers can search by city, language, and specialty — opening HeimPath's Connect pillar.",
         "details": "Backend: create Professional model with fields: name, company, profession_type (makler/lawyer/tax_advisor/notary/mortgage_broker), city, languages spoken, website, phone, email, description, is_verified, avg_rating, review_count. Create ProfessionalReview model: user_id, professional_id, rating (1-5), review_text, created_at. Endpoints: GET /api/v1/professionals (list with filters: city, profession, language), GET /api/v1/professionals/{id} (detail + reviews), POST /api/v1/professionals/{id}/reviews (authenticated). Seed with initial curated list of professionals in major cities (Berlin, Munich, Hamburg, Frankfurt, Düsseldorf). Frontend: directory browse page with filters sidebar, professional card grid, detail page with reviews. Add contextual links from journey steps (e.g., Step 7 lawyer task links to lawyer directory). Review submission form with star rating and text. Consider: professional claim/verification flow for future, featured/sponsored listings for monetization.",
@@ -696,7 +696,7 @@
         "updatedAt": "2026-04-17T19:19:12.836Z"
       },
       {
-        "id": 54,
+        "id": "54",
         "title": "Rental-Investor Specific Journey Path",
         "description": "The current journey is built around owner-occupiers. Rental investors need a dedicated path that includes: sourcing tenants, structuring rental contracts, setting up Betriebskosten accounting, understanding the Mietspiegel for their target area, and evaluating GmbH vs. private ownership structure. This is the most critical missing feature for the investor persona.",
         "details": "When property_use is 'rent_out', the journey should fork significantly after the buying phase. Add investor-specific steps: (1) Rental Market Analysis — understand local Mietspiegel, set competitive rent, calculate net yield after all costs. (2) Tenant Sourcing — create listing, schedule viewings, screen applicants, Schufa check process. (3) Rental Contract Setup — Mietvertrag structure, Kaution (deposit) handling, Staffelmiete vs Indexmiete options, Zeitmietvertrag considerations. (4) Betriebskosten Setup — define allocable costs, set up utility billing structure, Heizkostenverordnung compliance. (5) Ownership Structure Review — GmbH vs private holding decision point (link to Task for GmbH comparison tool). Modify journey generation logic: when property_use === 'rent_out', inject these investor-specific steps after the closing phase. Keep existing buying steps but add investor context to them (e.g., Step 5 costs should include rental-specific deductions). Frontend: ensure new steps have appropriate content renderers and tasks.",
@@ -708,7 +708,7 @@
         "updatedAt": "2026-04-17T20:06:40.389Z"
       },
       {
-        "id": 55,
+        "id": "55",
         "title": "Rental Income Management and Portfolio Dashboard",
         "description": "After closing, the platform drops investors with nothing to manage their property. Build a post-purchase rental management dashboard with: rent roll tracking, expense tracker, annual tax summary, and Nebenkostenabrechnung (utility billing) helper. The investor journey doesn't end at closing — it's just beginning.",
         "details": "Backend: create Portfolio model (user_id, properties[]). Create Property model (address, purchase_price, purchase_date, current_value_estimate, monthly_rent, tenant_name, lease_start, lease_end). Create Transaction model (property_id, type: rent_income/expense/tax, amount, date, category, description). Endpoints: GET/POST /api/v1/portfolio/properties, GET /api/v1/portfolio/summary (total income, expenses, net cash flow, vacancy rate), GET /api/v1/portfolio/properties/{id}/transactions, POST /api/v1/portfolio/properties/{id}/transactions. Nebenkostenabrechnung helper: input utility costs for the year, allocate by tenant sqm share, generate summary. Annual tax summary: aggregate rental income, deductible expenses (mortgage interest, depreciation 2% AfA, repairs, Hausgeld), calculate taxable rental income. Frontend: portfolio dashboard with property cards, income/expense chart, KPI cards (total yield, vacancy, cash flow). Transaction entry form. Nebenkostenabrechnung wizard. Tax summary export (PDF).",
@@ -720,7 +720,7 @@
         "updatedAt": "2026-04-18T06:02:07.164Z"
       },
       {
-        "id": 56,
+        "id": "56",
         "title": "Fix Documents Page — Failed to Load on Page Load",
         "description": "The Documents page throws a 'Failed to load documents' error immediately on page load. This is a critical reliability bug for one of HeimPath's core features — document translation and analysis for foreign investors.",
         "details": "Reproduce: navigate to /documents as a logged-in user. Investigate: check browser console for the failing API call (likely GET /api/v1/documents). Common causes: (1) API endpoint returning 500 — check backend logs in Docker. (2) Frontend query error — check TanStack Query error handling. (3) Auth token not being sent — check request headers. (4) Empty state handling — the endpoint may work but the error state triggers incorrectly when there are no documents. Fix the root cause. Ensure the page shows an empty state ('No documents yet — upload your first document') when the user has no documents, and only shows an error when there's an actual API failure.",
@@ -732,7 +732,7 @@
         "updatedAt": "2026-04-17T07:39:39.189Z"
       },
       {
-        "id": 57,
+        "id": "57",
         "title": "Mietspiegel Integration — Rent Estimates by Postcode in ROI Calculator",
         "description": "The ROI Calculator requires manual rent entry but most investors don't know realistic market rent for a specific postcode. Add a 'rent estimate for this area' feature that auto-fills or suggests market rent based on location, property size, and condition — using Mietspiegel data or comparable rent sources.",
         "details": "Backend: extend market data module with rent estimate lookup. Data sources: (1) Static Mietspiegel dataset for major cities (Berlin, Munich, Hamburg, Frankfurt, Cologne, Düsseldorf, Stuttgart, Leipzig, Dresden) with rent ranges by postcode, size bracket, and building age. (2) Fallback to state-level averages from existing market_data. Create endpoint: GET /api/v1/market/rent-estimate?postcode=10115&size_sqm=75&building_year=1990. Response: { estimated_rent_per_sqm: 12.50, rent_range: { min: 10.00, max: 15.00 }, source: \"Berlin Mietspiegel 2024\", confidence: \"high\" }. Frontend: in ROI Calculator, add a 'Suggest rent' button next to the monthly rent field. When clicked, use the property location and size to fetch rent estimate. Auto-fill the field with the estimate and show the range as helper text. Also show this data on the journey market insights panel.",
@@ -744,7 +744,7 @@
         "updatedAt": "2026-04-17T07:39:39.198Z"
       },
       {
-        "id": 58,
+        "id": "58",
         "title": "Add After-Tax Cash Flow to ROI Calculator",
         "description": "The ROI Calculator shows Cash-on-Cash Return and Cap Rate but doesn't account for German income tax on rental income. Rental income is taxed at the marginal rate (up to 45%), which dramatically changes real net returns. Add a tax rate input and show after-tax cash flow alongside pre-tax figures.",
         "details": "Frontend: add an optional 'Tax Settings' section to the ROI Calculator with: (1) Marginal tax rate input (slider or dropdown: 0%, 14%, 24%, 33%, 42%, 45%) with explanation that German rental income is taxed at your personal income tax rate. (2) Solidaritätszuschlag toggle (5.5% surcharge, applies if tax > €18,130). (3) Church tax toggle (8-9% depending on state). Backend or frontend calculation: after-tax rental income = gross rent - deductible expenses (mortgage interest, depreciation 2% AfA, maintenance) → taxable rental income × (1 - marginal rate) → after-tax cash flow. Display: add 'After-Tax' column/row alongside existing pre-tax metrics. Show after-tax Cash-on-Cash Return, after-tax monthly cash flow, effective tax rate on rental income. Add a note explaining AfA (2% straight-line depreciation on building value, excluding land).",
@@ -756,7 +756,7 @@
         "updatedAt": "2026-04-17T07:39:39.245Z"
       },
       {
-        "id": 59,
+        "id": "59",
         "title": "GmbH vs. Private Ownership Comparison Tool",
         "description": "Investors buying multiple properties in Germany need to decide whether to hold via private purchase or a property-holding GmbH. The tax treatment differs significantly and there's currently no guidance or calculator for this comparison — a critical gap for any investor planning to scale.",
         "details": "Frontend: create a new calculator page at /calculators/ownership-structure. Inputs: number of properties (or planned), total annual rental income, personal marginal tax rate, estimated annual appreciation, planned holding period. Compare two scenarios side-by-side: (1) Private ownership: income taxed at marginal rate (up to 45% + Soli), 10-year Spekulationsfrist for tax-free capital gains, 2% AfA depreciation, full deductibility of mortgage interest. (2) GmbH holding: 15% Körperschaftsteuer + 5.5% Soli + ~14% Gewerbesteuer = ~30% total on rental income, BUT only 5% of capital gains taxed on sale (via §8b KStG), extended depreciation options, GmbH setup costs (~€2,000-5,000), ongoing accounting costs (~€3,000-5,000/year), trade tax considerations. Output: 10-year projection for each scenario showing cumulative after-tax cash flow, exit tax on sale, total wealth comparison. Highlight breakeven point where GmbH becomes advantageous. Add educational section explaining key differences, pros/cons, and when to consult a Steuerberater. Backend: calculation endpoint or pure frontend calculation. Link from journey investor path (Task #54) and from ROI calculator results.",
@@ -768,7 +768,7 @@
         "updatedAt": "2026-04-18T17:22:03.069Z"
       },
       {
-        "id": 60,
+        "id": "60",
         "title": "Improve Email Verification Banner UX — Dismiss After First View",
         "description": "The orange email verification banner appears on every single page and dominates the screen. It should appear once prominently, then collapse to a subtle indicator (e.g., small icon in the header or a one-time dismissible toast).",
         "details": "Frontend: find the email verification banner component (likely in layout or header). Change behavior: (1) First visit after login: show full banner with verification prompt. (2) After user dismisses (clicks X or 'Remind me later'): store dismissal in localStorage with timestamp. (3) Subsequent page views: show only a subtle indicator — small warning icon next to the user avatar in the header, or a dot on the settings icon. (4) Re-show full banner after 7 days if still not verified. (5) Always show a verification prompt on the settings/profile page. Add a 'Resend verification email' button to both the banner and the settings page indicator.",
@@ -780,7 +780,7 @@
         "updatedAt": "2026-04-17T07:39:39.259Z"
       },
       {
-        "id": 61,
+        "id": "61",
         "title": "Mortgage Amortisation Calculator with Payment Schedule",
         "description": "The Financing Eligibility tool assesses mortgage likelihood but doesn't calculate monthly payments, total interest paid, or LTV ratios. Add a mortgage amortisation calculator that generates a payment schedule and shows total interest costs alongside the eligibility assessment.",
         "details": "Frontend: extend the financing calculator page (or add a new tab/section) with a mortgage amortisation calculator. Inputs: property price, down payment (amount or %), interest rate (Sollzins), initial repayment rate (Anfangstilgung, typically 1-3%), fixed rate period (Zinsbindung: 5/10/15/20 years), special repayment allowance (Sondertilgung %). Calculations: monthly payment (Annuität), remaining balance after Zinsbindung, total interest paid during fixed period, total interest over full loan term, LTV ratio (Beleihungsauslauf), time to full repayment. Output: summary cards (monthly payment, total interest, payoff date, LTV), amortisation schedule table (year, payment, interest portion, principal portion, remaining balance), chart showing principal vs interest over time. Add a 'Compare rates' feature: enter 2-3 interest rate scenarios side by side. Link this from the financing eligibility results page ('See your estimated payments →'). Backend: pure frontend calculation (no API needed) — standard annuity formulas.",
@@ -792,7 +792,7 @@
         "updatedAt": "2026-04-18T19:16:25.204Z"
       },
       {
-        "id": 62,
+        "id": "62",
         "title": "AI-Powered Kaufvertrag (Purchase Contract) Clause Analyzer",
         "description": "Upload a Kaufvertrag PDF and get clause-by-clause analysis with risk ratings, plain-English explanations, and flagged unusual terms. Foreign buyers must sign a German purchase contract they can't fully understand — manual notary interpreters cost 450-950 EUR and only explain during the appointment.",
         "details": "Backend: Extend document service with clause detection for Kaufvertrag sections (Kaufpreis, Gewährleistung, Übergabe, Grundbuch, Finanzierungsvollmacht, Rücktrittsrecht). Create clause analysis endpoint that returns structured sections with risk ratings (low/medium/high). Use pattern matching for standard Kaufvertrag sections + Azure/OpenAI for explanation generation. Frontend: Kaufvertrag analysis results page with expandable clause cards, color-coded risk indicators, and plain-English explanations. Add \"What to ask your notary\" checklist generated from flagged clauses. Extends existing document translation pipeline — no new infrastructure needed.",
@@ -804,7 +804,7 @@
         "updatedAt": "2026-04-19T08:30:22.542Z"
       },
       {
-        "id": 63,
+        "id": "63",
         "title": "Public Calculator Pages for SEO & Viral Growth",
         "description": "Create public (no-auth) versions of the 3 highest-traffic calculators (Hidden Costs, Mortgage, ROI) with SEO-optimized landing pages. All HeimPath calculators currently require authentication, meaning zero organic search traffic for high-intent queries like \"German property purchase costs calculator.\" Hypofriend ranks for these terms because their tools are public.",
         "details": "Frontend: Create public routes for Hidden Costs Calculator, Mortgage Calculator, and ROI Calculator (no auth required). Reuse existing calculator components but wrap in a public layout (no sidebar, minimal header with HeimPath branding). Add SEO meta tags (title, description, canonical), structured data (JSON-LD FAQPage/HowTo), and OG tags for social sharing. Add \"Save your results — sign up free\" CTA after calculation. Create sitemap.xml including public pages. Update robots.txt with proper crawl directives. Ensure public pages are indexable. Backend: No changes needed — calculators are frontend-only. State comparison endpoint is already public — extend pattern.",
@@ -816,7 +816,7 @@
         "updatedAt": "2026-04-19T08:30:22.611Z"
       },
       {
-        "id": 64,
+        "id": "64",
         "title": "Interactive German Real Estate Glossary with Contextual Tooltips",
         "description": "Build a searchable glossary of 200+ German real estate terms with contextual tooltip integration throughout the app. Foreign buyers encounter dozens of German terms (Grunderwerbsteuer, Beleihungsauslauf, Teilungserklärung) across laws, articles, and journey steps with no quick way to understand them.",
         "details": "Backend: Create glossary model (term, definition_short, definition_long, category, example_usage, related_terms[]) with seed data for 100 most common terms. Categories: buying_process, costs_taxes, financing, legal, rental, property_types. Endpoints: GET /api/v1/glossary (list + search with ?q= param), GET /api/v1/glossary/{slug}. Frontend: Glossary browse page (/glossary) with alphabetical nav sidebar, category filtering, and search. GlossaryTerm component that wraps German terms in dotted underline + hover tooltip (desktop) / tap tooltip (mobile) using Radix UI Tooltip. Integrate tooltips into law detail pages, educational sections, and journey step content. Add glossary link to sidebar navigation.",
@@ -828,7 +828,7 @@
         "updatedAt": "2026-04-19T10:48:12.306Z"
       },
       {
-        "id": 65,
+        "id": "65",
         "title": "Guided First-Session Onboarding Flow",
         "description": "Add a 3-step onboarding wizard for new users: set goals, see recommended first action, complete one quick win. New users currently land on an empty dashboard with no guidance, leading to low activation rates.",
         "details": "Frontend: Onboarding modal/wizard triggered on first login (check user.onboarding_completed flag). Step 1: \"What's your situation?\" (Explorer researching from abroad / Settler ready to buy in Germany / Investor building portfolio). Step 2: \"What's your priority?\" (understand costs / find financing / start guided journey / evaluate a property). Step 3: \"Here's your first step\" — deep link to recommended feature based on selections. Dashboard \"Getting Started\" checklist replacing empty state: complete profile, run first calculator, create a journey, upload a document, save a professional. Track checklist completion. Show confetti/celebration animation on first milestone. Backend: Add onboarding_completed boolean and onboarding_persona string to user model + migration. PATCH /api/v1/users/me to update.",
@@ -840,7 +840,7 @@
         "updatedAt": "2026-04-19T12:58:33.966Z"
       },
       {
-        "id": 66,
+        "id": "66",
         "title": "Mortgage Pre-Qualification for Non-Citizens",
         "description": "Extend the Financing Wizard with citizenship-aware pre-qualification that shows adjusted down payment requirements, bank compatibility, and documentation differences for foreign buyers. Banks require 30-40% down payments from foreigners (vs 10-20% for residents) but no calculator adjusts for this.",
         "details": "Frontend: Add citizenship/residency status inputs to Financing Wizard: EU citizen with German residence, non-EU with Niederlassungserlaubnis, non-EU with Aufenthaltserlaubnis, non-resident (buying from abroad). Adjust scoring algorithm: down payment recommendations (residents: 20%, non-EU residents: 30%, non-residents: 40%), income documentation requirements, employment stability weighting. Show \"Bank compatibility\" indicator — which bank types typically accept each category (Sparkasse, Deutsche Bank, ING, Commerzbank, online banks). Add required document checklist specific to citizenship status (Meldebescheinigung, Aufenthaltstitel copy, work contract, 3 months payslips, tax returns from home country for non-residents). Display \"Financing tips for your situation\" section with actionable advice. All static data — no API integration needed for MVP.",
@@ -852,7 +852,7 @@
         "updatedAt": "2026-04-19T14:04:01.895Z"
       },
       {
-        "id": 67,
+        "id": "67",
         "title": "Cross-Border Tax Guide for Foreign Property Owners",
         "description": "Interactive guide showing tax obligations based on country of residence, with explanations of DBA (double-taxation agreement) treaties, filing requirements, and deductible expenses. Foreign investors navigating tax obligations across multiple jurisdictions currently pay 500+ EUR for initial tax advisor consultations with no digital alternative.",
         "details": "Frontend: New calculator tab \"Tax Guide\" with country selector (top 10 investor countries: UK, US, France, Netherlands, Turkey, Poland, Italy, China, Russia, India). Per-country guide showing: DBA treaty status with Germany, withholding tax rates on rental income, filing requirements (Anlage V, Anlage AUS), deductible expenses (mortgage interest, AfA depreciation, Hausgeld, repairs), key deadlines. Side-by-side comparison: resident vs non-resident investor tax burden. Educational section explaining beschränkte vs unbeschränkte Steuerpflicht, how AfA works for non-residents, Solidaritätszuschlag applicability. Link from ROI calculator and GmbH comparison results. Consider professional directory upsell (connect with bilingual Steuerberater). All static curated content — no external API needed.",
@@ -864,7 +864,7 @@
         "updatedAt": "2026-04-19T18:04:54.836Z"
       },
       {
-        "id": 68,
+        "id": "68",
         "title": "Professional Reviews and Community Trust Signals",
         "description": "Enhance the professional directory review system with structured review prompts, verified purchase badges, aggregate trust scores, and seeded initial reviews. The directory exists but has no social proof — foreign buyers need to trust recommendations from fellow expats.",
         "details": "Backend: Add fields to ProfessionalReview model: service_used (enum: buying, selling, rental, tax, legal), language_used, would_recommend (boolean), response_time_rating (1-5). Add computed fields to Professional: recommendation_rate, review_highlights. Seed 20-30 initial reviews for top professionals in Berlin, Munich, Hamburg, Frankfurt, Düsseldorf. Frontend: Enhanced review form with structured prompts (service used, language, would you recommend, free text). Professional cards show: aggregate star rating, review count, \"Recommended by X expats\" badge (when recommendation_rate > 80%), top review snippet. Filter professionals by \"Highest rated\" and \"Most reviewed\" sort options. Review detail view with structured breakdown. Add \"Leave a review\" prompt after journey completion for professionals linked to journey steps.",
@@ -876,7 +876,7 @@
         "updatedAt": "2026-04-19T18:04:54.884Z"
       },
       {
-        "id": 69,
+        "id": "69",
         "title": "Nebenkosten (Running Costs) Tracker — Estimated vs Actual",
         "description": "Post-purchase tracker where owners log actual monthly running costs and compare against estimates from their property evaluation. Actual Nebenkosten (heating, Hausgeld, Grundsteuer, insurance) can be 30-50% higher than seller's Exposé claims — owners need a way to track and catch overcharges.",
         "details": "Backend: Extend portfolio Transaction model with cost_category enum (hausgeld, grundsteuer, insurance, heating, water, electricity, maintenance, misc) and estimated_amount field. Create endpoint GET /api/v1/portfolio/properties/{id}/cost-summary that aggregates actual vs estimated by category over a date range. Frontend: \"Running Costs\" tab in portfolio property detail page. Monthly cost entry form with category dropdown and amount. 12-month bar chart: estimated (from property evaluation if linked) vs actual costs per category. KPI cards: total monthly Nebenkosten, variance from estimate, highest cost category. Alert banner when actual exceeds estimated by >20% for any category. Link property to saved evaluation (optional) to pull estimated costs automatically.",
@@ -888,7 +888,7 @@
         "updatedAt": "2026-04-19T19:25:13.218Z"
       },
       {
-        "id": 70,
+        "id": "70",
         "title": "Clean Up Tech Debt and Harden Security",
         "description": "Focused cleanup sprint addressing technical hygiene: remove unused Items module, enforce rate limiting on auth endpoints, expose weekly digest email, add sitemap.xml for SEO, and review security headers.",
         "details": "1. Remove unused Items module: delete items route, components, models, and service. Remove from router aggregation and sidebar. 2. Enforce rate limiting on auth endpoints (login, register, password reset): use existing rate limiting service, apply 5 attempts/15min lockout on login, 3 attempts/hour on register, 3 attempts/hour on password reset. 3. Expose weekly digest email: the digest_service exists but is not triggered. Create a management command or scheduled endpoint to generate and send weekly digests for opted-in users. 4. SEO infrastructure: generate sitemap.xml including public law pages, article pages, and public calculator pages (from Task #63). Add robots.txt with proper crawl directives. 5. Security headers review: ensure CSP, HSTS, X-Frame-Options, X-Content-Type-Options are set in production nginx config.",
@@ -900,7 +900,7 @@
         "updatedAt": "2026-04-19T19:48:44.177Z"
       },
       {
-        "id": 71,
+        "id": "71",
         "title": "Mobile-Optimized Journey Experience",
         "description": "Audit and optimize the journey experience for mobile viewports. Property research often happens on mobile (commuting, lunch breaks) but journey steps with tables, charts, and multi-column layouts may not render optimally on small screens.",
         "details": "Audit: Test all journey step content renderers at 375px viewport width. Check all calculator tables, charts, and multi-column layouts. Fixes: Ensure no horizontal overflow or truncated content in journey steps. Task checkboxes must be tap-friendly (min 44px touch targets per WCAG 2.1). Charts should be readable without horizontal scrolling (consider simplified mobile chart variants). Document upload flow should support camera capture on mobile. Add horizontal scroll indicators on data tables that overflow. Test tab view vs list view on mobile — ensure both are usable. Verify all modals and dropdowns work with mobile keyboard. Verify touch gestures don't conflict with swipe navigation.",
@@ -912,7 +912,7 @@
         "updatedAt": "2026-04-19T20:23:41.233Z"
       },
       {
-        "id": 72,
+        "id": "72",
         "title": "Fix \"How It Works\" Section Duplicate Content Render",
         "description": "QA Report UX Bug 2: The \"How It Works\" 4-step section (Research → Preparation → Buying → Closing) renders its content twice — descriptions appear once above and once below the step icons. This is a React render bug or CSS issue making the section look broken on close inspection.",
         "details": "Investigate HowItWorksSection.tsx — the component has two render blocks: a desktop layout (hidden md:flex) and a mobile layout (md:hidden). At certain viewports both may render simultaneously, or there may be a duplicate render caused by a parent component. Steps: 1) Test at 768px, 901px, and 1280px viewports to reproduce the duplicate. 2) Check if the desktop/mobile breakpoint overlap causes both to show at a specific width. 3) Fix the responsive classes to ensure mutual exclusivity at all widths. 4) Verify the section renders exactly once at every tested viewport.",
@@ -924,7 +924,7 @@
         "updatedAt": "2026-04-21T03:36:38.835Z"
       },
       {
-        "id": 73,
+        "id": "73",
         "title": "Fix Login Page Layout Inconsistency for Logged-Out Users",
         "description": "QA Report UX Bug 3: The login page layout changes inconsistently. When accessed from a logged-out state, the login page renders as a narrow centred form without the product feature list on the left side. The two-column split layout (features left, form right) is only rendered when accessing /login while already authenticated. The logged-out user is the one who most needs to see the feature list as persuasion.",
         "details": "1) Investigate the login page component to find the conditional rendering that hides the feature list for logged-out users. 2) The two-column layout should ALWAYS show for logged-out users: left side shows product features/benefits (guided journeys, legal knowledge, cost calculators, document translation), right side shows the login form. 3) If the user is already authenticated and hits /login, they should be redirected to the dashboard (this part already works). 4) Ensure the feature list is responsive — full two-column on md+, stacked (features above form) on mobile.",
@@ -936,7 +936,7 @@
         "updatedAt": "2026-04-21T03:58:27.097Z"
       },
       {
-        "id": 74,
+        "id": "74",
         "title": "Add Breadcrumb Navigation to Article and Law Detail Pages",
         "description": "QA Report UX 10: Both article and law detail pages have only a simple \"← Back\" text link with no indication of where the user came from. Users landing on individual law pages from the global search (CMD+K) have no contextual orientation. Add breadcrumb navigation showing the full path (e.g., \"Laws > Buying Process > Notarization Requirement\" or \"Articles > Buying Guide > Understanding Grundbuch\").",
         "details": "1) Create a reusable Breadcrumb component (or use shadcn/ui breadcrumb if available). 2) Law detail pages: show breadcrumb \"Laws > [Category Name] > [Law Title]\" where category is one of: Buying Process, Costs & Taxes, Rental & Landlord Law, Condominium Ownership, Agent Regulations. 3) Article detail pages: show breadcrumb \"Articles > [Article Title]\". 4) Each breadcrumb segment should be a clickable link navigating to the parent page. 5) Replace or augment the existing \"← Back\" link with the breadcrumb. 6) On mobile, consider truncating middle segments with ellipsis if the breadcrumb is too long. 7) Style with muted-foreground text, \"/\" or \">\" separators, and the current page segment in regular foreground weight.",
@@ -948,7 +948,7 @@
         "updatedAt": "2026-04-21T04:56:10.069Z"
       },
       {
-        "id": 75,
+        "id": "75",
         "title": "Add Scroll-Triggered Animations to Landing Page Sections",
         "description": "QA Report Landing Page Motion & Animation suggestions: Add scroll-triggered entrance animations to landing page sections to make the page feel more dynamic and less abrupt. Currently everything below the hero appears instantly with no visual transition as the user scrolls.",
         "details": "1) \"How It Works\" section: The 4 phase step icons (Research, Preparation, Buying, Closing) should animate in sequence (staggered fade-in + slide-up) as the user scrolls the section into view. Use Intersection Observer or a lightweight library. Stagger delay: 100-150ms between each step. 2) \"Why HeimPath?\" / Features section: Feature cards should fade-in with a slight slide-up as they enter the viewport. 3) Advantages section: Similar fade-in treatment. 4) CTA banner section: Fade-in when scrolled into view. 5) Use tw-animate-css utilities where possible (animate-in, fade-in, slide-in-from-bottom). 6) All animations must respect prefers-reduced-motion — add motion-reduce:animate-none to every animated element. 7) Animations should trigger once (not re-trigger on scroll back up). 8) Consider using a simple useInView hook with Intersection Observer for triggering.",
@@ -960,7 +960,7 @@
         "updatedAt": "2026-04-22T09:32:45.705Z"
       },
       {
-        "id": 77,
+        "id": "77",
         "title": "Add Parallax Scroll Effect to Landing Page Hero Background",
         "description": "QA Report Landing Page suggestion: Add a gentle parallax scroll effect on the hero background gradient. Currently the gradient background is static, making the hero feel flat as the user scrolls past it.",
         "details": "1) Apply a subtle parallax effect to the hero section's background gradient and decorative blur blobs so they move at a slower rate than the page scroll. 2) The effect should be very subtle (0.3-0.5x scroll speed) — just enough to add depth, not enough to cause motion sickness. 3) Implementation: use CSS transform: translateY with a scroll event listener or CSS background-attachment: fixed (simpler but less control). Prefer a lightweight JS approach using requestAnimationFrame for smoothness. 4) The decorative blur blobs (bg-blue-400/10 and bg-purple-400/10) should also shift slightly on scroll. 5) Must respect prefers-reduced-motion — disable parallax entirely for users with motion reduction enabled. 6) Must not cause layout shifts or janky scrolling on mobile. Consider disabling on mobile entirely (md+ only) since parallax on touch devices often feels wrong.",
@@ -972,7 +972,7 @@
         "updatedAt": "2026-04-22T09:42:24.865Z"
       },
       {
-        "id": 78,
+        "id": "78",
         "title": "Add Journey Progress Ring Chart to Dashboard",
         "description": "QA Report Dashboard Enhancement: Replace the plain journey progress bar with a circular/donut chart showing per-phase completion (e.g., Research 80%, Preparation 33%, Buying 0%, Closing 0%). This adds visual sophistication and gives users an at-a-glance view of their journey status.",
         "details": "1) Replace the existing progress bar in the \"My Property Journey\" dashboard card with a donut/ring chart. 2) Each ring segment represents a journey phase: Research, Preparation, Buying, Closing (and Ownership, Rental Setup if applicable). 3) Use phase-specific colors: Research=blue, Preparation=purple, Buying=orange, Closing=green (matching the existing phase color scheme from JOURNEY_PHASES constant). 4) Show percentage labels for each phase, either inside the ring or as a legend beside it. 5) Center of the ring can show overall completion percentage (e.g., \"42% Complete\"). 6) Use Recharts (already a project dependency if available) or a lightweight SVG-based donut chart. If no charting library is available, build a simple SVG donut using stroke-dasharray/stroke-dashoffset. 7) Add animation: ring segments should animate from 0 to their final value on page load. 8) Respect prefers-reduced-motion — skip animation for those users. 9) Must work in both light and dark mode. 10) On mobile, ensure the chart is readable — consider reducing size or switching to a compact horizontal bar on very small screens.",
@@ -984,7 +984,7 @@
         "updatedAt": "2026-04-21T05:06:30.966Z"
       },
       {
-        "id": 79,
+        "id": "79",
         "title": "Add Portfolio Performance Line Chart",
         "description": "QA Report Dashboard Enhancement: On the Portfolio page, add a 12-month line chart showing net cash flow over time. Even if the portfolio is empty, show a ghost/placeholder state with sample data to signal sophistication and demonstrate the feature's potential.",
         "details": "1) Add a \"Performance\" section to the Portfolio page showing a 12-month line chart of net cash flow (rental income minus expenses). 2) X-axis: months (Jan–Dec or last 12 months). Y-axis: EUR amount. 3) Line color: green for positive months, red for negative (or a single line with the area fill changing color). 4) If the user has portfolio data with transactions, plot actual net cash flow per month. 5) Empty/placeholder state: show a subtle ghost chart with sample data (dashed line, muted colors) and an overlay message \"Add properties and track income to see your portfolio performance\". The ghost state should look like a real chart at a glance to demonstrate the value. 6) Use Recharts if available, or a lightweight SVG chart. 7) Include a small legend and hover tooltips showing exact values per month. 8) Support dark mode — use appropriate colors for grid lines, labels, and chart elements. 9) Responsive: on mobile, the chart should scale down gracefully — consider hiding the Y-axis labels and relying on tooltips instead.",
@@ -996,7 +996,7 @@
         "updatedAt": "2026-04-21T05:46:54.967Z"
       },
       {
-        "id": 80,
+        "id": "80",
         "title": "Add Budget vs Actual Gauge and Days-to-Target Countdown to Dashboard",
         "description": "QA Report Dashboard Enhancement: Add two new dashboard widgets — (1) a Budget vs Actual gauge chart showing estimated total cost versus the user's budget (e.g., \"Budget: €180,000 / Estimated cost: €195,000\") for instant financial clarity, and (2) a Days-to-Target countdown widget showing days until the user's target closing date to add urgency and motivation.",
         "details": "1) Budget vs Actual Gauge: a) Show a semicircular or horizontal gauge comparing the user's budget (from journey setup) against estimated total property cost (from their property evaluation if linked). b) Color coding: green if under budget, amber if within 10%, red if over budget. c) Display both values as text labels (Budget: €X / Estimated: €Y). d) If no evaluation is linked, show a CTA \"Run a Property Evaluation to see how your budget compares\". e) Place this widget in the dashboard near the journey card or in a \"Financial Overview\" section. 2) Days-to-Target Countdown: a) Show a prominent countdown number (e.g., \"145 days until target closing\") based on the user's timeline selection from journey setup. b) If no timeline is set, show a CTA \"Set a target date in your journey\". c) Use a large number display with a small label below. d) Consider showing milestone markers (e.g., \"60 days to go — time to schedule your notary appointment\"). 3) Both widgets must support dark mode and be responsive on mobile.",
@@ -1008,7 +1008,7 @@
         "updatedAt": "2026-04-21T06:08:26.551Z"
       },
       {
-        "id": 81,
+        "id": "81",
         "title": "Color-Code Portfolio Stat Cards and Improve Sidebar Active State",
         "description": "QA Report Dashboard Iconography & Visual Hierarchy improvements: (1) The Portfolio page stat cards (Properties, Net Cash Flow, Vacancy Rate, Gross Yield) use generic greyscale icons — color-code them for instant visual recognition. (2) The sidebar navigation active state is too subtle — improve the highlight to make the current page clearly identifiable.",
         "details": "1) Portfolio stat card color-coding: a) Properties count card: blue icon and accent (matching the primary brand color). b) Net Cash Flow card: green icon for positive values, red icon for negative values — dynamically color based on the actual value. c) Vacancy Rate card: amber/yellow icon and accent (warning tone). d) Gross Yield card: teal icon and accent. e) Apply the color to: the icon itself, a subtle left border or top accent stripe on the card, and optionally a light tinted background (e.g., bg-blue-50 dark:bg-blue-950/20 for the properties card). f) Keep the same card structure — just add color differentiation. 2) Sidebar active state improvement: a) The current blue background pill is too subtle. b) Make the active page icon use the primary color (not just the background). c) Add a left border accent (3-4px solid primary) on the active item. d) Increase background contrast of the active pill. e) Ensure the improvement works in both collapsed and expanded sidebar states. f) Ensure dark mode contrast is sufficient.",
@@ -1020,7 +1020,7 @@
         "updatedAt": "2026-04-21T05:15:06.691Z"
       },
       {
-        "id": 82,
+        "id": "82",
         "title": "Add Avatar Upload to User Profile",
         "description": "QA Report Dashboard Enhancement: The Profile section shows \"TU\" initials (or similar) as the avatar. Add avatar upload functionality so users can personalize their profile with a photo, significantly increasing engagement and personalization.",
         "details": "1) Backend: a) Add an avatar_url field to the User model (nullable string, Alembic migration). b) Create endpoint POST /api/v1/users/me/avatar that accepts an image upload (multipart/form-data). c) Validate: max 2MB, allowed types: JPEG, PNG, WebP. d) Store the image — use Azure Blob Storage if configured, or store as base64 in DB for MVP simplicity. e) Return the avatar URL in the user profile response. f) Create endpoint DELETE /api/v1/users/me/avatar to remove the avatar. 2) Frontend: a) On the Profile page, make the initials avatar clickable to open a file picker. b) Show an upload overlay/hover state on the avatar circle (\"Click to upload\" or a camera icon). c) Preview the selected image before upload. d) Show a loading spinner during upload. e) After successful upload, update the avatar everywhere it appears (sidebar, profile page, header). f) Add a \"Remove avatar\" option if an avatar is set. 3) The avatar should appear in: sidebar (collapsed and expanded), profile page, and any user-facing area showing the current user. 4) Fallback to initials when no avatar is uploaded. 5) Support dark mode styling for the upload overlay.",
@@ -1032,7 +1032,7 @@
         "updatedAt": "2026-04-22T08:59:54.624Z"
       },
       {
-        "id": 83,
+        "id": "83",
         "title": "Improve Dashboard Layout and Information Hierarchy",
         "description": "QA Report Dashboard Layout & Hierarchy Changes: Reorganize dashboard elements for better information hierarchy based on user state. (1) Move \"Getting Started\" checklist above \"My Property Journey\" for new users. (2) Collapse the \"Evaluate a Property\" empty-state card to a compact chip after Research phase completion. (3) Increase visual weight of Recent Documents, Calculations, and Bookmarked Laws cards.",
         "details": "1) Getting Started checklist priority: a) For users with fewer than 3 completed onboarding steps, move the \"Getting Started\" checklist to the TOP of the dashboard (above \"My Property Journey\"). This is the most important thing for new users to see. b) Once the user has completed 3+ steps, move the checklist below the journey card (or collapse it to a dismissible banner). c) Use conditional rendering based on the user's onboarding completion count. 2) Evaluate a Property card: a) When the user has no active journey or is in the Research phase, show the full \"Evaluate a Property\" empty-state card with the large illustration + CTA (current behavior). b) After the user has completed the Research phase, collapse it to a compact \"Quick Action\" chip/button (e.g., a small card with an icon and \"Evaluate Property\" text, inline with other quick actions). c) This reduces visual noise for users who have progressed past the initial research stage. 3) Recent Documents / Calculations / Bookmarked Laws cards: a) Increase card min-height so they don't look under-weighted compared to the journey card. b) Add a \"last updated\" timestamp for each item (e.g., \"Hidden Costs — 2 days ago\"). c) Add a hover state with subtle elevation/shadow change. d) Consider adding a small icon or color accent to differentiate the three card types.",
@@ -1044,7 +1044,7 @@
         "updatedAt": "2026-04-21T09:38:49.274Z"
       },
       {
-        "id": 84,
+        "id": "84",
         "title": "Add Dashboard Micro-Interactions and Celebration Animations",
         "description": "QA Report Dashboard Micro-interactions: Add polished micro-interactions throughout the dashboard to make the product feel premium. (1) Journey step cards should animate open/closed with smooth accordion transition. (2) Task checkboxes should animate with a satisfying checkmark draw animation. (3) Add a confetti burst or celebration modal when a journey phase is fully completed. (4) Progress bars should animate from left to right on page load.",
         "details": "1) Journey step accordion animation: a) Currently step cards snap open/close instantly. Add a smooth height transition (300-400ms ease) when expanding/collapsing journey step details. b) Use CSS transition on max-height or a library like framer-motion for smoother height animation. c) Add a subtle rotate animation on the expand/collapse chevron icon. 2) Task checkbox animation: a) When a user checks a task, animate the checkmark with a draw-in effect (SVG stroke-dashoffset animation, ~300ms). b) Add a subtle scale bounce (1.0 → 1.2 → 1.0) on the checkbox container when checked. c) The task counter should animate its number increment (not just jump). 3) Phase completion celebration: a) When a user completes the final task in a journey phase (e.g., 5/5 Research steps done), trigger a celebration. b) Show a confetti burst animation (use a lightweight library like canvas-confetti, ~3KB gzipped, or CSS-only confetti). c) Display a brief celebration modal/toast: \"Research Phase Complete! You're making great progress.\" with a checkmark icon and the next phase name. d) The confetti should last 2-3 seconds and not block interaction. 4) Progress bar animation: a) On page load, progress bars should animate from 0% to their actual value (500ms ease-out). b) Use CSS transition or tw-animate-css utilities. 5) All animations must respect prefers-reduced-motion — disable all animations for those users (instant state changes, no confetti). 6) Animations should not cause layout shifts.",
@@ -1056,7 +1056,7 @@
         "updatedAt": "2026-04-21T18:41:05.131Z"
       },
       {
-        "id": 85,
+        "id": "85",
         "title": "Add Warm Amber Accent Color for Trust Indicators",
         "description": "QA Report Colour & Treatment suggestion: The app currently uses green for everything (success states, verified badges, trust indicators). Add a warm amber accent color specifically for trust indicators (verified badges, success states, completion markers) to differentiate them from standard success feedback and create a warmer, more premium feel.",
         "details": "1) Define a new amber accent color token in the frontend color system (Colors.ts or Tailwind config). Suggested: amber-500 (#f59e0b) for light mode, amber-400 (#fbbf24) for dark mode. 2) Apply amber accent to trust-related UI elements: a) \"Verified\" badges on professional directory cards. b) \"Recommended by X expats\" badges. c) Journey phase completion checkmarks/badges. d) Onboarding completion indicators. e) Review rating stars. 3) Keep green for: form validation success, toast success messages, positive financial values (cash flow). 4) Keep the primary teal/green brand color unchanged — amber is a supplementary accent only. 5) Ensure sufficient contrast ratio (WCAG AA) for amber on both light and dark backgrounds. 6) Update any existing trust-indicator elements that currently use green to use the new amber accent.",
@@ -1068,7 +1068,7 @@
         "updatedAt": "2026-04-21T12:42:17.011Z"
       },
       {
-        "id": 86,
+        "id": "86",
         "title": "Add Hero Section Lifestyle Photograph to Landing Page",
         "description": "QA Report Landing Page — highest impact recommendation: The hero section needs a real lifestyle photograph to build emotional trust for foreign buyers making €200K–€500K decisions. The current SVG illustration is a step up from icon cards but lacks the emotional resonance of a photograph showing real people achieving the dream of homeownership in Germany. Replace or complement the SVG illustration with a full-bleed or half-width photograph on the right side of the hero.",
         "details": "1) Image selection — ideal shot: a couple (non-German-looking, to reinforce \"international buyers\") standing outside a modern German apartment building, one holding keys, both smiling. Alternative options: an aerial view of a German city (Munich rooftops, Berlin canal) to establish geographic identity. Search terms for sourcing: \"couple new apartment keys\", \"berlin apartment building exterior\", \"germany real estate modern\", \"happy homeowner front door\". Sources: Unsplash.com (free, high-res), Pexels.com (free), Getty Images (licensed). 2) Implementation: a) Download a high-quality image (minimum 1200px wide). b) Optimize for web: convert to WebP format with JPEG fallback, compress to under 150KB. c) Use next-gen image loading: add width/height attributes to prevent CLS, use loading=\"lazy\" if below fold or loading=\"eager\" if above fold. d) Place the image in the right column of the hero section, replacing or complementing the current HeroIllustration SVG component. e) Consider keeping the SVG as a fallback for slow connections or as a loading placeholder while the photo loads. f) The image should be responsive: hidden on mobile (too small to be impactful), visible on md+ breakpoints. g) Apply a subtle rounded corner and optional shadow for a polished look. h) Add proper alt text for accessibility (e.g., \"International couple receiving keys to their new home in Germany\"). 3) Dark mode consideration: a) Apply a subtle overlay or brightness reduction in dark mode so the photo doesn't look jarring against the dark background. b) Use Tailwind classes like \"dark:brightness-90\" or a semi-transparent overlay div. 4) Performance: a) Store the image in the public/images/ directory. b) Ensure the image doesn't block LCP — use appropriate preload hints if it's the hero image. c) Consider using an <picture> element with srcset for different viewport sizes (e.g., 640w, 1024w, 1280w).",
@@ -1080,7 +1080,7 @@
         "updatedAt": "2026-04-21T03:31:07.647Z"
       },
       {
-        "id": 87,
+        "id": "87",
         "title": "Add Illustrative Images to \"How It Works\" Phase Steps",
         "description": "QA Report Landing Page Photography recommendation: Each of the 4 phase circles in the \"How It Works\" section (Research, Preparation, Buying, Closing) should be accompanied by a small illustrative image or icon-illustration to add visual weight and emotional context beyond the current lucide-react icons.",
         "details": "1) Image sourcing: a) Primary source: Storyset (storyset.com) — free, colourful \"people\" illustrations that match a modern SaaS aesthetic. b) Alternative sources: Undraw (undraw.co), Illustrations.co, or custom inline SVGs (like the HeroIllustration approach). c) Search terms per phase: Research phase — \"house search illustration\", \"property research\", \"magnifying glass house\". Preparation phase — \"document signing\", \"checklist illustration\", \"paperwork preparation\". Buying phase — \"handshake deal\", \"contract signing illustration\", \"real estate transaction\". Closing phase — \"home keys handover\", \"happy homeowner keys\", \"house key celebration\". 2) Implementation: a) Each phase step should show a small illustration (approx 80-120px) either above the icon circle or replacing the icon circle entirely. b) If using Storyset/external illustrations: download as SVG, optimize, and place in public/images/ or inline as React components. c) If using inline SVG approach (like HeroIllustration.tsx): create 4 small SVG components — ResearchIllustration, PreparationIllustration, BuyingIllustration, ClosingIllustration. d) Illustrations should use the existing phase color scheme: Research=blue, Preparation=purple, Buying=orange, Closing=green. e) Support dark mode — either via Tailwind classes on SVG elements or by adjusting brightness/opacity. 3) Layout: a) Desktop (md+): illustration sits above the icon circle in each phase column. b) Mobile: illustration sits to the left of the phase text in the vertical timeline layout. c) Illustrations should not make the section feel cluttered — keep them small and subtle. 4) Ensure illustrations are decorative (aria-hidden=\"true\") and don't affect accessibility.",
@@ -1092,7 +1092,7 @@
         "updatedAt": "2026-04-21T18:41:05.173Z"
       },
       {
-        "id": 88,
+        "id": "88",
         "title": "Add Background Patterns to \"Why HeimPath?\" Feature Cards",
         "description": "QA Report Landing Page recommendation: The three \"Why HeimPath?\" feature cards (International Buyers, Risk-Aware, Cost Transparency) sit on plain white backgrounds creating visual monotony. Add subtle background patterns or light isometric icon illustrations behind each card to break up the whiteness and add visual depth.",
         "details": "1) Each of the 3 feature cards should have a distinct subtle background decoration: a) International Buyers card — faint globe or world map outline, or small airplane/passport icons at very low opacity (5-10%). b) Risk-Aware card — faint shield or checkmark pattern, or subtle legal scales motif. c) Cost Transparency card — faint euro symbols, calculator grid, or bar chart outline. 2) Implementation options (pick one): a) Inline SVG patterns rendered as absolutely positioned decorative elements behind the card content (preferred — same approach as HeroIllustration, fully self-contained). b) CSS background patterns using radial-gradient or repeating-linear-gradient for geometric dots/lines. c) Light isometric icon illustrations from a free source (Undraw, Storyset) converted to SVG and embedded. 3) Styling requirements: a) Opacity must be very low (5-10%) so the pattern is a subtle texture, never competing with the card text. b) Use the card's accent color for the pattern (blue for International Buyers matching its icon color, etc.). c) Pattern should be clipped to the card boundaries (overflow-hidden). d) Must work in dark mode — adjust opacity or color so patterns remain subtle on dark backgrounds (e.g., use dark:opacity-5). 4) Position the pattern in the bottom-right or top-right corner of each card, not covering the full card. 5) All decorative elements must be aria-hidden=\"true\".",
@@ -1104,7 +1104,7 @@
         "updatedAt": "2026-04-22T11:16:50.110Z"
       },
       {
-        "id": 89,
+        "id": "89",
         "title": "Add Geometric Pattern Overlay to CTA Banner Section",
         "description": "QA Report Landing Page recommendation: The CTA banner section's purple/blue gradient is already strong and inviting. Add a subtle repeating geometric pattern (hexagons, or a faint map outline of Germany) as an overlay at 5-10% opacity to add texture without losing readability.",
         "details": "1) Pattern options (pick one): a) Hexagonal grid pattern — repeating hexagons in white at 5-8% opacity, suggesting structure and reliability. b) Faint map outline of Germany — a simplified SVG silhouette of Germany positioned off-center (right side), at 5-10% opacity, reinforcing geographic identity. c) Dot grid pattern — evenly spaced small circles in white at 5% opacity for a clean tech aesthetic. d) Abstract geometric shapes — overlapping circles or angular shapes suggesting property/architecture. 2) Implementation: a) Create an inline SVG pattern or use a CSS repeating background-image. b) Position as an absolutely positioned layer inside the CTA section (pointer-events-none, z-index below text). c) The pattern must NOT reduce readability of the CTA heading, description, or button. d) Use white or light color at 5-10% opacity against the purple/blue gradient. 3) Responsive: a) On mobile, the pattern should scale or simplify — avoid visual noise on small screens. b) Consider hiding the pattern below sm: breakpoint if it looks cluttered. 4) The pattern element must be aria-hidden=\"true\". 5) No impact on CTA button click targets or text selection.",
@@ -1116,7 +1116,7 @@
         "updatedAt": "2026-04-22T11:23:19.433Z"
       },
       {
-        "id": 90,
+        "id": "90",
         "title": "Add Footer-to-Hero Gradient Continuity on Landing Page",
         "description": "QA Report Landing Page colour treatment: The footer gradient (blue → purple) is the most visually striking element on the page. Use this same gradient as a subtle background wash behind the hero section to create visual continuity between the top and bottom of the page, bookending the experience with a cohesive color identity.",
         "details": "1) The hero section currently uses bg-gradient-to-br from-blue-50 to-purple-50 (light) and dark:from-blue-950/20 dark:to-purple-950/20 (dark). The footer uses a stronger blue→purple gradient. 2) Adjust the hero gradient to more closely echo the footer gradient's color direction and intensity — slightly increase the saturation/opacity of the hero gradient so the visual connection between header and footer is more apparent. 3) Alternatively, add a very subtle gradient band or decorative border at the top of the hero section that mirrors the footer's gradient intensity, creating a \"bookend\" effect. 4) Keep the hero gradient subtle enough to not overpower the text and SVG illustration / photograph — this is a background wash, not a dominant element. 5) In dark mode, ensure the gradient tones remain cohesive between hero and footer. 6) Test that any gradient changes don't reduce contrast of the hero text (especially the h1 and paragraph text). Maintain WCAG AA contrast ratios.",
@@ -1128,7 +1128,7 @@
         "updatedAt": "2026-04-22T11:30:04.141Z"
       },
       {
-        "id": 91,
+        "id": "91",
         "title": "Add Ownership Handover & Rental Setup Journey Phases with Portfolio Connection",
         "description": "The journey currently ends at Closing (phase 4). Two additional phases — Ownership (5) and Rental Setup (6) — are visible in the journey stepper UI but have no steps or content. Implement these post-purchase phases with real guided steps, and connect them to a future Portfolio Management feature so completed properties flow into the user's property portfolio.",
         "details": "**Phase 5: Ownership Handover**\nSteps to implement:\n1. Grundbuch Entry Confirmation — verify land registry entry is complete\n2. Property Handover Protocol (Übergabeprotokoll) — checklist for key handover, meter readings, defect documentation\n3. Utility Registration — register with electricity, gas, water, internet providers\n4. Anmeldung / Address Registration — register new address at Bürgeramt\n5. Insurance Setup — building insurance (Gebäudeversicherung), liability\n6. Hausverwaltung Contact — connect with property management if applicable\n\n**Phase 6: Rental Setup** (for investor persona)\nSteps to implement:\n1. Rental Strategy Decision — self-manage vs property manager, long-term vs furnished\n2. Mietvertrag Template — generate/review rental contract with legal compliance (Mietpreisbremse awareness)\n3. Tenant Screening Checklist — Schufa, income verification, previous landlord reference\n4. Kaution Setup — deposit account (Kautionskonto) creation guidance\n5. Nebenkosten Planning — ancillary cost breakdown for tenants\n6. First Rental Listing — guidance on listing platforms (ImmoScout24, WG-Gesucht, etc.)\n\n**Portfolio Connection**\n- When a journey reaches Ownership phase completion, prompt the user to \"Add to Portfolio\"\n- Create a `Property` model linked to the completed journey with: address, purchase price, purchase date, property type, current estimated value, rental income (if rented)\n- The portfolio dashboard (separate feature) will aggregate all properties\n- Journey completion should auto-populate portfolio entry from journey data (location, budget, property type)\n\n**Backend:**\n- Add journey steps seed data for phases 5 and 6\n- Create Property model + migration (id, user_id, journey_id FK, address, purchase_price, purchase_date, property_type, estimated_value, monthly_rental_income, status enum: owned/rented/sold)\n- Create portfolio service with CRUD operations\n- API endpoints: GET/POST /api/v1/portfolio, GET/PATCH/DELETE /api/v1/portfolio/{id}\n\n**Frontend:**\n- Add step content components for each Ownership and Rental Setup step\n- Add \"Add to Portfolio\" CTA on journey completion\n- Create portfolio entry form pre-filled from journey data",
@@ -1140,7 +1140,7 @@
         "updatedAt": "2026-04-21T14:59:18.613Z"
       },
       {
-        "id": 92,
+        "id": "92",
         "title": "Add Portfolio Management to Landing Page Features & App Navigation",
         "description": "Portfolio Management is a key differentiator for the investor persona but is not currently mentioned on the landing page, feature cards, or app navigation. Add Portfolio Management as a visible feature across the landing page \"Why HeimPath?\" section, \"How It Works\" phases, the app sidebar, and other important touchpoints to communicate the full end-to-end value proposition.",
         "details": "**Landing Page Changes:**\n1. \"How It Works\" section — extend the phase stepper from 4 phases (Research → Preparation → Buying → Closing) to include 2 post-purchase phases: Ownership & Rental Setup. Show that HeimPath covers the entire lifecycle, not just the purchase.\n2. \"Why HeimPath?\" feature cards — add a 4th card for Portfolio Management: \"Track your properties, monitor rental yields, and manage your German real estate portfolio — all in one place.\" Icon: LayoutDashboard or PieChart from lucide-react.\n3. Advantages section — add a bullet or card about post-purchase support and portfolio tracking.\n4. Hero section — update subtitle or supporting text to mention \"from first search to portfolio management\" or similar end-to-end messaging.\n\n**App Navigation Changes:**\n1. Sidebar — add \"Portfolio\" nav item (icon: LayoutDashboard) below Calculators, linking to /portfolio. Show a \"Coming Soon\" badge if the portfolio feature isn't built yet, or link to the actual page if available.\n2. Dashboard — add a Portfolio summary card or CTA in the right sidebar for users who have completed at least one journey.\n3. CMD+K search — add portfolio-related search entries.\n\n**Frontend Files to Modify:**\n- `frontend/src/components/Landing/` — HowItWorks, Features/WhyHeimPath, Advantages, Hero sections\n- `frontend/src/components/Sidebar/` — add Portfolio nav item\n- `frontend/src/components/Dashboard/DashboardPage.tsx` — add Portfolio CTA/summary\n- `frontend/src/routes/` — create /portfolio route (placeholder or real page)\n\n**Design Notes:**\n- Use a consistent icon for Portfolio across all touchpoints (LayoutDashboard recommended)\n- Portfolio color accent: teal-600 or emerald-600 to differentiate from existing feature colors\n- Landing page additions should feel natural, not forced — the value prop is \"we guide you from search to portfolio\"",
@@ -1152,7 +1152,7 @@
         "updatedAt": "2026-04-21T16:41:34.652Z"
       },
       {
-        "id": 93,
+        "id": "93",
         "title": "Fix signup page error handling — misleading \"Something went wrong\" toast",
         "description": "The signup page shows a misleading \"Something went wrong!\" toast title for ALL API errors (400, 422, 429, network errors), making expected errors look like 500 server crashes. Users report \"500 error - something went wrong\" when the actual error is a duplicate email (400) or validation failure (422).",
         "details": "Root cause: showErrorToast() in useCustomToast.ts hardcodes \"Something went wrong!\" as the toast title for every error. The actual error message is in the description field which is less prominent.\n\nFix:\n1. Update showErrorToast to accept optional title parameter with \"Error\" as default\n2. Add specific error handling in signup mutation for common registration errors (400 duplicate, 422 validation, 429 rate limit)\n3. Show registration-specific error messages inline in the form where appropriate\n4. Improve extractErrorMessage to provide better fallback messages based on error type",
@@ -1164,7 +1164,7 @@
         "updatedAt": "2026-04-21T18:41:05.252Z"
       },
       {
-        "id": 94,
+        "id": "94",
         "title": "Fix staging auth 500 — Redis not provisioned",
         "description": "All auth endpoints (register, login, verify-email, forgot-password, reset-password) return 500 Internal Server Error on staging because Redis is not provisioned in the staging infrastructure. The rate_limit_service, email_verification_service, and password_reset_service all require Redis but REDIS_URL defaults to redis://localhost:6379 which doesn't exist on Azure Container Apps.",
         "details": "Root cause: infra/terraform/staging.tf has no Azure Cache for Redis resource. The backend services (rate_limit_service.py, email_verification_service.py, password_reset_service.py) all connect to Redis on first use and throw unhandled ConnectionError when Redis is unreachable.\n\nFix approach: Add Azure Cache for Redis (Basic C0 tier for staging) to Terraform staging infrastructure, wire the REDIS_URL env var into the backend container app, and verify all auth endpoints work after deployment.\n\nFiles to modify:\n- infra/terraform/staging.tf — add azurerm_redis_cache resource\n- infra/terraform/variables.tf — add redis-related variables if needed\n- infra/terraform/outputs.tf — add redis connection string output\n- Possibly infra/terraform/prod.tf — add Redis for production too\n\nAlternative lighter fix: Make the Redis-backed services gracefully degrade to in-memory fallback when Redis is unavailable. This is less ideal for production but would unblock staging immediately.",
@@ -1176,7 +1176,7 @@
         "updatedAt": "2026-04-21T19:19:45.281Z"
       },
       {
-        "id": 95,
+        "id": "95",
         "title": "Reduce journey steps accordion height when closed",
         "description": "The journey steps accordion items take up too much vertical space when collapsed/closed. Reduce the closed-state height so the accordion is more compact and users can see more steps at a glance without excessive scrolling.",
         "details": "- Locate the accordion component used for journey steps (likely in frontend/src/components/Journey/)\n- Reduce padding/min-height of collapsed accordion items\n- Ensure the accordion trigger text and icons remain readable\n- Test that expanding/collapsing still works smoothly with reduced height\n- Verify on both desktop and mobile viewports",
@@ -1188,7 +1188,7 @@
         "updatedAt": "2026-04-22T12:44:33.661Z"
       },
       {
-        "id": 96,
+        "id": "96",
         "title": "Reduce journey progress tracker prominence on tablet view",
         "description": "The journey progress tracker/stepper feels too prominent and takes up too much space on tablet viewports. It dominates the screen and needs to be visually reduced or restructured for tablet-sized screens.",
         "details": "- Identify the progress tracker component (likely PhaseProgress or similar in frontend/src/components/Journey/)\n- On tablet breakpoint (md:), reduce the tracker size — consider: smaller font, condensed step indicators, horizontal compact layout, or collapsible tracker\n- Ensure the tracker remains functional and readable\n- The tracker should complement the content, not dominate the viewport on tablets\n- Test across tablet widths (768px - 1024px)",
@@ -1200,7 +1200,7 @@
         "updatedAt": "2026-04-22T12:52:01.108Z"
       },
       {
-        "id": 97,
+        "id": "97",
         "title": "Redesign journey card layout on My Journeys page",
         "description": "Redesign the journey cards on the My Journeys page: (1) Card title should show only the property type (e.g. \"Apartment\") instead of \"Apartment in Niedersachsen\". (2) Keep the location icon and state/city value underneath the title as-is. (3) Remove the house logo/icon and the duplicate apartment type display. (4) Pin the \"Continue Journey\" button permanently to the bottom of the card.",
         "details": "- Locate the journey card component (likely in frontend/src/components/Journey/ or the journeys route)\n- Change card title to show only propertyType (e.g. \"Apartment\", \"House\") without the location suffix\n- Keep the location row (icon + state name) as a subtitle below the title\n- Remove the house/property icon that duplicates the property type info\n- Make the \"Continue Journey\" button stick to the bottom of the card using flex layout (mt-auto or similar)\n- Ensure cards maintain consistent height in grid layout with button always at bottom",
@@ -1212,7 +1212,7 @@
         "updatedAt": "2026-04-22T13:01:42.514Z"
       },
       {
-        "id": 98,
+        "id": "98",
         "title": "Add interactive next button after completing each journey phase",
         "description": "After a user completes all steps in a journey phase, there should be an interactive \"Next\" button (or similar CTA) that guides them to proceed to the next phase. Currently there is no clear visual prompt to advance after phase completion.",
         "details": "- In the journey phase view, detect when all steps in the current phase are marked complete\n- Show a prominent \"Continue to Next Phase\" or \"Next Phase →\" button\n- The button should navigate to or expand the next phase\n- Include a congratulatory micro-interaction or message (e.g. \"Phase complete! Ready for the next step?\")\n- Disable/hide the button if the user is on the last phase\n- On the last phase, show a \"Journey Complete\" message instead",
@@ -1224,7 +1224,7 @@
         "updatedAt": "2026-04-22T13:39:37.629Z"
       },
       {
-        "id": 99,
+        "id": "99",
         "title": "Fix journey steps progress not syncing with journey card on My Journeys page",
         "description": "Bug: When a user completes steps within a journey, the progress shown on the journey card on the My Journeys page does not automatically update to reflect the new completion state. The user must manually refresh to see updated progress.",
         "details": "- Investigate the query invalidation flow: when a journey step is marked complete, the journey list query should be invalidated\n- Check if the journey detail mutation's onSuccess properly invalidates the journeys list query key\n- Ensure queryKeys.journeys.list() is invalidated when a step status changes\n- May need to add invalidation in the step completion mutation hook\n- Also check if the journey card reads from a stale cache",
@@ -1236,7 +1236,7 @@
         "updatedAt": "2026-04-22T12:05:52.862Z"
       },
       {
-        "id": 100,
+        "id": "100",
         "title": "Fix email notification icon click showing \"something went wrong\" error",
         "description": "Bug: Clicking the email/notification icon in the top-right navigation bar results in a \"something went wrong\" error. The notification feature either has a broken endpoint, missing implementation, or unhandled error state.",
         "details": "- Locate the notification icon component in the navbar/header (likely in frontend/src/components/Sidebar/ or a layout component)\n- Identify what action the click triggers — API call, route navigation, or popover\n- Check if the backend endpoint exists and is functional\n- If the notification feature is not yet implemented, either: (a) remove the icon, or (b) show a \"Coming soon\" tooltip instead of an error\n- If the endpoint exists but fails, fix the error handling",
@@ -1248,7 +1248,7 @@
         "updatedAt": "2026-04-22T12:13:34.440Z"
       },
       {
-        "id": 101,
+        "id": "101",
         "title": "Fix calculator tabs overflowing viewport when sidebar is visible",
         "description": "Bug: On the calculators page, the tab row listing the different calculators (Hidden Costs, ROI, State Comparison) overflows horizontally out of the viewport when the sidebar navigation is open on desktop. The content area does not properly account for the sidebar width.",
         "details": "- The calculators page layout does not constrain its width when the sidebar is expanded\n- Fix the calculator page container to respect the available width (likely needs overflow-hidden, max-w-full, or proper flex/grid sizing)\n- Ensure the tab row either wraps, scrolls horizontally with overflow-x-auto, or shrinks to fit\n- This affects all calculator tab contents (Hidden Costs, ROI, State Comparison) — the fix should be at the page/container level\n- Test with sidebar open and closed on various desktop widths",
@@ -1260,7 +1260,7 @@
         "updatedAt": "2026-04-22T12:21:24.987Z"
       },
       {
-        "id": 102,
+        "id": "102",
         "title": "Redesign State Comparison calculator layout and reduce card size",
         "description": "The State Comparison calculator has layout issues: (1) Input field card and response display overflow the viewport when sidebar is visible. (2) The input form card is too large and wastes space. (3) The \"Include Agent\" option should be a checkbox or toggle instead of its current control. Overall the card housing the inputs needs to be more compact.",
         "details": "- Fix overflow: ensure the State Comparison section respects available width with sidebar open\n- Compact the input form card: reduce padding, use tighter spacing, consider a more horizontal/inline layout for inputs\n- Change \"Include Agent\" control to a checkbox or toggle switch (using shadcn Switch or Checkbox component)\n- Reduce the overall card height — inputs should not take excessive vertical space\n- Ensure the results/response area also stays within viewport bounds\n- Test with sidebar open and closed",
@@ -1272,7 +1272,7 @@
         "updatedAt": "2026-04-22T12:21:25.026Z"
       },
       {
-        "id": 103,
+        "id": "103",
         "title": "Update SCHUFA rating field to new NextGen Score system (2026)",
         "description": "SCHUFA launched their new NextGen Score 1.0 on March 17, 2026, replacing the old percentage-based system with a transparent 100-999 point scale. Our financing eligibility calculator still uses the old categories (excellent/good/satisfactory/adequate/poor mapped to percentages like 97.5%+, 95-97.5%, etc.). Update all SCHUFA-related fields, scoring, and UI to reflect the new official rating system.",
         "details": "## New SCHUFA NextGen Score System\n\n### Score Scale: 100-999 points (higher = better)\n\n### Official Rating Categories:\n| Score Range | Rating | German Term | ~Population |\n|---|---|---|---|\n| 776-999 | Excellent | Hervorragend | ~62% |\n| 709-775 | Good | Gut | ~20% |\n| 642-708 | Acceptable | Akzeptabel | ~8% |\n| 100-641 | Sufficient | Ausreichend | ~2% |\n| No score | Insufficient (open defaults) | Ungenügend | ~8% |\n\n### The 12 Scoring Criteria (with max points):\n1. Payment defaults (264 pts) — heaviest weight by far\n2. Bank account and credit card inquiries in last 12 months (117 pts)\n3. Non-banking inquiries in last 12 months (99 pts)\n4. Age of current address (94 pts)\n5. Age of oldest credit card (81 pts)\n6. Age of oldest bank contract (69 pts)\n7. Installment loans taken in last 12 months (66 pts)\n8. Longest remaining loan term (61 pts)\n9. Mortgage/property loan (55 pts)\n10. Identity verification on file (38 pts)\n11. Age of newest revolving credit (36 pts)\n12. Credit status (19 pts)\n\n### Files to Update:\n\n**Backend:**\n- `backend/app/schemas/financing.py` — Update SchufaRating Literal type to new categories: \"excellent\" (776-999), \"good\" (709-775), \"acceptable\" (642-708), \"sufficient\" (100-641), \"insufficient\", \"unknown\"\n- `backend/app/services/financing_service.py` — Update `_score_schufa()` scoring function and `_recommended_dp_percent()` logic for new categories\n- `backend/app/models/financing.py` — schufa_rating column may need wider string if category names change\n- `backend/tests/services/test_financing_service.py` — Update tests for new categories and scores\n\n**Frontend:**\n- `frontend/src/models/calculator.ts` — Update `SchufaRating` type union\n- `frontend/src/components/Calculators/FinancingWizard.tsx` — Update `SCHUFA_OPTIONS` dropdown labels from old percentage ranges to new point ranges, update `scoreSchufa()` function, update advisory messages\n- Consider adding an informational tooltip or help text explaining the new 12 criteria to educate users\n\n**Migration:**\n- Add Alembic migration to update any existing schufa_rating values in the database from old to new category names (e.g. \"satisfactory\" → \"acceptable\")\n\n### Key Mapping (Old → New):\n- \"excellent\" (97.5%+) → \"excellent\" (776-999) — name stays, range changes\n- \"good\" (95-97.5%) → \"good\" (709-775) — name stays, range changes  \n- \"satisfactory\" (90-95%) → \"acceptable\" (642-708) — name AND range change\n- \"adequate\" (80-90%) → \"sufficient\" (100-641) — name AND range change\n- \"poor\" (less than 80%) → \"insufficient\" (no score / open defaults) — name changes\n- \"unknown\" → \"unknown\" — keep as-is for users who haven't obtained SCHUFA yet",
@@ -1284,7 +1284,7 @@
         "updatedAt": "2026-04-22T12:37:20.435Z"
       },
       {
-        "id": 104,
+        "id": "104",
         "title": "Beta Launch Legal Compliance — Impressum, Privacy Policy, Terms",
         "description": "Add required German legal pages before any public launch: Impressum (§5 TMG), Datenschutzerklärung (GDPR/DSGVO privacy policy), and AGB (terms and conditions). These are legally required for any German-facing web application.",
         "details": "1) Create /impressum route with legally required business information (name, address, contact, registration info). 2) Create /privacy route with GDPR-compliant privacy policy covering data collection, cookies, third-party services (Stripe, Azure Translator, Sentry), user rights (access, deletion, portability). 3) Create /terms route with terms of service covering account usage, calculator disclaimers, document translation limitations. 4) Add footer links to all three pages from the main layout. 5) Add cookie consent banner if analytics/tracking cookies are used. 6) All pages should be accessible without login.",
@@ -1296,7 +1296,7 @@
         "updatedAt": "2026-04-22T15:00:26.398Z"
       },
       {
-        "id": 105,
+        "id": "105",
         "title": "Beta Launch SEO and Social Sharing — Meta Tags, Open Graph, Structured Data",
         "description": "Add proper SEO meta tags, Open Graph tags for social sharing, and JSON-LD structured data to improve search engine visibility and social media link previews for the landing page and key public pages.",
         "details": "1) Add title, description, canonical URL meta tags to all public pages (landing, login, signup, legal pages, public calculator pages). 2) Add Open Graph tags (og:title, og:description, og:image, og:url, og:type) for rich link previews on social media. 3) Add Twitter Card meta tags. 4) Add JSON-LD structured data (Organization, WebApplication, FAQPage if applicable). 5) Create a default OG image (1200x630) for social sharing. 6) Add sitemap.xml generation. 7) Add robots.txt with appropriate rules.",
@@ -1308,7 +1308,7 @@
         "updatedAt": "2026-04-22T15:23:53.231Z"
       },
       {
-        "id": 106,
+        "id": "106",
         "title": "Beta Launch Readiness — Error Monitoring, Performance Audit, Feedback Widget",
         "description": "Ensure production readiness by validating error monitoring (Sentry alerts), running performance audits (Lighthouse, Core Web Vitals), and adding an in-app user feedback mechanism for beta testers.",
         "details": "1) Verify Sentry is capturing errors in both frontend and backend with proper environment tagging. 2) Set up Sentry alert rules for error spikes and new issues. 3) Run Lighthouse audit on landing page and key authenticated pages — target 90+ on Performance, Accessibility, Best Practices, SEO. 4) Fix any critical Lighthouse findings (image optimization, lazy loading, font display, CLS). 5) Add a lightweight feedback widget (floating button or menu item) that lets beta testers submit feedback with optional screenshot. 6) Store feedback in DB or send to a designated email/Slack channel.",
@@ -1320,7 +1320,7 @@
         "updatedAt": "2026-04-22T15:49:26.162Z"
       },
       {
-        "id": 107,
+        "id": "107",
         "title": "Rental Journey Path — Guided Apartment Search to Move-In",
         "description": "Add a rental-focused journey path for the ~55% of Germany's population that rents. Guide users through apartment search, application, Mietvertrag review, Anmeldung, and Kaution handling — reusing the existing journey infrastructure.",
         "details": "1) Add 'rental' as a new journey type option in the journey creation wizard. 2) Define rental-specific phases: Search, Application, Contract Review, Move-In. 3) Create rental step templates with tasks (e.g., SCHUFA request, Selbstauskunft preparation, Mietvertrag clause review, Anmeldung registration). 4) Add rental-specific content keys and step body renderers. 5) Rental journey should share the same infrastructure (JourneyDetail, StepCard, PhaseIndicator) with buying journeys. 6) Add rental-specific calculators: warm vs cold rent breakdown, Nebenkosten estimator.",
@@ -1332,7 +1332,7 @@
         "updatedAt": "2026-04-22T17:02:32.813Z"
       },
       {
-        "id": 108,
+        "id": "108",
         "title": "Professional Marketplace Foundation — Vetted Service Provider Directory",
         "description": "Build the foundation for HeimPath's primary revenue channel: a directory of vetted English-speaking professionals (notaries, mortgage brokers, tax advisors, real estate agents) that foreign property buyers can browse and contact.",
         "details": "1) Create Professional model with fields: name, type (notary/broker/tax_advisor/agent), languages, location/state, description, contact info, website, verified status. 2) Create admin interface to add/manage professionals. 3) Build public directory page with filtering by type, state, and language. 4) Add professional profile cards with contact form (sends inquiry email). 5) Integrate contextual professional recommendations into journey steps (e.g., suggest notaries during closing phase). 6) Track referral clicks for future monetization metrics.",
@@ -1344,7 +1344,7 @@
         "updatedAt": "2026-04-24T07:07:05.039Z"
       },
       {
-        "id": 109,
+        "id": "109",
         "title": "Fix calculator result card overflowing outside viewport on all calculator tabs",
         "description": "The result/summary card on the right side of all calculator tab pages overflows outside the visible viewport when the sidebar is open. The card is cut off at the right edge. The two-column grid layout does not account for the sidebar width, causing the right column to extend beyond the screen.",
         "details": "1) Investigate the calculator page layout — likely a grid with the input form on the left and result card on the right. 2) The grid container probably has a fixed or percentage width that doesn't account for sidebar width. 3) Fix by ensuring the grid uses min-w-0 on grid children, or by using overflow-hidden/overflow-x-auto on the container, or by ensuring the parent container is properly constrained. 4) Test across all calculator tabs: Hidden Costs, ROI, State Comparison, Financing, Property Evaluation, GmbH vs Private, Mortgage, City Compare.",
@@ -1356,7 +1356,7 @@
         "updatedAt": "2026-04-22T14:07:38.587Z"
       },
       {
-        "id": 110,
+        "id": "110",
         "title": "Professional Contact & Referral System",
         "description": "Close the monetization loop on the Connect pillar by adding a contact inquiry form to professional profiles and tracking referral clicks. Users can submit inquiries directly to professionals from the directory, and all referral clicks are tracked for monetization metrics.",
         "details": "1. Backend: Contact inquiry model + migration (professional_id, sender name/email/message, sent_at, status). Service function to send inquiry email via existing email integration. POST /professionals/{id}/inquiries endpoint (auth required). Referral click tracking: POST /professionals/{id}/click (no auth, increments click counter on Professional model). Add click_count field to Professional model + migration.\n2. Frontend: Contact form modal on professional profile detail page (name, email, message fields). Submit via mutation hook, show success/error toast. Track click events on \"Contact\" button and profile card CTAs (call referral click endpoint on click). Display click_count in admin views only.\n3. Email: Send inquiry email to professional's email address with sender details and message. Include link back to HeimPath. Use existing email/notification infrastructure.",
@@ -1368,7 +1368,7 @@
         "updatedAt": "2026-04-24T14:39:05.738Z"
       },
       {
-        "id": 111,
+        "id": "111",
         "title": "AI-Powered Kaufvertrag (Purchase Contract) Explainer",
         "description": "Allow users to upload a German purchase contract (Kaufvertrag) and receive a clause-by-clause English explanation with risk annotations. No competitor in the German market offers this for foreign buyers. High-impact moat-building feature for The Settler persona facing a notary appointment with a 30-page German contract.",
         "details": "1. Backend: Extend document translation engine (Task #7) to handle structured contract analysis. New endpoint POST /contracts/analyze — accepts PDF/DOCX upload, extracts text, segments into clauses, sends each clause to Claude API (claude-sonnet-4-6) with a prompt that: explains the clause in plain English, flags risk level (low/medium/high), identifies standard vs non-standard terms, highlights buyer-unfavorable clauses. Returns structured JSON with clause breakdown. Store analysis result (linked to user, share_id pattern for sharing). GET /contracts/{share_id} to retrieve saved analysis.\n2. Frontend: New \"Contract Explainer\" page under /contract-explainer. File upload with drag-and-drop. Progress indicator during analysis (can take 30-60s for large contracts). Results displayed as expandable clause cards with color-coded risk badges (green/yellow/red). Side-by-side: original German text | English explanation. Share button generates shareable link. Add to sidebar nav and dashboard.\n3. Pricing: Gate behind premium subscription (Stripe). Free tier: first 3 clauses only, blur the rest with upgrade CTA.",
@@ -1382,7 +1382,7 @@
         "updatedAt": "2026-04-24T15:24:25.033Z"
       },
       {
-        "id": 112,
+        "id": "112",
         "title": "Allow 0% down payment in mortgage calculator",
         "description": "The mortgage calculator on the free tools page should accept 0 as a valid down payment amount. Currently it likely enforces a minimum, preventing users who want to model 100% financing scenarios from using it.",
         "details": "Find the down payment input/validation in the mortgage calculator component (likely frontend/src/routes/tools/mortgage-calculator.tsx or a Calculators component). Remove or lower the minimum validation so 0 is accepted. Ensure the calculation logic handles 0 down payment without division errors or NaN.",
@@ -1394,7 +1394,7 @@
         "updatedAt": "2026-04-24T12:22:35.590Z"
       },
       {
-        "id": 113,
+        "id": "113",
         "title": "Increase compare rates scenario label size for editability",
         "description": "The label for each scenario in the \"Compare Rates\" section of the mortgage calculator is too small, making it hard for users to click and edit the scenario name.",
         "details": "Find the scenario label input in the mortgage/compare rates calculator component. Increase the font size, input width, or click target so it's clearly editable. Consider using a more prominent inline-edit pattern (e.g. larger text with an edit icon on hover).",
@@ -1406,7 +1406,7 @@
         "updatedAt": "2026-04-24T12:33:56.379Z"
       },
       {
-        "id": 114,
+        "id": "114",
         "title": "Show potential sale profit after 10 years in mortgage calculator",
         "description": "The mortgage calculator should show how much equity/profit the user would realise if they sold the property after 10 years. This helps users understand the long-term financial benefit of buying vs renting.",
         "details": "After the amortisation table, add a summary section: \"If you sell after 10 years\" showing — remaining mortgage balance at year 10, estimated property value (using a configurable annual appreciation rate, default 2%), gross proceeds, minus outstanding mortgage = estimated equity/profit. Include a small appreciation rate input (slider or number field, 0–5%). Show net profit after subtracting agent commission (~3.57% incl. VAT) and notary/transfer costs optionally.",
@@ -1418,7 +1418,7 @@
         "updatedAt": "2026-04-24T12:48:37.980Z"
       },
       {
-        "id": 115,
+        "id": "115",
         "title": "Fix column spacing in mortgage amortisation table",
         "description": "The space between the Year column and the other columns in the mortgage amortisation table is too wide. Columns should have equal or proportional widths that use only the space they need.",
         "details": "Find the amortisation table in the mortgage calculator. Replace fixed-width or excessive padding on the Year column with auto or content-based width (e.g. w-auto, table-auto layout, or constrained col width). All columns should be visually balanced.",
@@ -1430,7 +1430,7 @@
         "updatedAt": "2026-04-24T12:57:56.523Z"
       },
       {
-        "id": 116,
+        "id": "116",
         "title": "Fix \"How it works\" footer link not redirecting",
         "description": "Clicking \"How it works\" in the footer does not navigate anywhere. It should scroll to or navigate to the How It Works section of the landing page.",
         "details": "Find the footer component (frontend/src/components/Landing/LandingFooter.tsx). Locate the \"How it works\" link and fix its href — either a hash anchor to the landing page section (#how-it-works) or a route to /#how-it-works. If the landing page section has no id, add one.",
@@ -1442,7 +1442,7 @@
         "updatedAt": "2026-04-24T13:13:07.934Z"
       },
       {
-        "id": 117,
+        "id": "117",
         "title": "Fix \"Features\" link not redirecting on free tools page",
         "description": "Clicking \"Features\" on the free tools page does not navigate to anything. It should link to the Features section of the landing page or a dedicated features anchor.",
         "details": "Find the free tools page header/nav (frontend/src/routes/tools/ or ToolsCta component). Locate the \"Features\" link and set its href to /#features or the correct landing page anchor. Ensure the landing page Features section has a matching id attribute.",
@@ -1454,7 +1454,7 @@
         "updatedAt": "2026-04-24T13:14:54.613Z"
       },
       {
-        "id": 118,
+        "id": "118",
         "title": "Fix slow Terms of Service redirect from landing and free tools pages",
         "description": "On initial click, the Terms of Service link from the landing page and free tools page takes noticeably long to redirect. Should navigate instantly like other internal links.",
         "details": "Find Terms of Service links in the landing page and free tools page. Check if they use an anchor tag with href=\"/terms\" vs TanStack Router Link component. Replace any plain anchor tags with TanStack Router Link for client-side navigation without full page reload. Also check if the /terms route has any heavy data loading on mount that could be deferred.",
@@ -1466,7 +1466,7 @@
         "updatedAt": "2026-04-24T13:21:47.377Z"
       },
       {
-        "id": 119,
+        "id": "119",
         "title": "Make agent commission and moving costs toggles in hidden cost calculator",
         "description": "The \"Include Agent Commission\" and \"Include Moving Costs\" options in the Hidden Cost Calculator should be toggle switches (not checkboxes or buried options) placed as the last two fields in the form, one after the other, for better UX.",
         "details": "Find these two fields in HiddenCostsCalculator component. Convert them to toggle switch UI (use the existing Switch component from shadcn/ui). Move them to be the last two fields in the input form, in order: agent commission toggle first, moving costs toggle second. Ensure labels and values remain correct.",
@@ -1478,7 +1478,7 @@
         "updatedAt": "2026-04-24T13:38:55.154Z"
       },
       {
-        "id": 120,
+        "id": "120",
         "title": "Logo on login page should redirect to landing page",
         "description": "Clicking the HeimPath logo on the login page should navigate the user to the landing page (/), not stay on the same page or go nowhere.",
         "details": "Find the Logo component usage on the login page (frontend/src/routes/login.tsx). The Logo component likely links to \"/\" already — verify and fix if it links elsewhere or has no link. Same check for the signup page.",
@@ -1490,7 +1490,7 @@
         "updatedAt": "2026-04-24T13:45:26.527Z"
       },
       {
-        "id": 121,
+        "id": "121",
         "title": "Add portfolio management to features list on login and signup pages",
         "description": "The features list shown on the left panel of the login and signup pages is missing \"Portfolio Management\". Add it alongside the existing feature bullets.",
         "details": "Find the feature list in the login/signup left panel (frontend/src/routes/login.tsx and signup.tsx, or a shared auth layout component). Add a new entry for \"Portfolio Management\" with an appropriate icon (e.g. BarChart2 or Briefcase from lucide-react) and a short description.",
@@ -1502,7 +1502,7 @@
         "updatedAt": "2026-04-24T13:51:19.838Z"
       },
       {
-        "id": 122,
+        "id": "122",
         "title": "Replace login and signup left panel background with home image",
         "description": "Replace the current background on the left side of the login and signup pages with a Pinterest home image (https://i.pinimg.com/736x/06/a7/a4/06a7a42a44eecb0e4ca8dccfbb4b6d0e.jpg). The image should cover the full left panel with a dark overlay so text remains readable.",
         "details": "Download the image and save it to frontend/public/images/auth-bg.jpg. In the login and signup left panel, replace the current background (gradient or colour) with this image using Tailwind bg-cover bg-center. Add a semi-transparent dark overlay (bg-black/50 or similar) on top to maintain text contrast. Ensure the feature list text is still clearly readable.",
@@ -1514,7 +1514,7 @@
         "updatedAt": "2026-04-24T13:57:46.795Z"
       },
       {
-        "id": 123,
+        "id": "123",
         "title": "Hide phase completion banner once next phase is started",
         "description": "The \"Ready for next phase\" / phase completion banner should disappear automatically once the user has already started steps in the next phase. It is only useful as a prompt before the user has moved on.",
         "details": "In PhaseCompletionCta (or StepListView where it is rendered), add a condition to suppress the banner: check whether any step in the next phase has status other than \"not_started\" (i.e. \"in_progress\", \"completed\", or \"skipped\"). If the next phase is already underway, do not render the CTA card. The steps array is available in context.",
@@ -1526,7 +1526,7 @@
         "updatedAt": "2026-04-24T15:24:38.080Z"
       },
       {
-        "id": 124,
+        "id": "124",
         "title": "Rental Property Evaluation Calculator",
         "description": "Implement a full German rental property evaluation calculator based on property_evaluation_spec.md. Accepts property details, financing, tax assumptions, and growth rates to produce a month-1 cashflow snapshot and 10-year annual cashflow model with German AfA depreciation, progressive §32a EStG tax, equity buildup, and exit year sale proceeds.",
         "details": "Backend: POST /api/v1/calculators/property-evaluation endpoint. Implement PropertyEvaluationRequest and PropertyEvaluationResponse schemas as specified in property_evaluation_spec.md Section 5. Implement all calculation sections: property purchase (closing costs), rent, Hausgeld, AfA depreciation, annuity financing with monthly compounding for loan balance, rental yield, monthly cashflow pre/after tax, 10-year annual table (AnnualCashflowRow), progressive German income tax (§32a EStG), equity buildup, exit year. Use the validation test case from Section 7 of the spec to verify outputs within ±0.01 € tolerance. Frontend: form with 9 collapsible input sections mirroring the Excel layout, live recalculation on field blur (debounced 300ms), KPI summary cards (monthly_cashflow_after_tax, gross_rental_yield, factor_cold_rent_vs_price, final_equity_kpi), horizontal-scroll 10-year cashflow table with sticky row labels, green/red color coding for positive/negative cashflow. German locale number formatting (1.234,56 €).",
@@ -1538,7 +1538,7 @@
         "updatedAt": "2026-04-24T16:36:53.745Z"
       },
       {
-        "id": 125,
+        "id": "125",
         "title": "Shareable Evaluation Links — Public Read-Only Calculator URLs",
         "description": "Allow users to generate a shareable public URL for their saved property evaluation. The recipient can view the full evaluation results (read-only, no auth required) and is shown a CTA to sign up and run their own analysis. Viral growth loop: every shared link is a potential new user.",
         "details": "Backend: add share_id (secrets.token_urlsafe(8)) to the HiddenCostCalculation model (or create a new PropertyEvaluation model if task 124 introduces one). Add GET /api/v1/calculators/property-evaluation/shared/{share_id} public endpoint returning full evaluation data. Add POST /{id}/share endpoint for authenticated users to generate the share_id. Frontend: \"Share\" button on evaluation results page copies share URL to clipboard with success toast. Public shared view renders full KPI cards and 10-year table with a signup CTA banner at the top (\"Analyse your own property — free\"). No auth required to view shared link.",
@@ -1552,7 +1552,7 @@
         "updatedAt": "2026-04-24T16:36:53.773Z"
       },
       {
-        "id": 126,
+        "id": "126",
         "title": "Contract Explainer → Evaluation Calculator Bridge",
         "description": "When an AI Kaufvertrag analysis extracts a purchase price from the contract, offer a one-click \"Evaluate this property\" action that pre-populates the rental property evaluation calculator with that figure. Reduces the friction between legal review and financial decision — the two most critical steps in the buying journey.",
         "details": "After a Kaufvertrag analysis completes, parse the contract summary or analyzed_clauses for a purchase price value (the AI already identifies the Kaufpreis clause). If found, show an \"Evaluate this property\" button in the ContractExplainerPage results view. Clicking it navigates to /calculators (or the new evaluation calculator route from task 124) with the purchase_price pre-filled as a query param (?purchase_price=X). The evaluation calculator reads this param on mount and pre-populates the field. Frontend only change if the backend already returns the purchase price in the analysis response; otherwise add a purchase_price_extracted field to ContractAnalysisResponse.",
@@ -1566,7 +1566,7 @@
         "updatedAt": "2026-04-24T19:11:39.719Z"
       },
       {
-        "id": 127,
+        "id": "127",
         "title": "Professional Reviews and Verified Trust Signals",
         "description": "Add star ratings and verified reviews to the professional directory. Foreign buyers rely on social proof more than local buyers — this turns the directory from a listing into a trust platform and differentiates HeimPath from Immoscout/McMakler for the foreign buyer persona.",
         "details": "Backend: create ProfessionalReview model (id, professional_id FK, reviewer_user_id FK, rating 1-5, comment text, is_verified bool, created_at). Endpoints: POST /api/v1/professionals/{id}/reviews (authenticated, one review per user per professional), GET /api/v1/professionals/{id}/reviews (public, paginated). Add avg_rating and review_count computed fields to ProfessionalResponse. Add Alembic migration. Frontend: star rating input component on professional detail page (authenticated users only). Display average star rating + count on professional cards in the directory listing. Show paginated review list on professional detail page. \"Verified buyer\" badge if reviewer has a completed journey. Guard: users cannot review a professional more than once (409 on duplicate).",
@@ -1578,7 +1578,7 @@
         "updatedAt": "2026-04-24T16:36:53.780Z"
       },
       {
-        "id": 128,
+        "id": "128",
         "title": "Add Free Tools link to login/signup footer and landing page",
         "description": "Add a \"Free Tools\" link to the footer on login and signup pages (alongside existing Imprint, Privacy, Terms links). Also add a prominent \"Free Tools\" section or CTA on the landing page to market the calculators as a selling point and attract users before they register.",
         "details": "Login/Signup footer: add a Free Tools link pointing to /tools or /calculators next to the existing legal footer links in AuthLayout.tsx. Landing page: add a dedicated \"Try our free tools\" section or feature card in the landing page — highlight the hidden cost calculator, mortgage calculator, and ROI calculator as free-to-use without an account. Place it between the \"How it works\" and \"Why HeimPath\" sections, or add a prominent CTA banner. The free tools page already exists at /tools; just needs visibility and marketing copy.",
@@ -1590,7 +1590,7 @@
         "updatedAt": "2026-04-24T17:04:51.497Z"
       },
       {
-        "id": 129,
+        "id": "129",
         "title": "Fix \"Continue to Ownership\" button navigating to rental setup instead of ownership section",
         "description": "Bug: clicking the \"Continue to Ownership\" phase button on the journey page navigates the user to the rental setup section instead of the ownership/buying phase. Fix the navigation target so it correctly scrolls to or routes to the ownership phase steps.",
         "details": "Investigate the phase completion CTA or phase navigation button that says \"Continue to Ownership\". Check the onClick handler or Link href — it is likely pointing to the wrong phase ID or route param (e.g., using the rental setup phase slug instead of the ownership phase slug). Fix the target to point to the correct phase section. Check PhaseCompletionCta.tsx, StepListView.tsx, or wherever phase navigation CTAs are rendered.",
@@ -1602,7 +1602,7 @@
         "updatedAt": "2026-04-24T19:11:39.613Z"
       },
       {
-        "id": 130,
+        "id": "130",
         "title": "Reorder journey steps — move landlord obligation and rental yield after \"Define Your Goals\" for rent-out users",
         "description": "When a user answers \"rent out\" to the \"What do you plan to do with the property?\" question in the journey, the steps \"Understand Landlord Obligations\" and \"Analyse Rental Yield\" should appear directly after \"Define Your Goals\" — not in their current position. This makes the flow contextually logical: once a user declares intent to rent, they immediately see rent-relevant steps.",
         "details": "Find where journey steps are ordered/filtered based on the user's property intent (live-in vs rent-out). The steps are likely defined in seed data or a static config. For users who chose rent_out: reorder so \"Understand Landlord Obligations\" and \"Analyse Rental Yield\" steps appear immediately after the \"Define Your Goals\" step, before the general research/preparation steps. Check journey step ordering logic in journey_service.py or the step seeding data. This may require adjusting step order_index values for these specific steps when intent=rent_out.",
@@ -1614,7 +1614,7 @@
         "updatedAt": "2026-04-24T19:11:39.670Z"
       },
       {
-        "id": 131,
+        "id": "131",
         "title": "Add \"Add to Portfolio\" CTA to the All Phases Complete card",
         "description": "When all journey phases are complete, the congratulations card (\"Congratulations on your purchase!\") should include a portfolio CTA. If the user has not yet added this property to their portfolio, show an \"Add to Portfolio\" button. If a portfolio entry already exists for this property, show a \"Manage Portfolio\" link instead. The button should be visible to all users but trigger a premium upgrade prompt if the user is on the free tier.",
         "details": "Find the \"All phases complete\" / congratulations card in the journey UI (likely in JourneyPage.tsx or a PhaseCompletionCta-like component). Add below the existing content: \"Track your property's performance, rental income, and expenses in your portfolio.\" with an \"Add to Portfolio\" button. Button logic: if user is free tier → navigate to /settings (subscription tab) with a tooltip \"Available on Premium\". If user is premium and no portfolio entry exists for journey.property_id → navigate to /portfolio/new?property_id=X. If portfolio entry exists → show \"Manage Portfolio\" link to /portfolio/{entry_id}. Check if the portfolio already has this property by querying portfolio entries filtered by property/address match.",
@@ -1626,7 +1626,7 @@
         "updatedAt": "2026-04-24T19:11:39.686Z"
       },
       {
-        "id": 132,
+        "id": "132",
         "title": "Change \"Continue Journey\" to \"View Journey\" on completed journey cards",
         "description": "On the My Journeys page, journey cards for completed journeys show a \"Continue Journey\" button — this is misleading since there's nothing left to continue. Change the label to \"View Journey\" (or \"Completed — View\") when journey.status === \"completed\" or all phases are done.",
         "details": "Find the journey card component (likely JourneyCard.tsx or in the My Journeys page). The button label is probably hardcoded as \"Continue Journey\". Add a condition: if the journey is complete (all phases done / status === \"completed\"), render \"View Journey\" instead. Optionally show a green checkmark or \"Completed\" badge alongside the button. The href/navigation should remain the same — just the label and styling change.",
@@ -1638,7 +1638,7 @@
         "updatedAt": "2026-04-24T19:11:39.693Z"
       },
       {
-        "id": 133,
+        "id": "133",
         "title": "Show \"Manage Portfolio\" suggestion on journey steps page when portfolio exists for the property",
         "description": "On the journey steps detail page, when all steps are complete AND a portfolio entry already exists for the journey's property, show a \"Manage Portfolio\" card or banner suggesting the user track their property there. Complements the \"Add to Portfolio\" CTA (task 131) — task 131 is for the congratulations card, this is for the journey steps page itself.",
         "details": "On the journey steps page (JourneyPage or StepListView), after detecting all steps are complete, check if a portfolio property exists linked to this journey's property (by address or property_id). If yes, show a subtle banner or card at the bottom: \"Your journey is complete! You have a portfolio entry for this property. [Manage Portfolio →]\" linking to /portfolio/{entry_id}. If no portfolio entry, show the \"Add to Portfolio\" prompt (per task 131 logic). This avoids showing duplicate CTAs — show one or the other based on portfolio existence.",
@@ -1650,7 +1650,7 @@
         "updatedAt": "2026-04-24T19:11:39.710Z"
       },
       {
-        "id": 134,
+        "id": "134",
         "title": "Make tab view the default view for journey steps",
         "description": "The journey steps page has a list/tab view toggle. Change the default so tab view is shown first instead of list view.",
         "details": "Find the view toggle state initialisation in the journey steps page or StepListView component (task #48 added this toggle). Change the default state from \"list\" to \"tab\". Likely a useState initialiser: change useState(\"list\") to useState(\"tab\") or similar.",
@@ -1662,7 +1662,7 @@
         "updatedAt": "2026-04-24T19:11:39.715Z"
       },
       {
-        "id": 135,
+        "id": "135",
         "title": "Expand document translation to support additional German RE document types",
         "description": "Add support for four new German real estate document types in the translation pipeline: Grundbuchauszug (land registry extract), Teilungserklärung (condominium declaration), Mietvertrag (rental contract), and Wohnungsgrundriss (floor plan with annotations). Each type needs specialised extraction logic, relevant legal term detection, and properly structured translated output.",
         "details": "Implementation order:\n1. Backend: Add new document type enum values (GRUNDBUCHAUSZUG, TEILUNGSERKLAERUNG, MIETVERTRAG, WOHNUNGSGRUNDRISS) to the existing document type model\n2. Backend: Create type-specific extraction prompts for each document — each has a distinct structure and vocabulary\n3. Backend: Grundbuchauszug: extract Abteilung I (ownership), Abteilung II (encumbrances), Abteilung III (mortgages); flag any Grundschulden or Wegerechte\n4. Backend: Teilungserklärung: extract Sondernutzungsrechte, Gemeinschaftseigentum vs Sondereigentum split, WEG rules\n5. Backend: Mietvertrag: extract rent, deposit (Kaution), notice period (Kündigungsfrist), maintenance obligations, renewal clauses\n6. Backend: Wohnungsgrundriss: extract room labels, dimensions, annotations — translate all German labels to English\n7. Frontend: Update document upload UI to show document type selector with the four new types\n8. Frontend: Add type-specific result sections in the document viewer\n\nAcceptance criteria:\n- All four document types accepted by the upload endpoint\n- Each produces a structured, translated output with type-appropriate sections\n- Existing document types unaffected\n- Tests cover each new type with a sample document fixture",
@@ -1674,7 +1674,7 @@
         "updatedAt": "2026-04-26T10:47:50.762Z"
       },
       {
-        "id": 136,
+        "id": "136",
         "title": "Add clause-by-clause risk annotations to translated documents",
         "description": "Enhance the document translation output so every clause is individually assessed for risk and annotated with a traffic-light rating (red/amber/green) and a plain-English explanation. This transforms translation from a passive output into an active risk-screening tool — no competitor does this.",
         "details": "Implementation:\n1. Backend: After translation, run a second AI pass on each clause to assign a risk level: HIGH (red), REVIEW (amber), STANDARD (green)\n2. Backend: Risk categories to detect:\n   - Unusual penalty clauses (Vertragsstrafe)\n   - Non-standard payment terms or upfront lump sums\n   - Rights-of-first-refusal (Vorkaufsrecht) for third parties\n   - Restrictive use clauses (usage limited to specific purpose)\n   - Maintenance liability shifts to buyer\n   - Clauses deviating from standard German RE norms (BGB defaults)\n   - Sonderumlage references or WEG capital reserve deficits\n3. Backend: Return clause-level annotation in the translation response: { text, translated_text, risk_level, risk_reason }\n4. Frontend: Render clause risk as coloured left-border (red/amber/green) in the document viewer\n5. Frontend: Clicking/tapping an annotated clause expands the risk explanation inline\n6. Frontend: Summary banner at top of document: \"X high-risk clauses found — review before signing\"\n\nSchema change: translation response now includes a `clauses` array with per-clause data alongside the existing full-text translation.\n\nAcceptance criteria:\n- High-risk clauses visually distinct from standard clauses\n- Risk reason shown on expand — plain English, no legal jargon\n- Zero false negatives on known high-risk patterns (tested with fixture contracts)",
@@ -1686,7 +1686,7 @@
         "updatedAt": "2026-04-26T11:08:01.873Z"
       },
       {
-        "id": 137,
+        "id": "137",
         "title": "Link German legal terms in translated documents to HeimPath glossary",
         "description": "Every German Fachbegriff (technical legal term) appearing in a translated document should be hyperlinked to its HeimPath glossary entry. On tap/hover, the user sees a plain-English definition inline without leaving the document view. Creates a compounding moat: every translated document makes the glossary more discoverable, and every glossary entry makes translation more useful.",
         "details": "Implementation:\n1. Backend: After translation, run a post-processing pass that scans the translated output for known legal terms from the HeimPath glossary database\n2. Backend: For each matched term, wrap it in a structured annotation: { term, glossary_id, definition_preview }\n3. Backend: For unmatched terms that look like German legal vocabulary (heuristic: capitalised nouns ending in common legal suffixes), queue them to a \"glossary gap\" table for review\n4. Frontend: Render matched terms as underlined/dashed-underline inline links in the document viewer\n5. Frontend: On hover/tap: show a popover with the term, plain-English definition, and a \"View full glossary entry\" link\n6. Frontend: On mobile: tap opens a bottom sheet with the definition\n\nDependencies: requires the HeimPath glossary to have a queryable API endpoint returning term + definition by slug or ID.\n\nAcceptance criteria:\n- All glossary terms present in a document are linked\n- Popover loads without page navigation\n- Unmatched legal terms are logged to the glossary gap table\n- No broken links (terms link to existing glossary entries only)",
@@ -1698,7 +1698,7 @@
         "updatedAt": "2026-04-26T11:38:12.200Z"
       },
       {
-        "id": 138,
+        "id": "138",
         "title": "Add per-clause confidence scoring to document translation output",
         "description": "Show users where the AI translation is uncertain so they know which clauses to double-check with a Notar or Steuerberater. Each translated clause displays a confidence indicator derived from the translation model's output scores. Being transparent about uncertainty is more trustworthy than projecting false confidence — this differentiates HeimPath from generic translation tools.",
         "details": "Implementation:\n1. Backend: Extract confidence scores from the translation model response for each clause (most LLM APIs return logprobs or a confidence proxy)\n2. Backend: Map to three bands: HIGH (>90%) — no callout; MEDIUM (70–90%) — subtle indicator; LOW (<70%) — prominent warning\n3. Backend: Include confidence_level and confidence_score in the clause-level response alongside risk annotations\n4. Backend: LOW confidence triggers typically: archaic German phrasing, highly technical legal constructs, jurisdiction-specific terms, or mixed-language content\n5. Frontend: HIGH: no visual treatment — clean translation shown as-is\n6. Frontend: MEDIUM: small \"~\" prefix or italic style, tooltip on hover: \"Translation may vary — verify with source text\"\n7. Frontend: LOW: amber warning icon beside the clause, expanded message: \"Complex legal language — consult a professional for this clause\"\n8. Frontend: Document summary bar shows count of low-confidence clauses alongside high-risk clause count\n\nAcceptance criteria:\n- Three confidence levels rendered distinctly\n- Low-confidence clauses clearly call out the need for professional review\n- High-confidence clauses show no visual noise\n- Summary bar shows accurate low-confidence count",
@@ -1710,7 +1710,7 @@
         "updatedAt": "2026-04-26T19:34:17.815Z"
       },
       {
-        "id": 139,
+        "id": "139",
         "title": "Set up quarterly Urbyo competitive monitoring process",
         "description": "Urbyo is HeimPath's closest direct competitor and the only platform that could replicate HeimPath's \"guided DIY\" positioning by shipping document translation. Establish a lightweight quarterly monitoring habit to track whether the competitive gap is widening or narrowing — this directly determines how urgently document translation investment needs to accelerate.",
         "details": "Quarterly review checklist (to be run every 3 months):\n1. Check Urbyo's public changelog, blog, and release notes for new features\n2. Review their job postings — engineering roles (NLP, document processing, AI) signal what they're building next\n3. Check App Store / Play Store reviews mentioning document handling, translation, or legal guidance\n4. Scan expat forums (Reddit r/germany, r/eupersonalfinance, Toytown Germany, InterNations) for user comparisons between Urbyo and HeimPath\n5. Do a side-by-side feature comparison against the last quarter's table\n\nOutput each quarter: a one-paragraph written summary answering: \"Has the gap widened or narrowed? Does document translation investment need to accelerate?\"\n\nAdditional monitoring signals to watch:\n- Any Urbyo fundraising announcements (new capital = new feature velocity)\n- Press mentions of Urbyo + \"document\" or \"translation\" or \"AI\"\n- LinkedIn posts from Urbyo engineers about document AI work\n\nThis is a business/product process task — not a dev task. Assign to product owner. Schedule first review for end of Q2 2026.",
@@ -1722,7 +1722,7 @@
         "updatedAt": "2026-06-17T11:53:14.802Z"
       },
       {
-        "id": 140,
+        "id": "140",
         "title": "Implement recurring transaction auto-generation for portfolio",
         "description": "The is_recurring flag already exists on PortfolioTransaction but has no automation behind it. Build a backend scheduled job that auto-creates the next period's transaction for any recurring entry, and update the frontend to show a \"next due\" indicator. This removes the biggest operational friction for multi-property owners without requiring fintech licensing — and is 90% built already.",
         "details": "Backend:\n1. Add migration: new column `recurrence_interval` (enum: \"monthly\" | \"annually\") on portfolio_transaction, nullable (NULL = non-recurring)\n2. Add `last_generated_date` column to track when the last auto-entry was created\n3. Implement scheduled job (APScheduler or Celery beat, weekly run): scan all transactions where is_recurring=True and recurrence_interval IS NOT NULL; for each, check if the current period's entry already exists; if not, create a new transaction copying type/amount/category/description/property_id/user_id with updated date\n4. Monthly: generate on the same day-of-month as the original transaction date\n5. Annually: generate on the same month+day each year\n6. New service function: `generate_recurring_transactions(session)` — idempotent, safe to run multiple times\n7. New endpoint (optional): POST /portfolio/properties/{id}/transactions/generate-recurring for manual trigger\n\nFrontend:\n1. Add recurrence_interval field to transaction create/edit form (dropdown: None / Monthly / Annually)\n2. In TransactionList, show a \"Next due: [date]\" badge on recurring transactions\n3. Allow users to stop recurrence: edit transaction and set recurrence_interval to None\n\nAcceptance criteria:\n- Monthly recurring rent transaction auto-appears on the correct date each month\n- Re-running the job on the same day does not create duplicate entries\n- Recurring badge visible in transaction list\n- Recurrence can be stopped via edit form",
@@ -1734,7 +1734,7 @@
         "updatedAt": "2026-04-26T19:34:18.903Z"
       },
       {
-        "id": 141,
+        "id": "141",
         "title": "Add Rentflow hand-off prompt in portfolio for large portfolios",
         "description": "When a user has 6 or more properties in their HeimPath portfolio, show a contextual non-intrusive prompt suggesting Rentflow for advanced bank-sync accounting. This turns HeimPath's accounting gap into a trusted referral — good UX and a potential affiliate revenue stream. Rentflow connects to 1,100+ German banks and offers DATEV-ready accounting that HeimPath deliberately does not replicate.",
         "details": "Frontend implementation:\n1. In PortfolioPage, check total property count from the portfolio summary query\n2. When count >= 6: render a dismissible info banner/card above the property grid\n3. Copy: \"Managing 6+ properties? Rentflow connects to 1,100+ German banks for automatic rent tracking and DATEV-ready accounting.\"\n4. CTA button: \"Learn about Rentflow →\" — opens affiliate link in new tab\n5. Dismiss button: X icon, stores dismissal in user preferences (backend) or localStorage (acceptable for MVP)\n6. Do not show again after dismissal (persist across sessions)\n7. Track click-through event for analytics\n\nBackend (if persisting dismissal server-side):\n1. Add `rentflow_prompt_dismissed` boolean to user preferences or a simple user_setting key-value store\n2. Endpoint: PATCH /users/me/preferences { rentflow_prompt_dismissed: true }\n\nBusiness action (parallel, not a dev task):\n- Reach out to Rentflow BD team about a referral/affiliate arrangement\n- HeimPath delivers qualified post-purchase investors; Rentflow gets warm leads\n- Target: affiliate link live before or at feature launch\n\nAcceptance criteria:\n- Prompt appears only when property count >= 6\n- Prompt does not reappear after dismissal\n- CTA opens correct URL in new tab\n- Prompt absent when property count < 6",
@@ -1746,7 +1746,7 @@
         "updatedAt": "2026-04-29T09:44:50.927Z"
       },
       {
-        "id": 142,
+        "id": "142",
         "title": "Add PDF export to Anlage V tax summary",
         "description": "The Anlage V tax summary (§ 21 EStG) is fully implemented but users cannot share it with their Steuerberater. Add an \"Export as PDF\" button to the AnlageVTab. No new data is needed — this is purely a rendering concern. Use browser print-to-PDF as the first implementation: it requires only CSS and a button, with no new backend dependencies.",
         "details": "Implementation (browser print approach — preferred for speed):\n1. Add a `@media print` CSS stylesheet (Tailwind print: utilities) that:\n   - Hides the year selector buttons, tab navigation, chart, and page chrome\n   - Shows only: property address, tax year, KPI summary, and the line-item table\n   - Uses clean black-and-white layout suitable for printing/PDF saving\n2. Add \"Export as PDF\" button in AnlageVTab header area\n3. Button onClick: calls window.print() — browser opens print dialog with \"Save as PDF\" option\n4. Print header: \"Anlage V Summary — [property address] — Tax Year [year]\"\n5. Print footer: \"Generated by HeimPath · Estimate only — consult a licensed Steuerberater before filing · [date]\"\n6. HeimPath logo included in print header\n\nAlternative (server-side PDF, if print CSS proves insufficient):\n- Backend endpoint: GET /portfolio/properties/{id}/tax-summary/pdf?year=YYYY\n- Uses weasyprint or reportlab to render a structured PDF\n- Returns application/pdf response with Content-Disposition: attachment\n\nStart with browser print approach; escalate to server-side only if layout control is insufficient.\n\nAcceptance criteria:\n- PDF output includes property address, year, all line items with Zeile numbers, AfA breakdown, net taxable income\n- HeimPath branding and disclaimer present\n- Page chrome (nav, tabs, year buttons) absent from PDF\n- Works in Chrome, Firefox, Safari",
@@ -1758,7 +1758,7 @@
         "updatedAt": "2026-04-27T06:41:37.136Z"
       },
       {
-        "id": 143,
+        "id": "143",
         "title": "Build GmbH vs. Private ownership tax break-even calculator",
         "description": "Every German multi-unit investor faces the same question: at what portfolio size does setting up an Immobilien-GmbH (approx 15% corporate tax on rental income) beat personal ownership (up to 42% marginal tax rate)? No competitor has this calculator. Pure frontend arithmetic — same pattern as the existing ROICalculator. Output is a crossover chart showing the break-even year and cumulative tax saving.",
         "details": "Inputs:\n- Annual net rental income (€)\n- Personal marginal tax rate (%) — e.g. 42% for high earners\n- Solidarity surcharge included (yes/no) — adds 5.5% on top\n- GmbH setup cost (€) — one-time, typically €1,500–3,000 notary + registration\n- GmbH annual accounting/tax advisor cost (€) — typically €3,000–6,000/year\n- Planned holding period (years) — 1–30 slider\n\nCalculation logic:\n- Private annual tax = net_rental_income × (marginal_rate / 100) × (1 + solidarity_surcharge)\n- GmbH annual tax = net_rental_income × 0.15 (Körperschaftsteuer) + net_rental_income × 0.055 × 0.15 (Solidaritätszuschlag on KSt) + net_rental_income × 0.0380 (Gewerbesteuer avg)  ≈ net_rental_income × 0.2988\n- GmbH effective rate ≈ 29.88% (use as constant with footnote)\n- Annual saving = private_tax - gmbh_tax - gmbh_annual_cost\n- Break-even year = GmbH_setup_cost / annual_saving (if positive)\n- Cumulative savings chart: Year 1..holding_period showing running total\n\nNote on dividend distribution: when income is extracted from GmbH as dividend, Abgeltungsteuer (25% + Soli) applies. Include an educational note but keep the calculator focused on retained income scenario.\n\nComponent structure: follow ROICalculator.tsx pattern — two-column layout, inputs left, results right, Recharts LineChart for crossover. Add new tab to /calculators route.\n\nAcceptance criteria:\n- Break-even year calculated correctly\n- Chart shows crossover point visually\n- Legal disclaimer: \"For illustration only — consult a Steuerberater for your specific situation\"\n- TypeScript clean, no SonarCloud violations",
@@ -1770,7 +1770,7 @@
         "updatedAt": "2026-04-25T20:25:25.674Z"
       },
       {
-        "id": 144,
+        "id": "144",
         "title": "Build tenant default stress test calculator for multi-unit portfolios",
         "description": "German tenant protection laws mean eviction can take 18–24 months and cost thousands in legal fees. Many expat investors don't model this risk before buying. Build a \"Tenant Trap\" stress test calculator: given a portfolio's mortgage obligations and rental income, calculate how long the investor's cash reserves last if a percentage of tenants stop paying. Pure frontend arithmetic, no APIs, follows the existing calculator pattern.",
         "details": "Inputs:\n- Number of units in portfolio\n- Average monthly rent per unit (€)\n- Average monthly mortgage payment per unit (€)\n- Monthly non-mortgage fixed costs per unit (€) — Hausgeld, insurance, etc.\n- Current cash reserves / emergency fund (€)\n- % of units assumed non-paying (slider: 10%–50%, default 20%)\n- Assumed eviction duration (months, default 18)\n- Estimated legal cost per eviction (€, default 5,000)\n\nCalculation logic:\n- non_paying_units = round(num_units × non_paying_pct)\n- monthly_income_loss = non_paying_units × avg_monthly_rent\n- monthly_net_shortfall = monthly_income_loss (income still owed on all mortgages/costs)\n- total_legal_costs = non_paying_units × legal_cost_per_eviction\n- months_reserves_last = cash_reserves / monthly_net_shortfall (before legal costs)\n- months_after_legal = (cash_reserves - total_legal_costs) / monthly_net_shortfall\n\nOutput cards:\n1. Monthly income loss (€)\n2. Months reserves last (without legal costs)\n3. Months reserves last (after legal costs)\n4. Recommended buffer (= eviction_duration × monthly_net_shortfall + total_legal_costs)\n5. Traffic-light verdict: GREEN (reserves > recommended buffer), AMBER (50–100% of buffer), RED (<50%)\n\nEducational section: brief explainer on German eviction law timeline (Mahnung → Kündigung → Räumungsklage → Gerichtsvollzieher), linked to the relevant HeimPath journey step.\n\nAcceptance criteria:\n- All five output cards render correctly\n- Traffic-light verdict changes correctly across thresholds\n- Edge case: 0% non-paying → all green, no shortfall\n- Disclaimer: \"Scenario modelling only — actual timelines vary by Bundesland\"",
@@ -1782,7 +1782,7 @@
         "updatedAt": "2026-04-26T10:47:50.884Z"
       },
       {
-        "id": 145,
+        "id": "145",
         "title": "Build GEG energy retrofit cost estimator calculator",
         "description": "New German laws (Gebäudeenergiegesetz, GEG) mandate that older buildings be brought up to strict energy standards, but no platform quantifies this cost for buyers. Build a calculator where users input their property's current energy class (A–H from the Energieausweis) and key property data, and receive a 10-year mandatory upgrade cost roadmap. Cost ranges are hardcoded from published GEG data — no external API needed.",
         "details": "Inputs:\n- Current energy class (A+ / A / B / C / D / E / F / G / H) — from Energieausweis\n- Property size (m²)\n- Building type (Einfamilienhaus / Mehrfamilienhaus / Eigentumswohnung)\n- Building year (pre-1950 / 1950–1978 / 1979–1994 / 1995–2009 / 2010+)\n- Heating system (Gas / Oil / Heat pump / District heating / Other)\n- State (Bundesland) — affects subsidy availability\n\nHardcoded cost data (source: BDEW, Fraunhofer ISE, dena 2023–2024 reports):\n- Energy class → required upgrades mapping (e.g. F/G/H → mandatory heat pump transition by 2034, facade insulation, window replacement)\n- Cost ranges per m² by upgrade type and building age\n- BEG subsidy percentages (federal: up to 35% for heat pump, 20% for insulation)\n\nOutput:\n- Required upgrades list with estimated cost range (min/max) per upgrade\n- Subsidy-adjusted net cost range\n- 10-year timeline: which upgrades are mandatory by which year (GEG deadlines)\n- Total estimated investment (pre- and post-subsidy)\n- Monthly cost amortised over 20 years (impact on yield)\n\nAcceptance criteria:\n- Energy class H → highest cost, multiple mandatory upgrades shown\n- Energy class A → minimal or no required upgrades\n- Subsidy deduction applied correctly\n- Sources cited in educational footer (GEG 2024, BDEW, BEG subsidy schedule)\n- Disclaimer: \"Estimates based on published ranges — commission a Energieberater for a binding assessment\"",
@@ -1794,7 +1794,7 @@
         "updatedAt": "2026-04-26T10:47:50.900Z"
       },
       {
-        "id": 146,
+        "id": "146",
         "title": "Build WEG-Protokolle auditor as a document translation extension",
         "description": "Many investors buy a unit only to discover months later that the WEG voted last year to replace the entire roof, triggering a €20,000 Sonderumlage. Build an AI-powered auditor that scans the last 3 years of WEG meeting minutes (Protokolle) and flags hidden upcoming costs, structural disputes, and deferred maintenance decisions. This is a natural extension of HeimPath's existing document translation infrastructure — the AI pipeline is already there, this adds a specialised extraction layer on top.",
         "details": "Implementation:\n1. Backend: New document type: WEG_PROTOKOLL\n2. Backend: Specialised extraction prompt focused on WEG-specific risk signals:\n   - Sonderumlage votes (any amount, past or proposed)\n   - Rücklage (maintenance reserve) balance vs. building age (flag if reserve < 1% of property value/year)\n   - Structural work discussions (Dach, Fassade, Aufzug, Fenster, Heizung)\n   - Neighbour disputes or ongoing legal proceedings (Rechtsstreit)\n   - Votes on rule changes that restrict rental or renovation rights\n   - Any reference to energy upgrade obligations (GEG, Sanierungspflicht)\n3. Backend: Return structured WEG risk report: { risk_flags: [], reserve_assessment: {}, upcoming_costs: [], disputes: [] }\n4. Backend: Accept multiple documents in one upload (3 years of Protokolle as a batch)\n5. Frontend: New upload flow for WEG documents — accept PDF, accept multiple files\n6. Frontend: Results rendered as a risk dashboard, not a raw translation:\n   - \"Red flags\" section: items requiring immediate attention\n   - \"Watch list\": items to monitor\n   - \"No issues found\" sections shown in green\n7. Frontend: Each flag shows the source quote from the original document (in German + translated)\n\nMVP caveat: WEG minutes are inconsistent in format (some typed, some scanned/handwritten). Handwritten PDFs will produce low-confidence results — show confidence warning prominently. The MVP is a keyword-flagging tool, not full semantic comprehension.\n\nAcceptance criteria:\n- WEG_PROTOKOLL document type accepted by upload endpoint\n- Sonderumlage mentions always flagged as red\n- Low-confidence warning shown for scanned/handwritten documents\n- Source quote shown for each flag",
@@ -1806,7 +1806,7 @@
         "updatedAt": "2026-04-26T19:34:18.614Z"
       },
       {
-        "id": 147,
+        "id": "147",
         "title": "Build Mietpreisbremse rent ceiling monitor for landlords",
         "description": "Many landlords unknowingly overcharge rent, only for tenants to join a Mieterverein and sue for up to two years of overpaid rent. Build a monitor that checks a specific property's rent against the local Mietspiegel (rent index) and alerts landlords if they are legally at risk or if they have room to increase. Start with the four cities where expat investors are most concentrated: Berlin, Hamburg, Munich, Frankfurt.",
         "details": "Implementation:\nPhase 1 — Data ingestion (backend):\n1. Ingest Mietspiegel data for Berlin, Hamburg, Munich, Frankfurt (all publish annual PDFs/Excel — parse and store in DB)\n2. Data model: MietspiegelEntry { city, postcode, street_range, building_year_range, size_range_sqm, features[], base_rent_per_sqm, valid_from, valid_to }\n3. Annual update process: cron job to check for new Mietspiegel publications, alert team when update needed\n4. API endpoint: GET /mietpreisbremse/check?city=Berlin&postcode=10115&size_sqm=65&building_year=1985&current_rent=1200\n\nPhase 2 — Calculation logic:\n- Lookup applicable Mietspiegel entry for address/size/year combination\n- Mietpreisbremse cap = Mietspiegel base rent × 1.10 (10% above index is the legal maximum)\n- Compare current_rent against cap\n- Status: OVER_LIMIT (current > cap), AT_RISK (current within 5% of cap), WITHIN_LIMIT, ROOM_TO_INCREASE (current < 90% of cap)\n- Calculate maximum legal rent and maximum legal increase\n\nPhase 3 — Frontend:\n1. Standalone page or portfolio property tab: \"Rent Check\"\n2. User enters current rent — property data (size, building year, city) pre-filled from portfolio if available\n3. Result: traffic-light status, current rent vs. cap, recommended action\n4. Alert if status = OVER_LIMIT: \"You may be liable for up to 2 years of overpaid rent — consult a Steuerberater\"\n5. Scheduled re-check: notify users annually when Mietspiegel updates\n\nAcceptance criteria:\n- Returns correct status for known test cases in each city\n- OVER_LIMIT triggers prominent warning\n- Data coverage: Berlin, Hamburg, Munich, Frankfurt at launch\n- Disclaimer: \"Based on publicly available Mietspiegel data — verify with a legal advisor\"",
@@ -1818,7 +1818,7 @@
         "updatedAt": "2026-04-27T11:42:39.434Z"
       },
       {
-        "id": 148,
+        "id": "148",
         "title": "Establish partnership referrals for features outside HeimPath's scope",
         "description": "Several high-value features are better served by specialist platforms than built in-house. This task tracks the business development work to establish referral/affiliate arrangements with three partners: Rentflow (bank-sync portfolio accounting), Hypofriend (mortgage pre-approval), and Myhammer or Blauarbeit (vetted English-speaking Handwerker). Each should be surfaced contextually in HeimPath at the right moment in the user journey.",
         "details": "Partner 1 — Rentflow (portfolio accounting):\n- Trigger: user reaches 6+ properties in portfolio (see separate Rentflow prompt task)\n- Contact: Rentflow BD team — HeimPath delivers post-purchase qualified investors\n- Goal: affiliate link + revenue share agreement\n- Fallback: non-affiliate contextual link if partnership not established within 60 days\n\nPartner 2 — Hypofriend (mortgage pre-approval):\n- Trigger: user reaches financing/mortgage step in guided journey\n- HeimPath's financing calculators are estimates; Hypofriend provides binding pre-approvals\n- Contact: Hypofriend partnerships team\n- Goal: co-marketing or affiliate arrangement\n- Integration: contextual CTA in FinancingWizard and MortgageEligibilityGuide components\n\nPartner 3 — Handwerker network (Myhammer / Blauarbeit / dedicated English-speaking network):\n- Trigger: user is in post-purchase ownership phase (OwnershipManagement journey step)\n- Research which platform has the best English-speaking contractor coverage in major cities\n- Goal: curated directory or affiliate referral, not a marketplace build\n- Integration: CTA in portfolio property detail page (\"Need a contractor?\")\n\nFor each partner:\n1. Identify correct contact / BD channel\n2. Draft outreach explaining HeimPath's user base and referral volume potential\n3. Agree terms (affiliate % or flat fee per referral)\n4. Implement contextual link/CTA in the relevant HeimPath touchpoint\n5. Track click-through and referral conversion\n\nSuccess metrics: at least one active affiliate arrangement live within Q3 2026.",
@@ -1830,7 +1830,7 @@
         "updatedAt": "2026-06-17T11:53:14.887Z"
       },
       {
-        "id": 149,
+        "id": "149",
         "title": "SECURITY C1: Remove unauthenticated private user-creation endpoint",
         "description": "POST /api/v1/private/users/ creates user accounts with zero authentication, rate limiting, or authorization. Any unauthenticated caller on the internet can create arbitrary accounts, enabling mass fake-account creation, database exhaustion, and credential abuse.",
         "details": "File: backend/app/api/routes/private.py\n\nOption A (preferred): Delete the endpoint and the entire private.py router if it has no other purpose. Remove its router registration from main.py.\n\nOption B (if endpoint is needed for internal tooling): Add `Depends(get_current_active_superuser)` as a dependency to the route, and add network-level restriction (Azure Container Apps internal ingress rule) so the /private prefix is only reachable from internal VNET.\n\nSteps:\n1. Check if /private router is used anywhere else in the codebase (grep for \"private\")\n2. If unused: delete backend/app/api/routes/private.py and remove its include_router() call from app/main.py (or app/api/main.py)\n3. If still needed: add `dependencies=[Depends(get_current_active_superuser)]` to the route decorator\n4. Add IP-allowlist Traefik middleware or Azure ingress rule restricting /api/v1/private/* to internal traffic only\n5. Write test: unauthenticated POST to /private/users/ must return 401/403 (not 200)",
@@ -1842,7 +1842,7 @@
         "updatedAt": "2026-04-27T13:19:35.675Z"
       },
       {
-        "id": 150,
+        "id": "150",
         "title": "SECURITY H4: Add Redis authentication (requirepass)",
         "description": "Redis is deployed without a password in both development and production. It stores the JWT refresh-token blacklist and all rate-limit counters. Any container in the same Docker network can connect unauthenticated, flush the blacklist (un-revoking all logged-out tokens), or clear rate-limit keys.",
         "details": "Files: compose.yml, compose.override.yml, backend/.env.example, backend/app/core/config.py\n\nSteps:\n1. Add `command: redis-server --requirepass ${REDIS_PASSWORD}` to the redis service in compose.yml\n2. Add REDIS_PASSWORD variable to .env.example with placeholder value and generation instructions\n3. Update REDIS_URL in backend service environment from `redis://redis:6379` to `redis://:${REDIS_PASSWORD}@redis:6379`\n4. Verify config.py REDIS_URL setting picks up the password correctly (it should, as it reads the env var)\n5. Apply same change in compose.override.yml for local dev\n6. Update Azure production secrets: add REDIS_PASSWORD to Container Apps secrets and update REDIS_URL secret value\n7. Rotate in production: update secret, redeploy both backend and redis containers\n\nNote: Redis 6+ ACL is preferred over requirepass for new deployments — but requirepass is simpler and sufficient for a single-user (backend) setup.",
@@ -1854,7 +1854,7 @@
         "updatedAt": "2026-04-27T13:35:27.203Z"
       },
       {
-        "id": 151,
+        "id": "151",
         "title": "SECURITY H5: Remove Adminer from production deployment",
         "description": "Adminer (a full database management web UI) is deployed as a production service and exposed over HTTPS via Traefik with no authentication layer. A successful login grants full read/write access to all database tables including users, documents, subscriptions, and financial data.",
         "details": "File: compose.yml\n\nSteps:\n1. Remove the entire `adminer:` service block (lines ~34-55) from compose.yml\n2. Remove the `adminer` entry from any `depends_on` blocks in other services (unlikely but check)\n3. Keep Adminer in compose.override.yml for local development only (it is already restricted to the local Docker network there)\n4. If staging environments need DB access, add Traefik BasicAuth middleware:\n   ```yaml\n   labels:\n     - \"traefik.http.middlewares.adminer-auth.basicauth.users=admin:$$apr1$$...\"\n     - \"traefik.http.routers.adminer.middlewares=adminer-auth\"\n   ```\n5. Document the local-only Adminer access procedure in the project README/runbook",
@@ -1866,7 +1866,7 @@
         "updatedAt": "2026-04-27T13:43:30.532Z"
       },
       {
-        "id": 152,
+        "id": "152",
         "title": "SECURITY H2+H3: Fix legacy login endpoint and TRUSTED_PROXY_IPS",
         "description": "Two related auth-bypass issues: (1) Legacy POST /login/access-token has no rate limiting, allowing unlimited password brute-force bypassing the 5-attempt lockout on /auth/login. (2) TRUSTED_PROXY_IPS defaults to \"*\", meaning any client can spoof X-Forwarded-For to appear as any IP address, defeating any future IP-based controls.",
         "details": "Files: backend/app/api/routes/login.py, backend/app/core/config.py, backend/.env.example, infra/terraform (for Azure secret)\n\nH2 — Legacy endpoint fix:\n1. In login.py, import `rate_limit_service` and add the same lockout check used in auth.py login:\n   ```python\n   if rate_limit_service.is_locked(form_data.username):\n       raise HTTPException(status_code=429, detail=\"Too many failed login attempts.\")\n   ```\n2. Also add `rate_limit_service.record_failed_attempt(form_data.username)` on auth failure\n3. Long-term plan: mark endpoint for deletion in next major release (add deprecation notice to OpenAPI description)\n\nH3 — Trusted proxy fix:\n1. In config.py, add a startup validator that rejects TRUSTED_PROXY_IPS=\"*\" when ENVIRONMENT is not \"local\":\n   ```python\n   @model_validator(mode=\"after\")\n   def _validate_trusted_proxy(self) -> \"Settings\":\n       if self.ENVIRONMENT != \"local\" and self.TRUSTED_PROXY_IPS == \"*\":\n           raise ValueError(\"TRUSTED_PROXY_IPS must not be '*' in non-local environments\")\n       return self\n   ```\n2. Update .env.example to document the correct value format (comma-separated CIDRs)\n3. Set the correct Azure Container Apps outbound IP range in production .env/secrets\n4. Update infra/terraform to pass the correct CIDR as TF_VAR",
@@ -1878,7 +1878,7 @@
         "updatedAt": "2026-04-27T17:27:08.430Z"
       },
       {
-        "id": 153,
+        "id": "153",
         "title": "SECURITY H6: Enforce SECRET_KEY as required env var with startup validation",
         "description": "SECRET_KEY has a default of secrets.token_urlsafe(32), which generates a new random value on every process restart. This silently invalidates all active JWT sessions on any container restart, deploy, or crash — and provides no signal that the config is misconfigured. A mass-restart attack could keep all users permanently logged out.",
         "details": "File: backend/app/core/config.py\n\nSteps:\n1. Remove the default value from SECRET_KEY:\n   ```python\n   # Before:\n   SECRET_KEY: str = secrets.token_urlsafe(32)\n   # After:\n   SECRET_KEY: str\n   ```\n2. The existing _check_default_secret validator already raises for \"changethis\" in non-local — verify it is called for SECRET_KEY and extend it to also reject empty strings\n3. Update .env.example comment to show `openssl rand -hex 32` generation command more prominently\n4. Add startup log message: `logger.info(\"SECRET_KEY loaded, length=%d\", len(settings.SECRET_KEY))`  (log length only, not value)\n5. Test in CI: if SECRET_KEY is missing from env, FastAPI startup must fail with a clear error (not start with a random key)\n6. Update docker-compose.yml to mark SECRET_KEY as a required variable: `SECRET_KEY=${SECRET_KEY?Variable not set}`",
@@ -1890,7 +1890,7 @@
         "updatedAt": "2026-04-27T17:27:08.496Z"
       },
       {
-        "id": 154,
+        "id": "154",
         "title": "SECURITY H1: Migrate JWT token storage from localStorage to HttpOnly cookies",
         "description": "Access tokens stored in localStorage are readable by any JavaScript executing in the page origin. Combined with the lack of Content Security Policy (M9), any XSS vector — however minor — can exfiltrate the token. Since access tokens have no jti (M3), stolen tokens cannot be revoked. Moving to HttpOnly cookies eliminates this entire class of attack.",
         "details": "This is a cross-cutting change touching both backend (cookie setting) and frontend (remove localStorage usage).\n\nBackend changes (backend/app/api/routes/auth.py):\n1. On successful login, set HttpOnly cookie instead of (or in addition to) returning token in body:\n   ```python\n   response.set_cookie(\n       key=\"access_token\",\n       value=access_token,\n       httponly=True,\n       secure=settings.ENVIRONMENT != \"local\",\n       samesite=\"strict\",\n       max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,\n   )\n   ```\n2. Update /auth/refresh to rotate the cookie\n3. Update /auth/logout to clear the cookie: `response.delete_cookie(\"access_token\")`\n4. Update get_current_user in deps.py to read from cookie as fallback if Bearer header absent\n\nFrontend changes (frontend/src/):\n1. Remove all `localStorage.setItem(\"access_token\", ...)` calls in useAuth.ts\n2. Remove `localStorage.getItem(\"access_token\")` calls — isLoggedIn() should call GET /auth/me instead\n3. Remove OpenAPI.TOKEN async resolver — browser sends cookie automatically\n4. Update initializeApiClient() to remove token injection\n5. The OpenAPI client already has CREDENTIALS: 'include' — verify cookies are sent cross-origin\n\nMigration: Keep Bearer header support in deps.py for backward compatibility during rollout.",
@@ -1902,7 +1902,7 @@
         "updatedAt": "2026-04-27T17:27:17.264Z"
       },
       {
-        "id": 155,
+        "id": "155",
         "title": "SECURITY M1+M10: Fix Stripe tier derivation and subscription cancellation",
         "description": "Two Stripe business-logic flaws: (1) Subscription tier on checkout is read from attacker-controlled metadata instead of the verified price_id — an attacker paying any amount with crafted metadata gets enterprise tier. (2) Cancellation sets tier=FREE in the DB without calling Stripe, so customers keep being billed while losing access.",
         "details": "File: backend/app/api/routes/subscriptions.py, backend/app/services/payment_service.py\n\nM1 — Derive tier from price_id:\n1. In the CHECKOUT_COMPLETED webhook handler, replace metadata lookup with price lookup:\n   ```python\n   # Instead of: tier_value = webhook_event.metadata.get(\"tier\")\n   line_items = stripe.checkout.Session.list_line_items(event[\"data\"][\"object\"][\"id\"])\n   price_id = line_items.data[0].price.id\n   tier = payment_service.tier_for_price(price_id)  # uses existing _price_to_tier map\n   ```\n2. Keep user_id from metadata (it is not privilege-sensitive — tier is what matters)\n3. Remove the \"tier\" key from checkout session metadata creation entirely so there is no confusion\n\nM10 — Fix cancellation:\n1. Store stripe_subscription_id on the User model (add column + Alembic migration) or look it up via stripe.Customer.list_subscriptions\n2. In the cancel endpoint:\n   ```python\n   stripe.Subscription.cancel(user.stripe_subscription_id)\n   ```\n3. Only update the DB tier after Stripe confirms cancellation (in the SUBSCRIPTION_DELETED webhook)\n4. Also implement the incomplete SUBSCRIPTION_UPDATED and SUBSCRIPTION_DELETED webhook handlers\n5. Replace `except ValueError: pass` with `logger.warning(\"Invalid tier value from Stripe: %s\", tier_value)`",
@@ -1914,7 +1914,7 @@
         "updatedAt": "2026-04-27T18:59:56.336Z"
       },
       {
-        "id": 156,
+        "id": "156",
         "title": "SECURITY M2: Add IP-based rate limiting layer",
         "description": "All rate limits are keyed by email address. An attacker can: (a) repeatedly lock any user out of their account by submitting 5 bad-password attempts for their email every 15 minutes; (b) bypass all rate limits entirely by using a different email. A secondary IP-based counter prevents both abuse patterns.",
         "details": "File: backend/app/services/rate_limit_service.py, backend/app/api/routes/auth.py, backend/app/api/routes/login.py\n\nSteps:\n1. Add IP-keyed sliding window to rate_limit_service.py:\n   ```python\n   IP_FAILED_WINDOW_SECONDS = 3600  # 1 hour\n   IP_FAILED_MAX = 30               # 30 failed attempts per IP before soft block\n\n   def record_ip_failed(self, ip: str) -> None:\n       key = f\"ip_fail:{ip}\"\n       self.redis.incr(key)\n       self.redis.expire(key, self.IP_FAILED_WINDOW_SECONDS)\n\n   def is_ip_blocked(self, ip: str) -> bool:\n       count = int(self.redis.get(f\"ip_fail:{ip}\") or 0)\n       return count >= self.IP_FAILED_MAX\n   ```\n2. In auth.py login endpoint, extract real client IP:\n   ```python\n   client_ip = request.client.host  # correct after H3 (ProxyHeadersMiddleware)\n   if rate_limit_service.is_ip_blocked(client_ip):\n       raise HTTPException(429, \"Too many requests from this IP\")\n   ```\n3. Call `rate_limit_service.record_ip_failed(client_ip)` alongside the existing email-keyed call on failed attempts\n4. Apply same to /login/access-token (legacy endpoint, H2)\n5. Do NOT lock IP on success — only on failure\n\nNote: This depends on H3 (TRUSTED_PROXY_IPS fix) being deployed first so client_ip is trustworthy.",
@@ -1928,7 +1928,7 @@
         "updatedAt": "2026-04-27T20:32:39.816Z"
       },
       {
-        "id": 157,
+        "id": "157",
         "title": "SECURITY M5+M6: Validate PDF magic bytes and sanitize stored file paths",
         "description": "Two file-handling vulnerabilities: (1) Document and contract uploads only check the Content-Type header, which is caller-controlled. A malicious file (HTML, JS polyglot) can be stored by setting Content-Type: application/pdf. (2) The original filename is embedded in the stored path — filenames with path components (../) could write outside UPLOAD_DIR.",
         "details": "Files: backend/app/api/routes/documents.py, backend/app/api/routes/contracts.py, backend/app/services/document_service.py\n\nM5 — Magic bytes validation:\n1. Add a helper function (can go in document_service.py):\n   ```python\n   PDF_MAGIC = b\"%PDF\"\n\n   def _validate_pdf_bytes(content: bytes) -> None:\n       if not content.startswith(PDF_MAGIC):\n           raise ValueError(\"File does not appear to be a valid PDF\")\n   ```\n2. Call it in both documents.py (after reading content) and contracts.py upload path\n3. This catches disguised files regardless of Content-Type header\n\nM6 — Sanitize file paths:\n1. In document_service.py save_upload(), replace:\n   ```python\n   # Before: preserves original filename\n   stored_name = f\"{uuid4().hex}_{filename}\"\n   # After: uuid only on disk, original name stays in DB\n   stored_name = f\"{uuid4().hex}.pdf\"\n   ```\n2. The `filename` (original name) is already stored in the Document model's `original_filename` column — so no data loss\n3. Add an assertion/validation that UPLOAD_DIR resolves to an absolute path to prevent relative-path confusion:\n   ```python\n   upload_path = Path(settings.UPLOAD_DIR).resolve()\n   assert upload_path.is_absolute()\n   ```",
@@ -1940,7 +1940,7 @@
         "updatedAt": "2026-04-27T20:46:10.416Z"
       },
       {
-        "id": 158,
+        "id": "158",
         "title": "SECURITY M9: Add Content Security Policy headers via Traefik middleware",
         "description": "No Content Security Policy is configured anywhere in the stack (no meta tag, no HTTP header). Without a CSP, any XSS vector can execute unrestricted JavaScript — exfiltrating tokens (H1), calling the API as the victim, or redirecting to phishing pages. CSP is the last line of defense that limits XSS blast radius.",
         "details": "Preferred location: Traefik middleware in compose.yml (no code change, applies to all responses)\n\nSteps:\n1. Add a Traefik headers middleware in compose.yml:\n   ```yaml\n   # In the proxy/traefik labels or a dynamic config file:\n   traefik.http.middlewares.security-headers.headers.contentSecurityPolicy: >-\n     default-src 'self';\n     script-src 'self';\n     style-src 'self' 'unsafe-inline';\n     img-src 'self' data: https:;\n     connect-src 'self' https://sentry.io;\n     font-src 'self';\n     frame-ancestors 'none';\n     base-uri 'self';\n     form-action 'self'\n   traefik.http.middlewares.security-headers.headers.xFrameOptions: DENY\n   traefik.http.middlewares.security-headers.headers.xContentTypeOptions: nosniff\n   traefik.http.middlewares.security-headers.headers.referrerPolicy: strict-origin-when-cross-origin\n   traefik.http.middlewares.security-headers.headers.permissionsPolicy: >-\n     camera=(), microphone=(), geolocation=()\n   ```\n2. Apply middleware to frontend router: `traefik.http.routers.frontend.middlewares=security-headers`\n3. Do NOT apply CSP to the backend API router (would block Swagger UI and API responses)\n4. Test with https://securityheaders.com after deploy\n5. For local dev, add the same middleware to compose.override.yml frontend service\n\nNote: 'unsafe-inline' in style-src is needed for Tailwind's runtime injection. If Tailwind moves to fully static CSS, this can be removed.",
@@ -1952,7 +1952,7 @@
         "updatedAt": "2026-04-27T21:52:05.608Z"
       },
       {
-        "id": 159,
+        "id": "159",
         "title": "SECURITY M3+L2: Shorten access token lifetime and implement refresh token rotation",
         "description": "Access tokens have no jti claim and cannot be individually revoked — a stolen 30-day \"remember me\" token is permanently valid even after the user logs out or changes their password. Refresh tokens are never rotated, so a leaked refresh token silently issues new access tokens indefinitely.",
         "details": "Files: backend/app/services/auth_service.py, backend/app/core/security.py, backend/app/api/routes/auth.py\n\nM3 — Shorten access token lifetime:\n1. Reduce ACCESS_TOKEN_EXPIRE_MINUTES from 60 (or 30*24*60 for remember_me) to 15 minutes unconditionally\n2. \"Remember me\" UX should be achieved by extending the refresh token lifetime (already 7 days), not the access token\n3. This limits the window for stolen token abuse to 15 minutes maximum\n\nL2 — Refresh token rotation:\n1. In auth_service.py refresh_access_token(), after issuing new access token:\n   a. Blacklist the old refresh token JTI in Redis (same code path as logout)\n   b. Issue a NEW refresh token with a fresh JTI and expiry\n   c. Return both new tokens in the response\n2. Update /auth/refresh endpoint to set updated refresh token in response (or cookie if H1 is done first)\n3. Add a small grace period (30 seconds) to handle concurrent requests with the same refresh token:\n   ```python\n   # Allow old token to be used within 30s of rotation\n   redis.setex(f\"refresh_grace:{old_jti}\", 30, \"1\")\n   ```\n\nDependencies: Ideally implement after H1 (HttpOnly cookies) since the rotation response changes shape.",
@@ -1966,7 +1966,7 @@
         "updatedAt": "2026-04-27T22:05:14.730Z"
       },
       {
-        "id": 160,
+        "id": "160",
         "title": "SECURITY M4+M8: Restrict shared content previews and move avatars to blob storage",
         "description": "Two data-exposure issues: (1) Shared contract and document links return full premium AI analysis to unauthenticated visitors — bypassing the subscription paywall. (2) Avatar images are base64-encoded and stored inline in the User DB row (up to 2.7MB/user), enabling storage exhaustion and degrading all User table queries.",
         "details": "M4 — Shared content restrictions:\nFiles: backend/app/api/routes/contracts.py, backend/app/api/routes/documents.py\n\n1. For contracts shared endpoint: return a preview response with only the first 3 risk findings and a `requires_subscription: true` flag, instead of full `is_premium=True` content\n2. Create a `ContractSharedPreviewResponse` schema with limited fields\n3. For documents shared endpoint: return document metadata + first page of translation (if any), not the full translation\n4. Add a `upgrade_cta` message in the shared response: \"Sign up to see the full analysis\"\n\nM8 — Avatar blob storage:\nFiles: backend/app/api/routes/users.py, backend/app/core/config.py\n\n1. Add Azure Blob Storage avatar container configuration (AZURE_STORAGE_ACCOUNT + AZURE_STORAGE_KEY already in .env)\n2. In avatar upload endpoint, replace base64 DB storage with:\n   ```python\n   blob_url = await azure_storage.upload_avatar(\n       user_id=current_user.id,\n       image_bytes=buf.getvalue(),\n       content_type=\"image/webp\"\n   )\n   current_user.avatar_url = blob_url  # https://... URL\n   ```\n3. Write Alembic migration to change avatar_url column from Text to String(500) (URLs are short)\n4. One-time data migration script: for existing base64 avatars, upload to blob and update URL",
@@ -1978,7 +1978,7 @@
         "updatedAt": "2026-04-28T04:09:30.668Z"
       },
       {
-        "id": 161,
+        "id": "161",
         "title": "SECURITY L1+L4+L5+L6+L7: Low-severity hardening bundle",
         "description": "Five low-severity hardening items bundled for efficiency: (L1) account deletion doesn't invalidate tokens; (L4) professional click counter has no auth/rate-limiting enabling analytics fraud; (L5) APScheduler has no explicit UTC timezone; (L6) CORS allows all methods and headers; (L7) OpenAPI docs are publicly accessible in production.",
         "details": "L1 — Token invalidation on account deletion (backend/app/api/routes/users.py):\n- On DELETE /me, call rate_limit_service or a new session_service to blacklist the user's current refresh token JTI before deleting the user row\n- If refresh token JTI is not available in the request context, at minimum revoke all keys matching `refresh:{user_id}:*` pattern in Redis\n\nL4 — Professional click rate limiting (backend/app/api/routes/professionals.py):\n- Add `get_optional_current_user` dependency to track_professional_click\n- If user is None (anonymous), apply IP-based rate limit: max 5 clicks per IP per professional per 24h\n- If user is authenticated, apply user-based rate limit: max 1 click per user per professional per 24h\n\nL5 — APScheduler UTC timezone (backend/app/main.py):\n```python\n# Before:\nscheduler.add_job(..., trigger=\"cron\", day_of_week=\"mon\", hour=2)\n# After:\nscheduler.add_job(..., trigger=\"cron\", day_of_week=\"mon\", hour=2, timezone=\"UTC\")\n```\n\nL6 — CORS specificity (backend/app/main.py):\n```python\nallow_methods=[\"GET\", \"POST\", \"PUT\", \"PATCH\", \"DELETE\", \"OPTIONS\"],\nallow_headers=[\"Authorization\", \"Content-Type\", \"Accept\", \"X-Requested-With\"],\n```\n\nL7 — Disable OpenAPI docs in production (backend/app/main.py):\n```python\napp = FastAPI(\n    openapi_url=\"/api/v1/openapi.json\" if settings.ENVIRONMENT == \"local\" else None,\n    docs_url=\"/docs\" if settings.ENVIRONMENT == \"local\" else None,\n    redoc_url=\"/redoc\" if settings.ENVIRONMENT == \"local\" else None,\n)\n```",
@@ -1990,7 +1990,7 @@
         "updatedAt": "2026-04-27T20:32:40.782Z"
       },
       {
-        "id": 162,
+        "id": "162",
         "title": "SECURITY M7+L3: Fix user-lookup response ordering and legacy endpoint user enumeration",
         "description": "Two information-disclosure issues: (1) GET /users/{user_id} returns 403 before checking if the user exists — any authenticated user can confirm whether a UUID belongs to a valid account by observing 403 vs 404. (2) Legacy GET /password-recovery-html-content returns 404 for unknown emails (superuser-only but still leaks existence).",
         "details": "M7 — Fix users/{user_id} ordering (backend/app/api/routes/users.py):\nCurrent code (wrong order):\n```python\nuser = session.get(User, user_id)\nif user == current_user:\n    return user\nif not current_user.is_superuser:\n    raise HTTPException(status_code=403, ...)   # ← 403 raised even if user=None\nif user is None:\n    raise HTTPException(status_code=404, ...)\nreturn user\n```\n\nCorrected order:\n```python\nuser = session.get(User, user_id)\nif user is None:\n    raise HTTPException(status_code=404, detail=\"User not found\")  # ← check first\nif user == current_user:\n    return user\nif not current_user.is_superuser:\n    raise HTTPException(status_code=403, detail=\"Not enough permissions\")\nreturn user\n```\n\nL3 — Legacy endpoint enumeration (backend/app/api/routes/login.py):\nIn /password-recovery-html-content, replace:\n```python\n# Before: returns 404 if email not found\nuser = session.exec(select(User).where(User.email == email)).first()\nif not user:\n    raise HTTPException(status_code=404, ...)\n```\nWith:\n```python\n# After: always returns 200 with same content\nuser = session.exec(select(User).where(User.email == email)).first()\nif not user:\n    return HTMLResponse(\"<p>If the email is registered, a link has been sent.</p>\")\n```",
@@ -2002,7 +2002,7 @@
         "updatedAt": "2026-04-27T19:36:02.038Z"
       },
       {
-        "id": 163,
+        "id": "163",
         "title": "Fix: \"Open ROI Calculator\" link from Rent Estimate does not navigate to ROI tab",
         "description": "Clicking \"Open ROI Calculator\" in the RentEstimate component should deep-link to /calculators?tab=roi but the tab does not activate. The Link component passes `search={{ tab: \"roi\" }}` correctly but the Calculators page does not respond to the search param on initial render.",
         "details": "File: frontend/src/components/Calculators/RentEstimate.tsx — the Link already sets `to=\"/calculators\"` with `search={{ tab: \"roi\", monthlyRent: ... }}`.\n\nInvestigation steps:\n1. Check how `calculators.tsx` reads the `tab` search param and passes it to `defaultValue` on the Tabs component.\n2. Confirm `Route.useSearch()` returns the `tab` value on navigation.\n3. Verify the Tabs `value` or `defaultValue` is wired to the URL param — if `defaultValue` is used instead of `value`, the tab won't change after mount.\n4. Fix: use controlled `value` prop on Tabs driven by `tab` search param (with a `useState` fallback to \"costs\" if undefined).\n5. Also confirm `monthlyRent` is correctly pre-filled in the ROI form after navigation.",
@@ -2014,7 +2014,7 @@
         "updatedAt": "2026-04-29T08:08:02.504Z"
       },
       {
-        "id": 164,
+        "id": "164",
         "title": "Fix: 500 error on document upload for translation",
         "description": "Uploading a document on the Document Translation page returns a 500 network error. This is a critical bug — document translation is a core feature. The upload endpoint or the file-processing pipeline is throwing an unhandled exception.",
         "details": "Investigation steps:\n1. Reproduce the 500 in the running app via docker compose, capture the full traceback from backend logs (`docker compose logs backend --tail 100`).\n2. Check `backend/app/api/routes/documents.py` upload endpoint — look for unhandled exceptions (missing env vars, storage connection, file size limits).\n3. Check `backend/app/services/document_service.py` — confirm Azure Blob Storage credentials are set and the container exists in staging.\n4. Check `backend/app/core/config.py` — verify `AZURE_STORAGE_CONNECTION_STRING` or equivalent is configured.\n5. If env vars are missing in staging, add them via Terraform (`infra/terraform/staging.tf`).\n6. Add proper error handling and a user-facing 422 with a clear message for unsupported file types or size limits.\n7. Write/update integration test for the upload endpoint.",
@@ -2026,7 +2026,7 @@
         "updatedAt": "2026-04-28T07:09:16.040Z"
       },
       {
-        "id": 165,
+        "id": "165",
         "title": "UX: Redesign calculator tabs — 17 flat tabs is unusable on mobile and overwhelming",
         "description": "The Calculators page has 17 TabsTrigger elements in a single horizontal row, which is unusable on mobile (tabs overflow off-screen) and overwhelming on desktop. Redesign the navigation into a grouped, scannable layout that helps users find the right calculator quickly.",
         "details": "Current state: 17 tabs in a flat `TabsList` horizontal row.\n\nProposed redesign — two viable approaches (choose one):\n**Option A: Category group headers + icon grid**\nReplace the flat tab bar with a 2-column or 3-column card grid (like the Knowledge Base filter chips). Group calculators into 4 categories:\n- Buying Costs: Hidden Costs, State Comparison, City Compare\n- Investment Returns: ROI Calculator, Property Evaluation, GmbH vs. Private, Exit Tax, Depreciation\n- Financing: Financing Wizard, Mortgage, Eligibility Guide, Cross-Border Tax\n- Renting: Rent Estimate, Rent Ceiling, Property Tax, Tenant Risk, Energy Retrofit\n\nEach card shows icon + title + 1-line description. Clicking navigates to the calculator view (keeps existing URL tab param pattern).\n\n**Option B: Compact grouped tab pills with overflow scroll**\nGroup tabs into sections with small category labels above. Allow horizontal scroll within each section.\n\nFile to update: `frontend/src/routes/_layout/calculators.tsx`\n\nAcceptance criteria:\n- All 17 calculators are accessible\n- URL deep-linking (`?tab=roi`) still works\n- Mobile: no horizontal overflow, all calculators reachable\n- Each calculator entry has a 1-line description visible before entering",
@@ -2038,7 +2038,7 @@
         "updatedAt": "2026-04-28T07:18:25.489Z"
       },
       {
-        "id": 166,
+        "id": "166",
         "title": "UX: Fix document translation page empty state and error messages",
         "description": "The document translation page shows \"Unable to load document — Something went wrong. Please try again\" as the default state before any document is uploaded. This is confusing and alarming. Fix the empty state to be welcoming and only show the error message on actual errors.",
         "details": "Issues to fix:\n1. **Empty state**: When no documents exist, show a welcoming empty state: icon + \"No documents yet\" + \"Upload your first German property document to get started\" + upload button. Do NOT show an error message.\n2. **Loading state**: Show a skeleton loader while fetching the document list, not an error message.\n3. **Error state**: Only show \"Something went wrong\" when there is an actual API error (non-2xx response). Include a \"Try again\" retry button.\n4. **Document list item errors**: If a specific document's translation status is `FAILED`, show an inline \"Translation failed — please re-upload\" on that card only.\n\nFiles to check: `frontend/src/routes/_layout/documents/index.tsx` and `frontend/src/components/Documents/DocumentList.tsx` (or similar). Identify where the error message is rendered unconditionally and split the empty/loading/error states properly.\n\nUse TanStack Query's `isLoading`, `isError`, `data` destructured values to branch the render path.",
@@ -2050,7 +2050,7 @@
         "updatedAt": "2026-04-29T09:28:32.538Z"
       },
       {
-        "id": 167,
+        "id": "167",
         "title": "UX: Dashboard overhaul — declutter, move recent activity to navbar icon, fix responsive cards",
         "description": "The dashboard feels overwhelming due to repeated content, non-clickable cards, and non-responsive layouts. Restructure it: move recent activity to a notification-bell-style icon in the top-right navbar, remove the separate count cards (docs this month, total calculations, bookmarked laws), integrate counts into the relevant content cards, and make all cards clickable with proper navigation.",
         "details": "Changes required:\n\n**1. Recent Activity → Navbar icon**\n- Remove the \"Recent Activity\" section from the dashboard main content area.\n- Add a clock/activity icon (e.g. `History` from lucide) to the top-right navbar, alongside the notification bell.\n- Clicking opens a dropdown or slide-over panel showing the last 10 activity events.\n- File: `frontend/src/components/Layout/TopBar.tsx` (or equivalent navbar component).\n\n**2. Remove separate count metric cards**\n- Remove standalone stat cards: \"Documents This Month\", \"Total Calculations\", \"Bookmarked Laws\".\n- Instead, integrate these counts as small badge/count chips inside the respective content cards (e.g., show \"3 docs\" count on the Documents card).\n\n**3. Make content cards responsive and clickable**\n- Recent Documents card: each document row is a clickable link → `/documents/{id}`.\n- Recent Calculations card: each calculation row links → `/calculators?tab=costs` (or the correct tab).\n- Bookmarked Laws card: each law row links → `/laws/{id}`.\n- Cards must be responsive at 375px (no overflow, text wraps, truncates with `truncate` class).\n- Add `cursor-pointer` and hover state to clickable rows.\n\n**4. General declutter**\n- Audit any sections that are duplicated or redundant vs. dedicated pages (e.g., don't show full journey progress if it's on the Journey page).\n- Keep the dashboard focused on: journey status, key actions, and recent activity (via icon).\n\nFiles: `frontend/src/components/Dashboard/` (main DashboardPage and sub-components).",
@@ -2062,7 +2062,7 @@
         "updatedAt": "2026-04-29T13:30:52.709Z"
       },
       {
-        "id": 168,
+        "id": "168",
         "title": "UX: Add target days to property journey progress chart in dashboard",
         "description": "The My Property Journey circular chart in the dashboard shows current progress but has no target completion date or day count. Add a \"target days\" indicator showing the expected total duration and days remaining so users can gauge pace.",
         "details": "Implementation:\n\n**Backend:**\n- Journey model may already have `target_completion_date` or a similar field. Check `backend/app/models/journey.py`.\n- If not, add a `target_days: int | None` field to the Journey model with an Alembic migration (nullable, default None).\n- Expose it in the journey summary schema used by the dashboard API (`/api/v1/dashboard/`).\n\n**Frontend:**\n- In the dashboard journey progress chart component, read `targetDays` (or `targetCompletionDate`) from the journey data.\n- Display it inside or below the circular chart, e.g.:\n  - \"Day 12 of 90\" as a subtitle under the percentage.\n  - Or a small label: \"Target: 90 days · 78 remaining\".\n- If `targetDays` is null, show nothing (graceful degradation).\n- The default target for a standard buying journey should be 90 days; make this configurable per journey type.\n\nFiles: `frontend/src/components/Dashboard/JourneyProgressChart.tsx` (or equivalent), `backend/app/models/journey.py`, Alembic migration if field is added.",
@@ -2074,7 +2074,7 @@
         "updatedAt": "2026-04-29T10:11:08.344Z"
       },
       {
-        "id": 169,
+        "id": "169",
         "title": "UX: Document translation upload — show per-document-type title and description",
         "description": "When a user uploads a document for translation, they currently see no context about what insights or analysis they will receive. Add a short title and description for each supported document type so users understand the value before uploading.",
         "details": "Supported document types (from DocumentType enum): Kaufvertrag, Grundbuch, Teilungserklärung, Mietvertrag, WEG-Protokoll, and possibly others.\n\nFor each type, define:\n- **Title** (English): e.g. \"Purchase Contract (Kaufvertrag)\"\n- **Description** (1–2 sentences): what the user gets, e.g. \"We'll translate the full contract, highlight key clauses, flag unusual terms, and warn about financial obligations or risk areas.\"\n\nProposed copy:\n| Type | Title | Description |\n|------|-------|-------------|\n| Kaufvertrag | Purchase Contract | Full translation + clause-by-clause analysis. We flag unusual terms, seller obligations, and financial risks. |\n| Grundbuch | Land Registry Extract | Translation of ownership record, liens, easements, and encumbrances — critical before any purchase. |\n| Teilungserklärung | Condominium Declaration | Explains your ownership share, shared costs, and usage rights in a multi-unit building. |\n| Mietvertrag | Rental Agreement | Full translation highlighting rent terms, notice periods, deposit rules, and tenant obligations. |\n| WEG-Protokoll | Owners' Meeting Minutes | Summary of decisions affecting shared costs, planned works, and community rules. |\n\nImplementation:\n- Add a `DOCUMENT_TYPE_META` constant in the upload form component mapping `DocumentType` → `{ title, description }`.\n- Display as a small info block when a document type is selected (or as cards in a type-picker UI).\n- Files: `frontend/src/components/Documents/DocumentUploadForm.tsx` (or equivalent).",
@@ -2086,7 +2086,7 @@
         "updatedAt": "2026-04-29T09:35:49.658Z"
       },
       {
-        "id": 170,
+        "id": "170",
         "title": "Feature: Wire up real email sending for email verification on sign-up",
         "description": "Email verification currently works in dev mode (token returned in the API response or printed to logs) but does not send a real email. Users registering on staging and production must receive an actual verification email and must verify before they can log in. Configure and enable real SMTP/SendGrid email delivery end-to-end.",
         "details": "Backend steps:\n1. Check `backend/app/core/config.py` — `SMTP_HOST`, `SMTP_USER`, `SMTP_PASSWORD`, `EMAILS_FROM_EMAIL` fields exist. Confirm the `emails_enabled` computed property logic.\n2. Check `backend/app/services/email_service.py` (or equivalent) — confirm the verification email send is gated on `settings.emails_enabled` and falls back to a log warning in dev.\n3. Verify the user registration flow: after creating the user, a verification token is generated and `send_verification_email()` is called.\n4. In staging Terraform (`infra/terraform/staging.tf`), add SMTP env vars (use SendGrid or Azure Communication Services). Add variables to `variables.tf` and secrets to `staging.tf`.\n5. **Do not** hardcode credentials — pass via Terraform variables from `.env` as `TF_VAR_*`.\n6. Test end-to-end on staging: register with a real email address, receive the email, click the link, verify the account is now active.\n\nFrontend steps:\n7. After registration, show a clear \"Check your email\" screen instead of immediately logging in.\n8. If the user tries to log in without verifying, show: \"Please verify your email. Didn't receive it? Resend.\" with a resend verification endpoint call.\n9. Add a `/resend-verification` endpoint if one doesn't exist.\n\nAcceptance criteria:\n- New user registration sends a real email to the provided address within 60 seconds.\n- Unverified user cannot log in — receives a 403 with a clear message.\n- Resend verification works (rate-limited to 1/minute).\n- Dev mode still works without SMTP configured (logs token instead of sending).",
@@ -2098,7 +2098,7 @@
         "updatedAt": "2026-04-28T09:57:46.989Z"
       },
       {
-        "id": 171,
+        "id": "171",
         "title": "UX: Portfolio page — add \"My Portfolios\" section heading above property cards",
         "description": "The Portfolio page renders property cards directly without a section context heading. Add a \"My Portfolios\" heading (with property count) above the cards so the page has clear visual hierarchy, especially once the page grows to include summary metrics and the Rentflow prompt.",
         "details": "Change in `frontend/src/components/Portfolio/PortfolioPage.tsx` (or equivalent):\n\n1. Above the portfolio property grid/list, add:\n   ```tsx\n   <div className=\"flex items-center justify-between mb-4\">\n     <h2 className=\"text-xl font-semibold\">My Portfolios</h2>\n     <span className=\"text-sm text-muted-foreground\">{count} properties</span>\n   </div>\n   ```\n2. If the page already has an \"Add Property\" button, keep it aligned to the right of this heading row.\n3. If count is 0, show \"No properties yet\" empty state below the heading (instead of the heading disappearing entirely).\n\nThis is a small cosmetic change — no backend work needed.",
@@ -2110,7 +2110,7 @@
         "updatedAt": "2026-04-29T09:27:44.954Z"
       },
       {
-        "id": 172,
+        "id": "172",
         "title": "UX: Add English translations in brackets for all German terms throughout the app",
         "description": "HeimPath's users are foreign investors and immigrants who may not know German real estate terminology. Wherever a German term appears in the UI (labels, headings, descriptions, calculator names, glossary entries, law titles, journey step names), the English meaning should appear in brackets immediately after — e.g. \"Grunderwerbsteuer (Property Transfer Tax)\".",
         "details": "Audit scope:\n\n**Priority 1 — High-traffic UI labels (fix in code):**\n- Calculator tab/card names: Grundsteuer, Mietpreisbremse, GEG, AfA, etc.\n- Journey phase/step names that use German terms\n- Document type labels: Kaufvertrag, Grundbuch, Teilungserklärung, Mietvertrag, WEG-Protokoll\n- Form field labels: Bundesland, Grundbuch, Notar, Makler, etc.\n\n**Priority 2 — Content data (fix in seeds/DB):**\n- Glossary terms: the `term` field is German; add English translation to `translation` or `short_definition` field and surface it in the UI card subtitle\n- Law titles that are in German: add English short title\n- Article tags/categories with German names\n\n**Priority 3 — Disclaimers and info text (fix inline):**\n- Any inline German phrases in explanatory text without English context\n\nImplementation approach:\n- For UI labels: create a `GERMAN_TERMS` constant map in `frontend/src/common/constants/germanTerms.ts` mapping term → `{ german, english }` and use it in components.\n- For calculator names (task #165 redesign): include English name in the card description.\n- For document types: handled in task #169 (title includes English in brackets).\n- For glossary: update `GlossaryTerm.short_definition` seed data to include English context if missing.\n\nDo not rename German terms — always keep German + add English in brackets. German terms are part of the product's educational value.",
@@ -2122,7 +2122,7 @@
         "updatedAt": "2026-04-29T13:46:20.122Z"
       },
       {
-        "id": 173,
+        "id": "173",
         "title": "UX: Consistent disclaimer styling — light wine/burgundy background across all calculators and tools",
         "description": "Disclaimers (legal caveats, \"verify with a Steuerberater\" notices) appear throughout the app in plain muted text that is easy to miss. Standardise disclaimer styling with a light wine/burgundy background so they are visually distinct and users cannot overlook them — without being alarmist.",
         "details": "1. Add a `Disclaimer` component at `frontend/src/components/ui/Disclaimer.tsx`:\n```tsx\ninterface IProps {\n  children: React.ReactNode\n  className?: string\n}\n\nfunction Disclaimer({ children, className }: Readonly<IProps>) {\n  return (\n    <div className={cn(\n      \"rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-xs text-rose-800\",\n      className\n    )}>\n      {children}\n    </div>\n  )\n}\n\nexport default Disclaimer\n```\n   Use Tailwind's rose palette (closest to light wine) — `bg-rose-50 border-rose-200 text-rose-800`.\n\n2. Replace all inline disclaimer `<p className=\"text-xs text-muted-foreground\">` patterns across calculators, mietpreisbremse, document translation, and property evaluation with `<Disclaimer>`.\n\n3. Grep pattern to find all disclaimer text: `disclaimer` (the field name) and phrases like \"verify with\", \"consult a\", \"not legal advice\", \"not financial advice\".\n\n4. Export from `frontend/src/components/ui/index.ts`.\n\n5. No backend changes needed.",
@@ -2134,7 +2134,7 @@
         "updatedAt": "2026-04-29T08:32:58.210Z"
       },
       {
-        "id": 174,
+        "id": "174",
         "title": "Feature: Admin panel for managing laws, glossary terms, and articles (content CMS)",
         "description": "Laws, glossary entries, and articles are currently seeded via Python scripts and cannot be updated without a code deploy. Build a superuser-only admin panel (or API endpoints) so content editors can add, edit, and publish new entries without touching code. This is essential for keeping the Knowledge Base current as German property law evolves.",
         "details": "**Backend: Admin CRUD endpoints**\n\nProtect all endpoints with `is_superuser` check via `CurrentSuperuser` dependency.\n\nLaws (`/api/v1/admin/laws`):\n- POST: create law entry (title, summary, full_text, category, state_code, etc.)\n- PUT /{id}: update law\n- DELETE /{id}: soft-delete (set `is_active=False`)\n- POST /{id}/versions: add a new version with change notes\n\nGlossary (`/api/v1/admin/glossary`):\n- POST: create term\n- PUT /{slug}: update term, short_definition, full_explanation, related_terms\n- DELETE /{slug}: soft-delete\n\nArticles (`/api/v1/admin/articles`):\n- POST: create article (title, slug, body_markdown, category, difficulty, status=DRAFT)\n- PUT /{slug}: update article\n- POST /{slug}/publish: set status=PUBLISHED\n\n**Frontend: Admin section (superuser only)**\n\nAdd a new route `/_layout/admin` visible only to `is_superuser` users (hide from nav for regular users).\n\nSub-pages:\n- `/admin/laws` — table with search, edit drawer\n- `/admin/glossary` — table with search, edit drawer\n- `/admin/articles` — table with status filter (DRAFT/PUBLISHED), edit drawer with markdown preview\n\nEach edit drawer has:\n- Form fields matching the schema\n- Save / Cancel buttons\n- \"Delete\" (soft) with confirmation dialog\n\nTechnology: use existing shadcn Table, Dialog, and form patterns. Markdown editing: simple `<textarea>` for MVP (no rich editor needed yet).\n\n**Files:**\n- `backend/app/api/routes/admin.py` (new)\n- `frontend/src/routes/_layout/admin/` (new folder)\n- Update `backend/app/api/main.py` to include admin router",
@@ -2146,7 +2146,7 @@
         "updatedAt": "2026-04-29T08:04:38.979Z"
       },
       {
-        "id": 175,
+        "id": "175",
         "title": "Feature: Admin panel for managing professionals directory",
         "description": "Professionals are currently seeded via a Python script and cannot be added or updated without a code deploy. Build superuser-only admin endpoints and UI so the HeimPath team can add, edit, verify, and deactivate professionals without touching code — essential for growing the trusted directory.",
         "details": "**Backend: Admin CRUD endpoints** (`/api/v1/admin/professionals`)\n\nProtected with `CurrentSuperuser` dependency.\n\n- `POST /`: create professional (name, type, city, languages, specialties, description, contact info, profile_image_url, is_verified, is_featured)\n- `PUT /{id}`: update any field\n- `DELETE /{id}`: soft-delete (set `is_active=False`)\n- `POST /{id}/verify`: set `is_verified=True`\n- `GET /`: list all (including inactive) with pagination + search\n\nSchema: extend existing `Professional` model — add `is_active: bool = True` if not already present.\n\n**Frontend: Admin professionals page**\n\nRoute: `/_layout/admin/professionals` (superuser only, part of admin panel from task #174).\n\nUI:\n- Searchable/filterable table: Name, Type, City, Languages, Verified, Active\n- \"Add Professional\" button → opens creation form drawer\n- Row actions: Edit, Verify (toggle), Deactivate\n- Edit drawer: all professional fields, profile image URL, multi-select for languages and specialties\n\n**Files:**\n- `backend/app/api/routes/admin.py` (extend, or create if task #174 not done yet)\n- `frontend/src/routes/_layout/admin/professionals.tsx` (new)\n\n**Dependency:** Can be implemented independently of task #174 but should use the same admin router/route structure.",
@@ -2160,7 +2160,7 @@
         "updatedAt": "2026-04-29T08:06:18.815Z"
       },
       {
-        "id": 176,
+        "id": "176",
         "title": "UX: Merge Financing Wizard and Mortgage Eligibility Guide into one unified tool",
         "description": "The Financing section has two overlapping calculators that confuse users: Financing Wizard (personal financial assessment → numeric eligibility score) and Mortgage Eligibility Guide (3-question lender access guide → lender compatibility matrix). Both assess mortgage access for foreign buyers. Harmonise them into a single \"Mortgage Eligibility Checker\" without losing any functionality from either.",
         "details": "**Current state**\n- FinancingWizard.tsx: 7 inputs (employment status, years employed, monthly net income, debt, down payment, SCHUFA, residency). Outputs: composite score 0–100, individual factor scores, max loan estimate, rate range, bank-compatibility table by residency, document checklist. Saveable/shareable.\n- MortgageEligibilityGuide.tsx: 3 inputs (nationality/residency, employment type, property use). Outputs: eligibility badge, per-lender-type breakdown (traditional banks, Sparkasse, online banks) with LTV caps and minimum down payment, employment-specific summary text, next steps.\n\n**What must be preserved from each**\nFrom Financing Wizard: numeric score and grade, factor breakdown, max loan estimate, rate range, document checklist by employment type, save/share.\nFrom Eligibility Guide: 3-question quick entry, named lender-type table with LTV/down payment by lender, employment-specific eligibility notes.\n\n**Proposed merged design**\nA single \"Mortgage Eligibility Checker\" with two sections presented in order:\n1. **Quick Profile** (from Guide): 3 dropdowns (residency, employment, property use) → immediately shows lender-type compatibility table + eligibility badge.\n2. **Detailed Assessment** (from Wizard): expandable or on-scroll section — add financial details (income, debt, down payment, SCHUFA) to get a numeric eligibility score, max loan estimate, and document checklist.\n- Remove standalone Financing Wizard and Mortgage Eligibility Guide from the calculators grid.\n- Add a single new \"Mortgage Eligibility\" entry under Financing category.\n- Update calculator tab key (e.g. `mortgage-eligibility`) and add case to the ActiveCalculator switch.\n- Save/share should cover the full form state (both sections).\n\n**Files to touch**\n- `frontend/src/components/Calculators/FinancingWizard.tsx` — absorb or replace\n- `frontend/src/components/Calculators/MortgageEligibilityGuide.tsx` — absorb or replace\n- `frontend/src/components/Calculators/MortgageEligibilityChecker.tsx` — NEW combined component\n- `frontend/src/components/Calculators/index.ts` — remove old exports, add new\n- `frontend/src/routes/_layout/calculators.tsx` — update CATEGORIES and ActiveCalculator switch",
@@ -2172,7 +2172,7 @@
         "updatedAt": "2026-04-30T04:36:41.995Z"
       },
       {
-        "id": 177,
+        "id": "177",
         "title": "UX: Merge Rent Estimate and Rent Ceiling Check into one unified Rent Analyser tool",
         "description": "The Renting & Compliance section has two calculators that naturally flow together: Rent Estimate (what is the market rent for a given postcode?) and Rent Ceiling Check (is my current rent legal under Mietpreisbremse?). A user setting rent should check both in sequence. Combine them into a single \"Rent Analyser\" without losing any functionality from either.",
         "details": "**Current state**\n- RentEstimate.tsx: inputs: postcode (5-digit, all Germany), property size (optional), building year (optional). Outputs: estimated rent per m², total monthly rent, rent range (min/max), confidence level (high for 9 major cities, medium for state averages), data source. Has \"Suggest\" button that pushes rent value to ROI Calculator via URL param. Geographic coverage: all Germany.\n- RentCeilingCalculator.tsx: inputs: city dropdown (Berlin, Hamburg, Munich, Frankfurt only), postcode, apartment size (required), building year (optional), current monthly rent (required). Outputs: legal ceiling rent (Mietspiegel × 1.10), status badge (OVER_LIMIT / AT_RISK / WITHIN_LIMIT / ROOM_TO_INCREASE), reference rent per m², overpayment amount with legal 2-year liability warning, room-to-increase amount, data source + disclaimer. Geographic coverage: 4 cities only.\n\n**What must be preserved**\nFrom Rent Estimate: postcode-first entry, confidence levels, wide geographic coverage (all Germany), \"Suggest to ROI\" button.\nFrom Rent Ceiling: city dropdown for the 4 restricted cities, current rent input, legal status determination, OVER_LIMIT warning with liability language, AT_RISK/WITHIN_LIMIT/ROOM_TO_INCREASE statuses.\n\n**Proposed merged design**\nA single \"Rent Analyser\" with progressive disclosure:\n1. **Market Rent section** (always visible): postcode + size → shows estimated rent, range, confidence. \"Suggest to ROI Calculator\" button preserved.\n2. **Legal Compliance section** (unlocked after market rent loaded or always shown): city dropdown (4 cities), current rent input → shows ceiling, status badge, overpayment/headroom. Pre-fills size from Market Rent section if entered.\n- The Legal Compliance section should show a notice \"Available for Berlin, Hamburg, Munich, Frankfurt only\" rather than hiding for other postcodes.\n- Remove standalone RentEstimate and RentCeilingCalculator entries from the calculators grid.\n- Add a single \"Rent Analyser\" entry under Renting & Compliance.\n- Update tab key to `rent-analyser` and update ActiveCalculator switch.\n\n**Files to touch**\n- `frontend/src/components/Calculators/RentEstimate.tsx` — absorb or replace\n- `frontend/src/components/Calculators/RentCeilingCalculator.tsx` — absorb or replace\n- `frontend/src/components/Calculators/RentAnalyser.tsx` — NEW combined component\n- `frontend/src/components/Calculators/index.ts` — update exports\n- `frontend/src/routes/_layout/calculators.tsx` — update CATEGORIES and switch",
@@ -2184,7 +2184,7 @@
         "updatedAt": "2026-04-30T04:36:42.102Z"
       },
       {
-        "id": 178,
+        "id": "178",
         "title": "Consolidate ROI Calculator and AfA Depreciation into Property Evaluation Calculator",
         "description": "The ROI Calculator and AfA (depreciation) Calculator overlap significantly with the Property Evaluation Calculator. Harmonise all three into a single, comprehensive Property Evaluation Calculator without losing any functionality.",
         "details": "## Background\n\n**ROI Calculator** (frontend/src/components/Calculators/ROICalculator.tsx) unique features to preserve:\n- Investment grade scoring (0–10 weighted scale with colour-coded label: \"Excellent / Good / Fair / Poor\")\n- Fixed 10-year area chart (recharts) showing cumulative equity growth vs. total cost\n- \"Suggest rent\" shortcut that navigates to Rent Estimate calculator with pre-filled price\n\n**Property Evaluation Calculator** (frontend/src/components/Calculators/PropertyEvaluationCalculator/) already covers:\n- Gross and net rental yield\n- Financing inputs (loan, rate, term)\n- Operating costs (Hausgeld, Grundsteuer, reserves)\n- Multi-year projection table\n- Cash-on-cash return\n\n**AfA Calculator** (frontend/src/components/Calculators/AfaCalculator.tsx) unique features to preserve:\n- German §7 EStG construction-year depreciation tiers:\n  - Pre-1925: 2.5% per year\n  - 1925–2022: 2.0% per year\n  - 2023+: 3.0% per year (degressive option also available)\n- Annual AfA deduction in EUR\n- Estimated annual tax saving (AfA × marginal tax rate input)\n- 10-year AfA schedule table\n\n## Implementation Plan\n\n### Phase 1 — Add Investment Score to Property Evaluation\n- After the existing yield/return metrics section, compute a weighted investment score:\n  - Gross yield (weight 30%)\n  - Net yield (weight 30%)\n  - Cash-on-cash return (weight 20%)\n  - Price-to-rent ratio (weight 20%)\n- Display score badge identical to current ROI Calculator scoring\n- Preserve existing score thresholds and labels\n\n### Phase 2 — Add 10-Year Chart to Property Evaluation\n- Port the recharts area chart from ROI Calculator into Property Evaluation\n- Show cumulative equity, total rent received, and total costs on the same chart\n- Replace the existing projection table with chart + collapsible table\n\n### Phase 3 — Add \"Suggest rent\" deep-link\n- Add a small \"Estimate market rent →\" button/link in the rent inputs section\n- Link to /calculators?tab=rent-estimate with purchasePrice pre-filled (existing query param support)\n\n### Phase 4 — Add AfA Section to Property Evaluation (optional advanced section)\n- Add a collapsible \"Tax & Depreciation\" card in Property Evaluation\n- Inputs: construction year (already present), purchase price allocation % for building vs. land (new), marginal tax rate (new)\n- Auto-detect AfA rate from construction year\n- Output: annual AfA deduction, estimated annual tax saving, cumulative 10-year tax saving\n- Keep standalone AfA Calculator for users who only want the AfA figure\n\n### Phase 5 — Retire standalone ROI Calculator\n- Remove \"ROI Calculator\" card from the Calculators page CATEGORIES list\n- Remove the `roi` case from the ActiveCalculator switch\n- Remove ROICalculator component export\n- Update any deep-links (/calculators?tab=roi) to redirect to ?tab=property-evaluation\n- Keep standalone AfA Calculator (it has enough unique depth to stand alone)\n\n## Files to Modify\n- frontend/src/components/Calculators/PropertyEvaluationCalculator/ (add score, chart, AfA section)\n- frontend/src/components/Calculators/PropertyEvaluationCalculator/types.ts (new inputs)\n- frontend/src/components/Calculators/index.ts (remove ROICalculator export)\n- frontend/src/routes/_layout/calculators.tsx (remove roi tab, keep afa tab)\n- backend/app/api/routes/calculators.py (no changes needed — ROI is pure frontend math)\n\n## Test Strategy\n- Verify investment grade score thresholds produce correct labels\n- Verify AfA rate selection matches German §7 EStG tiers\n- Verify removing `?tab=roi` URL falls back gracefully (returns to calculator grid)\n- Smoke test: enter identical inputs in old ROI Calculator and new Property Evaluation; verify same yield and score outputs\n- TypeScript: `bunx tsc --noEmit` must pass with 0 errors",
@@ -2196,7 +2196,7 @@
         "updatedAt": "2026-04-30T04:36:42.173Z"
       },
       {
-        "id": 179,
+        "id": "179",
         "title": "Fix notification click-through: all action notifications must navigate to their detail page",
         "description": "Clicking a notification (e.g. \"Document translated\") does not navigate to the document. Every notification that relates to a specific resource must carry an action_url so the user lands on the correct detail page when they click it.",
         "details": "## Root Cause\n\n`NotificationBell.tsx` already handles navigation:\n```tsx\nif (notification.actionUrl) {\n  navigate({ to: notification.actionUrl })\n}\n```\nThe bug is upstream — the backend does not populate `action_url` for all notification types when it creates notifications.\n\n## Backend Changes\n\n### 1. Audit all notification-creation call sites\nSearch for `create_notification` / `Notification(` in backend/app/services/ and backend/app/api/routes/ and ensure each call includes an `action_url`.\n\n### 2. Required action_url values per notification type\n\n| Notification type | action_url |\n|-------------------|-----------|\n| `document_translated` | `/documents/{document_id}` |\n| `translation_failed` | `/documents/{document_id}` |\n| `step_completed` | `/journey` |\n| `journey_completed` | `/journey` |\n| `calculation_saved` | `/calculators?tab={calculator_type}` |\n| `law_bookmarked` | `/laws/{law_id}` |\n| `property_saved` | `/properties/{property_id}` (if property route exists) |\n| `generic` / informational | omit action_url (no navigation) |\n\n### 3. Update notification service / creation helper\nIf there is a central `create_notification(type, user_id, ...)` helper, add an `action_url: str | None = None` parameter and thread it through to the model.\n\nIf notifications are created inline, add `action_url=f\"/documents/{document.id}\"` etc. at each call site.\n\n### 4. Migration check\nConfirm the `notification` table already has an `action_url` column (VARCHAR nullable). If not, add a new Alembic migration to add the column.\n\n## Frontend Changes\n\n### NotificationBell.tsx — no logic changes needed\nThe click handler already navigates when `actionUrl` is present.\n\n### Optional UX improvement\nWhen a notification has an `actionUrl`, show a subtle `→` chevron icon at the right edge of the row to signal clickability. Use `ChevronRight` from lucide-react (already in the project).\n\n## Files to Modify\n- backend/app/services/ — wherever notifications are created\n- backend/app/api/routes/ — any inline notification creation\n- backend/app/models/notification.py — verify/add action_url column\n- backend/app/alembic/versions/ — new migration if column is missing\n- frontend/src/components/Notifications/NotificationBell.tsx — optional chevron icon\n\n## Test Strategy\n- Unit test: document_translated notification has action_url = `/documents/{id}`\n- Unit test: generic informational notification has action_url = None\n- Integration test: POST /documents/{id}/translate → notification created with correct action_url\n- Manual smoke test: translate a document, click the notification bell, click the notification → lands on document detail page",
@@ -2208,7 +2208,7 @@
         "updatedAt": "2026-04-30T04:36:42.196Z"
       },
       {
-        "id": 180,
+        "id": "180",
         "title": "Ship branded PDF export for Property Evaluation Calculator",
         "description": "Replace the old raw-JSON export with a branded jsPDF report. Implementation already complete on feat/evaluation-pdf-export branch (GenerateEvaluationPdf.ts + PropertyEvaluationCalculator.tsx update). Needs PR, code review, CI, and merge.",
         "details": "",
@@ -2220,7 +2220,7 @@
         "updatedAt": "2026-04-30T04:39:41.020Z"
       },
       {
-        "id": 181,
+        "id": "181",
         "title": "Add journey deadline reminder notifications",
         "description": "Wire up the existing JOURNEY_DEADLINE notification type. The target_purchase_date column, DaysToTargetCard dashboard component, and notification type all exist but nothing triggers deadline reminders. Add a deadline_service that queries journeys with upcoming target dates and fires JOURNEY_DEADLINE notifications at 90/30/7/1-day milestones with deduplication. Add send-deadline-reminders CLI command and tests.",
         "details": "",
@@ -2232,7 +2232,7 @@
         "updatedAt": "2026-04-30T05:12:19.054Z"
       },
       {
-        "id": 182,
+        "id": "182",
         "title": "Add notification preferences — per-user, per-type opt-in/out",
         "description": "Users currently have no control over which notifications HeimPath sends. Add a NotificationPreferences model and settings UI so users can opt-out of weekly digests, deadline reminders, and other notification types. Backend must check preferences before firing any notification.",
         "details": "Backend: NotificationPreferences model (user_id FK, boolean flags: weekly_digest, journey_deadline, document_ready, system_alerts). Migration with default-all-on. GET/PATCH /api/v1/notifications/preferences endpoints. digest_service and deadline_service check prefs before sending. notification_service respects in-app prefs. Frontend: Settings page with toggles per category, linked from user profile and from unsubscribe link in digest emails.",
@@ -2246,7 +2246,7 @@
         "updatedAt": "2026-04-30T05:17:32.589Z"
       },
       {
-        "id": 183,
+        "id": "183",
         "title": "Add scheduled cron jobs for digest/deadline CLI + fix translation_failed in notification preferences",
         "description": "Weekly digest and deadline reminder CLI commands exist but are never executed in production — no scheduled infrastructure. Add Azure Container App Jobs with cron triggers for both commands in prod and staging Terraform. Also add translation_failed to NotificationPreferences.tsx which was missing after PR #265 added the notification type.",
         "details": "",
@@ -2261,7 +2261,7 @@
         "updatedAt": "2026-04-30T07:59:48.513Z"
       },
       {
-        "id": 184,
+        "id": "184",
         "title": "Add full notification history page at /notifications",
         "description": "The notification bell dropdown only shows recent items. Add a dedicated /notifications page with full paginated history, type/read-status filtering, bulk mark-read, and per-row delete. Link to it from the bell dropdown. Backend API already exists — purely a frontend task.",
         "details": "New TanStack Router route at /notifications. NotificationCenter component with: paginated list using existing useNotifications hook, filter tabs (All / Unread), type filter dropdown, bulk mark-all-read button, per-row mark-read and delete actions. Icon + title + relative timestamp per row, action_url click-through. Empty state. Link from NotificationBell dropdown footer. Loading and error states.",
@@ -2275,7 +2275,7 @@
         "updatedAt": "2026-04-30T08:00:48.836Z"
       },
       {
-        "id": 185,
+        "id": "185",
         "title": "Add contextual partner referral cards for Hypofriend and Myhammer",
         "description": "Add Hypofriend referral to mortgage pre-approval step and Myhammer referral to ownership management step. Extract reusable PartnerReferralBanner component.",
         "status": "done",
@@ -2285,7 +2285,7 @@
         "updatedAt": "2026-04-30T09:00:00.000Z"
       },
       {
-        "id": 186,
+        "id": "186",
         "title": "SECURITY: Verify and enforce Content-Security-Policy header on staging",
         "description": "QA audit found that the Content-Security-Policy (CSP) header is missing from staging.heimpath.com responses. Task #158 (SECURITY M9) was supposed to ship CSP via Traefik middleware — either the middleware config is not applied to the staging Container App or the rule is incorrect. A missing CSP allows XSS payloads to exfiltrate data even if no injection vector exists today.",
         "details": "1. Check infra/terraform for Traefik middleware config that sets CSP header. 2. Verify the staging Container App is using the Traefik ingress with the CSP middleware. 3. If the middleware exists but isn't applied, wire it to the staging route. 4. If it doesn't exist, add a Traefik middleware in Terraform that sets Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https://api.cognitive.microsofttranslator.com https://heimpath-translator.cognitiveservices.azure.com; frame-ancestors 'none'. 5. Deploy via Terraform and verify header appears on staging with curl -I https://staging.heimpath.com.",
@@ -2297,7 +2297,7 @@
         "updatedAt": "2026-04-30T20:35:10.710Z"
       },
       {
-        "id": 187,
+        "id": "187",
         "title": "Fix admin user table mobile layout — hide or stack columns on small viewports",
         "description": "QA audit detected 171 elements overflowing the 375px viewport on the Admin page. The Users tab table has 5 columns (Full Name, Email, Role, Status, Actions) with no responsive handling. While the table has overflow-x-auto wrapping, the visual experience on mobile is a broken initial layout before horizontal scrolling. The other admin tabs (Laws, Glossary, Articles, Professionals) may have the same issue.",
         "details": "Option A (preferred): Hide non-essential columns on mobile using Tailwind hidden/sm:table-cell classes. For Users tab: show only Name + Actions on mobile, hide Email/Role/Status. For Laws: show Citation + Actions, hide Category/Type. For Glossary: show Term (DE) + Actions. For Articles: show Title + Actions. For Professionals: show Name + Actions. Option B: Stack layout — convert rows to card-like stacked display on mobile using CSS grid. Implement in UsersAdmin.tsx, LawsAdmin.tsx, GlossaryAdmin.tsx, ArticlesAdmin.tsx, ProfessionalsAdmin.tsx. The DataTable.tsx component also needs the same treatment for the Users tab which uses the shared DataTable component.",
@@ -2309,7 +2309,7 @@
         "updatedAt": "2026-04-30T20:47:38.794Z"
       },
       {
-        "id": 188,
+        "id": "188",
         "title": "Fix calculator tabs — verify and implement missing tab handlers for ownership, tenant-trap, grundsteuer, speculation-tax, afa, tax-guide, cities",
         "description": "QA audit found that the calculator switch statement in calculators.tsx only handles 6 tab values (costs, property-evaluation, mortgage, eligibility, rent-analyser, geg-retrofit). Seven other tabs are defined as grid cards — ownership (GmbH vs Private), tenant-trap (Stress Test), grundsteuer (Property Tax), speculation-tax, afa (Depreciation), tax-guide, cities — but have no case in the CalcDisplay switch, meaning clicking them from the grid likely renders nothing or reverts to the grid. Each of these calculators exists in the codebase but may not be wired into the tab URL routing.",
         "details": "1. Navigate to /calculators in a browser and click each of the 7 unhandled tab cards to confirm the bug. 2. For each that fails to render: locate the calculator component in the codebase, add a case to the CalcDisplay switch statement, and test the ?tab=ownership, ?tab=tenant-trap etc. URL params. 3. Add TAB_ALIASES for any previous naming if needed. 4. Verify all 13 calculator tabs are reachable via URL parameter.",
@@ -2321,7 +2321,7 @@
         "updatedAt": "2026-04-30T20:36:01.543Z"
       },
       {
-        "id": 189,
+        "id": "189",
         "title": "Fix: redirect authenticated users away from /login and /signup to /dashboard",
         "description": "QA audit found that logged-in users who navigate directly to /login see the login form instead of being redirected to /dashboard. This is a standard UX expectation for authenticated apps. Same likely applies to /signup. Currently the route has no beforeLoad check for an existing session — it only guards the form from submitting if already logged in on mount.",
         "details": "In frontend/src/routes/login.tsx (and signup.tsx), add a beforeLoad that checks isLoggedIn() — if true, throw redirect({ to: '/dashboard' }). The isLoggedIn() helper reads the logged_in=1 cookie, which is already used in _layout.tsx. This is a 2-line fix per route. Also check if there are any other public routes that should redirect authenticated users (e.g. /tools might want to offer a \"Go to Dashboard\" prompt but not redirect).",
@@ -2333,7 +2333,7 @@
         "updatedAt": "2026-04-30T20:36:01.558Z"
       },
       {
-        "id": 190,
+        "id": "190",
         "title": "SECURITY: Add Strict-Transport-Security (HSTS) header to staging and production",
         "description": "QA audit found that Strict-Transport-Security is missing from staging.heimpath.com. Without HSTS, a user who types the domain without https:// is vulnerable to MITM on first connection. This is low risk on staging but must be present on production before any public launch. Should be added via Traefik middleware alongside the CSP work.",
         "details": "Add Strict-Transport-Security: max-age=31536000; includeSubDomains to the Traefik headers middleware in infra/terraform. Coordinate with task #186 (CSP) — both headers can be added in the same Traefik middleware block. For staging, use max-age=86400 (1 day) to allow rollback. For production, use max-age=31536000 (1 year). Deploy via Terraform and verify with curl.",
@@ -2345,7 +2345,7 @@
         "updatedAt": "2026-04-30T20:36:01.584Z"
       },
       {
-        "id": 191,
+        "id": "191",
         "title": "UX: Add search input to Legal Knowledge Base page (/laws)",
         "description": "QA audit found no search input on the /laws page despite it containing 19 laws. Users browsing the legal library have only category filter tabs available (2 tabs). As the law count grows (currently 19, target 50+), the absence of search significantly degrades discoverability. Foreign buyers typically search for specific terms like \"Grunderwerbsteuer\" or \"Notarkosten\" rather than browsing by category.",
         "details": "Add a search input to the /laws page that filters law cards client-side by title (DE + EN), citation, and one-line summary. Use a controlled input with useState, filter the laws array before rendering. The existing laws are already loaded in the query. Also add the same pattern to /glossary and /articles if they don't already have search. Wire the search to the URL as a ?q= param so search results are bookmarkable/shareable.",
@@ -2357,7 +2357,7 @@
         "updatedAt": "2026-04-30T20:35:32.683Z"
       },
       {
-        "id": 192,
+        "id": "192",
         "title": "UX: Add deep-link URLs for individual journey detail pages (/journeys/:id)",
         "description": "QA audit found that all journey links on /journeys resolve back to /journeys — there are no individual journey URLs. Users cannot bookmark, share, or deep-link to a specific property journey. This limits the product's shareability and prevents users from returning directly to their active journey from an email link or browser bookmark. The journey detail view is likely a modal or tab within the /journeys page, not a separate route.",
         "details": "Create a new TanStack Router route at /journeys/$journeyId that renders the journey steps view for a specific journey. The journey data is already fetched by the existing journey hooks. The URL should support: /journeys/:id (steps overview) and optionally /journeys/:id/steps/:stepIndex. Update journey cards on /journeys to link to /journeys/:id instead of opening a modal/tab. Update email notification links for journey deadlines to use the new URL. This enables the weekly digest email to deep-link directly to the user's active journey step.",
@@ -2369,7 +2369,7 @@
         "updatedAt": "2026-04-30T20:34:46.536Z"
       },
       {
-        "id": 193,
+        "id": "193",
         "title": "Deploy current main branch to production",
         "description": "Production is running a 3-month-old image (last-modified Feb 4, 2026). This single deploy closes two critical security issues: (1) Swagger UI is accessible at api.heimpath.com/docs because the old image had docs enabled — current code disables them when ENVIRONMENT != local; (2) www.heimpath.com is missing all security headers (CSP, HSTS, X-Frame-Options etc) — nginx.conf.template already has them configured but prod was never redeployed after they were added.",
         "details": "1. Identify current main HEAD commit SHA: `git rev-parse HEAD`\n2. Trigger production deploy workflow: `gh workflow run \"Deploy to Production\" -f image_tag=\"staging-<commit_sha>\"`\n3. Watch the run: `gh run watch <run_id>`\n4. Verify after deploy:\n   - `curl -sI https://api.heimpath.com/docs` must return HTTP 404 (not 200)\n   - `curl -sI https://www.heimpath.com` must include Content-Security-Policy, Strict-Transport-Security, X-Frame-Options headers\n5. Confirm last-modified date on www.heimpath.com has updated from Feb 4, 2026",
@@ -2381,7 +2381,7 @@
         "updatedAt": "2026-05-01T02:36:23.882Z"
       },
       {
-        "id": 194,
+        "id": "194",
         "title": "Provision Azure Cache for Redis and wire REDIS_URL into production",
         "description": "Production has no Redis instance. The backend's rate limiting service falls back to fakeredis (in-memory) when REDIS_URL is unreachable — rate limit counters reset on restart and don't propagate across the 2 backend replicas. Brute force attempts split across replicas get 2× the allowed attempts. The sophisticated sliding-window rate limiter (login: 5/15min, register: 3/hr, password reset: 3/hr) is effectively inoperative in production.",
         "details": "All infra changes via Terraform only — never az CLI or portal.\n\n1. Add Azure Cache for Redis resource to infra/terraform/prod.tf (Basic C0 tier is sufficient for rate limiting)\n2. Add variable `prod_redis_url` to variables.tf (secret, sourced from .env as TF_VAR_prod_redis_url)\n3. Wire REDIS_URL env var into prod backend container in prod.tf\n4. Run: `cd infra/terraform && set -a && source ../../.env && set +a && terraform plan`\n5. Review plan carefully — new Redis resource + new env var on backend container app\n6. `terraform apply`\n7. Verify: check backend logs for \"Connected to Redis\" (not \"fakeredis fallback\")\n8. Also add REDIS_URL to staging for consistency\n\nNote: Azure Cache for Redis Basic C0 (250MB, no SLA) is sufficient for rate limiting use case. Standard C1 if higher availability needed.",
@@ -2393,7 +2393,7 @@
         "updatedAt": "2026-05-01T02:50:06.005Z"
       },
       {
-        "id": 195,
+        "id": "195",
         "title": "Fix TRUSTED_PROXY_IPS to prevent IP spoofing in production",
         "description": "Production Terraform hardcodes TRUSTED_PROXY_IPS=* — every X-Forwarded-For header value is trusted unconditionally. An attacker can set X-Forwarded-For: 1.2.3.4 to spoof their source IP, bypassing the IP-based rate limiting and any IP blocklist logic in the rate limit service.",
         "details": "1. Determine the correct IP range to trust:\n   - Azure Container Apps uses a managed ingress controller — find the outbound/ingress CIDR for the Container Apps Environment (`cae-heimpath` in `rg-heimpath-shared`)\n   - Run: `az containerapp env show -n cae-heimpath -g rg-heimpath-shared --query \"properties.staticIp\" -o tsv`\n   - Or check Azure portal for the CAE's static outbound IP(s)\n2. Update infra/terraform/prod.tf: change TRUSTED_PROXY_IPS value from \"*\" to the specific IP/CIDR\n3. Add variable `prod_trusted_proxy_ips` to variables.tf with the discovered value in terraform.tfvars\n4. Same fix for staging (staging TRUSTED_PROXY_IPS is likely also \"*\")\n5. terraform plan → terraform apply\n6. Test: verify X-Forwarded-For spoofing no longer bypasses rate limiting\n\nNote: If Container Apps uses a dynamic IP pool, the alternative is to configure the ingress policy at the CAE level and trust only the internal network range.",
@@ -2405,7 +2405,7 @@
         "updatedAt": "2026-05-01T03:31:36.303Z"
       },
       {
-        "id": 196,
+        "id": "196",
         "title": "Increase WEB_CONCURRENCY and add DB connectivity to health check",
         "description": "Two medium issues to fix together since both touch backend config/code: (1) WEB_CONCURRENCY=1 means a single uvicorn worker per container — with max 2 replicas, only 2 requests can be processed concurrently; (2) health check endpoint returns true unconditionally without validating DB connectivity, so a broken DB connection won't trigger container restart or traffic removal.",
         "details": "### Part 1: WEB_CONCURRENCY\n- Update infra/terraform/prod.tf: WEB_CONCURRENCY = \"2\" (up from \"1\")\n- Update infra/terraform/staging.tf: same\n- Consider bumping CPU from 0.25 to 0.5 in prod.tf to support extra worker (optional — test under load first)\n- terraform plan → terraform apply\n\n### Part 2: Health check DB ping\n- File: backend/app/api/routes/utils.py (health check endpoint)\n- Add a lightweight `SELECT 1` using the existing DB session dependency\n- If DB ping fails, return HTTP 503 (not 200) with error detail\n- Example:\n  ```python\n  @router.get(\"/health-check/\")\n  async def health_check(db: Session = Depends(get_db)) -> bool:\n      try:\n          db.exec(text(\"SELECT 1\"))\n          return True\n      except Exception:\n          raise HTTPException(status_code=503, detail=\"Database unavailable\")\n  ```\n- This endpoint is used by Azure Container Apps liveness/readiness probes — 503 will cause traffic to be removed from the replica\n\n### Tests\n- Write test: mock DB failure → health check returns 503\n- Write test: normal case → health check returns 200 True",
@@ -2417,7 +2417,7 @@
         "updatedAt": "2026-05-15T18:55:59.686Z"
       },
       {
-        "id": 197,
+        "id": "197",
         "title": "Configure explicit DB connection pool and fix npm-audit CI suppression",
         "description": "Two low/medium items: (1) SQLAlchemy create_engine uses default pool settings (pool_size=5, max_overflow=10, no pre-ping) — stale connections will cause 500 errors; no circuit breaking on pool exhaustion; (2) npm-audit in CI runs with continue-on-error: true meaning frontend dependency vulnerabilities never fail the build.",
         "details": "### Part 1: DB connection pool\n- File: backend/app/core/db.py\n- Add explicit pool config to create_engine call:\n  ```python\n  engine = create_engine(\n      str(settings.SQLALCHEMY_DATABASE_URI),\n      pool_size=5,\n      max_overflow=10,\n      pool_timeout=30,\n      pool_pre_ping=True,   # detects stale connections before use\n      pool_recycle=1800,    # recycle connections every 30 min\n  )\n  ```\n- pool_pre_ping=True is the most important — prevents \"connection closed\" 500 errors after DB restarts\n\n### Part 2: npm-audit CI\n- File: .github/workflows/security-scan.yml (or wherever npm-audit runs)\n- Run: `npm audit --audit-level=high` in the frontend directory to see current high/critical vulns\n- Fix any high/critical vulnerabilities (npm audit fix or dependency updates)\n- Remove continue-on-error: true from the npm-audit step\n- Set `--audit-level=high` to only fail on high/critical (not low/moderate which may be acceptable)",
@@ -2429,7 +2429,7 @@
         "updatedAt": "2026-05-08T13:47:14.282Z"
       },
       {
-        "id": 198,
+        "id": "198",
         "title": "Remove TRUSTED_PROXY_IPS hardcode from CI/CD deploy workflows",
         "description": "TRUSTED_PROXY_IPS=* is set in --set-env-vars in both deploy workflows, not just Terraform. This means every deployment overwrites the env var back to * even after Terraform is fixed. Both places must be fixed together or the Terraform fix will be undone on the next push to main. This is a prerequisite companion to task #195.",
         "details": "Files to update:\n1. `.github/workflows/deploy-staging.yml` line 80:\n   Remove `--set-env-vars \"TRUSTED_PROXY_IPS=*\" \\` from the backend deploy step entirely.\n   The value should come from Terraform (task #195), not be overridden in CI.\n\n2. `.github/workflows/deploy-production.yml` line 51:\n   Same — remove `--set-env-vars \"TRUSTED_PROXY_IPS=*\"` from the production deploy step.\n\nImportant: Do this in the same PR as task #195 Terraform fix so both land atomically.\nAfter removing from workflows, the env var set by Terraform will persist across deploys.\n\nTest: After next staging deploy, verify `TRUSTED_PROXY_IPS` env var on the container has the correct IP value (not `*`).",
@@ -2443,7 +2443,7 @@
         "updatedAt": "2026-05-01T03:31:36.417Z"
       },
       {
-        "id": 199,
+        "id": "199",
         "title": "Enforce Redis as hard dependency in non-local environments",
         "description": "Remove the fakeredis fallback for staging/production environments. In multi-replica deployments, the fakeredis fallback creates per-process in-memory state — meaning a user who logs out on one replica remains authenticated on another. This is a silent security regression for both token blacklisting and rate limiting.",
         "details": "In backend/app/services/redis_client.py, remove the fakeredis fallback branch for ENVIRONMENT != 'local'. Add a startup check that raises RuntimeError if Redis is unavailable in staging/production. Update get_redis_client() to fail fast rather than silently degrade. Add a health check endpoint that verifies Redis connectivity. Update compose.yml health checks to gate backend startup on Redis being healthy. Test that the application refuses to start without Redis in non-local envs.",
@@ -2457,7 +2457,7 @@
         "updatedAt": "2026-05-07T11:12:51.571Z"
       },
       {
-        "id": 200,
+        "id": "200",
         "title": "Add retry policies for Stripe and Azure Translator using tenacity",
         "description": "Transient network errors on Stripe API calls fail checkout immediately with no retry, creating a false payment failure UX. Azure Translator HTTP 5xx responses also fail immediately, blocking document processing. Add exponential backoff retry logic using the tenacity library for all external API calls.",
         "details": "Install tenacity library. In backend/app/services/payment_service.py, wrap stripe.checkout.Session.create(), stripe.Customer.create(), stripe.billing_portal.Session.create() with @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=10), retry=retry_if_exception_type(stripe.APIConnectionError)). In backend/app/services/translation_service.py, wrap the aiohttp HTTP call with async tenacity retry for HTTP 5xx status codes. Add retry=retry_if_result(lambda r: r.status >= 500). Log retry attempts at WARNING level. Do not retry on 4xx errors (client errors). Add Stripe idempotency keys to checkout session creation to prevent double charges on retry.",
@@ -2469,7 +2469,7 @@
         "updatedAt": "2026-05-07T06:46:36.431Z"
       },
       {
-        "id": 201,
+        "id": "201",
         "title": "Implement persistent task queue for document processing using Celery",
         "description": "Document processing currently uses asyncio.create_task() which is in-process. On pod restart or deploy, all in-flight document processing is silently lost — documents remain stuck in PROCESSING status permanently. This is the highest-severity reliability gap as it directly impacts core user value (document translation).",
         "details": "Install celery[redis] and configure a Celery app in backend/app/worker.py using the existing Redis instance as broker. Move the process_document() async logic into a Celery task @app.task(bind=True, max_retries=3, default_retry_delay=60). Add a stuck-document detection cron job: query documents WHERE status=PROCESSING AND updated_at < NOW()-10min, mark them FAILED with error_message='Processing timeout — please retry'. Add POST /api/v1/documents/{id}/retry endpoint that re-queues failed documents (authenticated, own documents only, max 3 retries). Add a GET /api/v1/documents/{id}/status endpoint for polling. Update compose.yml to add a celery worker service. Add task_id field to Document model via Alembic migration to track Celery task IDs.",
@@ -2483,7 +2483,7 @@
         "updatedAt": "2026-05-07T14:38:51.358Z"
       },
       {
-        "id": 202,
+        "id": "202",
         "title": "Rate limit document upload and translation endpoints",
         "description": "Document upload and translation endpoints have no rate limiting. Each upload triggers expensive Anthropic + Azure Translator API calls. A single authenticated user (or compromised account) can flood the processing queue, exhaust the monthly translation quota, and drive up Anthropic API costs catastrophically.",
         "details": "In backend/app/api/routes/documents.py, apply the existing rate_limit_service pattern to the upload endpoint: 10 uploads per hour per user, 3 per minute burst. In backend/app/api/routes/translations.py, rate limit translation requests to 50 per hour per user. Add rate limits to contract analysis and clause analysis endpoints. Reuse the existing rate_limit_service.check_rate_limit() function — it already supports Redis-backed per-user limits. Return HTTP 429 with Retry-After header when limits are exceeded. Add monitoring: log when users hit rate limits to detect abuse patterns. Document the limits in the API schema description fields.",
@@ -2497,7 +2497,7 @@
         "updatedAt": "2026-05-07T19:00:22.440Z"
       },
       {
-        "id": 203,
+        "id": "203",
         "title": "Add circuit breakers for Stripe, Azure Translator, and Anthropic APIs",
         "description": "No circuit breaker exists for any external service. When one service is slow or down, every request that touches it hangs until timeout, causing a thundering herd effect that can take down the entire API. One degraded external dependency can cascade into full application unavailability.",
         "details": "Install pybreaker library. Create backend/app/core/circuit_breakers.py defining CircuitBreaker instances: stripe_breaker (fail_max=5, reset_timeout=30), translator_breaker (fail_max=5, reset_timeout=60), anthropic_breaker (fail_max=3, reset_timeout=120). Wrap payment_service.py Stripe calls with @stripe_breaker. Wrap translation_service.py Azure calls with @translator_breaker. Wrap all anthropic.py calls with @anthropic_breaker. When circuit is open, raise HTTP 503 with user-friendly message (e.g., 'Translation service temporarily unavailable, please try again in a few minutes'). Add circuit breaker state to the health check endpoint (/api/v1/utils/health). Log circuit state transitions (closed→open, open→half-open) to Sentry as warnings.",
@@ -2511,7 +2511,7 @@
         "updatedAt": "2026-05-07T19:35:01.875Z"
       },
       {
-        "id": 204,
+        "id": "204",
         "title": "Add React Error Boundary to prevent SPA white-screen crashes",
         "description": "No global React Error Boundary exists at the router root. An unhandled render error (e.g., null-dereference from an unexpected API response shape after transformKeys) crashes the entire SPA with a white screen and no recovery path. Users have no way to navigate away or retry.",
         "details": "Create frontend/src/components/ErrorBoundary/index.tsx as a class component (Error Boundaries must be class components in React). Display a user-friendly fallback UI with: error title, brief message, 'Reload page' button (window.location.reload()), and 'Go to dashboard' link. Capture errors to Sentry in componentDidCatch. Wrap the TanStack Router root outlet in frontend/src/routes/__root.tsx with the ErrorBoundary. Add route-level ErrorBoundary for the document translation routes specifically (highest risk of API shape mismatches). Add a test using React Testing Library that verifies ErrorBoundary renders fallback UI when child throws. Follow IProps interface pattern, PascalCase component name, default export at bottom.",
@@ -2523,7 +2523,7 @@
         "updatedAt": "2026-05-07T07:20:46.456Z"
       },
       {
-        "id": 205,
+        "id": "205",
         "title": "Validate batch translation response length to prevent silent clause misalignment",
         "description": "Azure Translator may return fewer results than texts sent in a batch request. The current index-based mapping silently drops trailing clauses without raising an error. For German legal documents (Kaufvertrag, Grundbuch), missing clauses could cause users to act on incomplete information — a client safety risk.",
         "details": "In backend/app/services/translation_service.py, in the batch translation response loop, add an assertion before mapping: if len(response) != len(texts): raise TranslationError(f'Azure Translator response count mismatch: sent {len(texts)}, received {len(response)} — aborting to prevent clause misalignment'). Add a fallback strategy for partial responses: if partial=True option is set, map only the responses received and mark unmapped texts as 'translation_failed'. Add the check in both the synchronous and async translation paths. Log the full request/response sizes at DEBUG level for observability. Add unit test with a mocked Azure response returning fewer items than sent.",
@@ -2537,7 +2537,7 @@
         "updatedAt": "2026-05-07T19:58:16.966Z"
       },
       {
-        "id": 206,
+        "id": "206",
         "title": "Add HTTP request timeouts to all aiohttp calls in translation service",
         "description": "The aiohttp ClientSession calls in translation_service.py have no explicit timeout. The default is 300 seconds. A slow Azure API response blocks async workers for up to 5 minutes per request, exhausting the event loop and causing all concurrent requests to stall.",
         "details": "In backend/app/services/translation_service.py, create a shared aiohttp.ClientTimeout object: TRANSLATION_TIMEOUT = aiohttp.ClientTimeout(total=60, connect=10, sock_read=50). Pass timeout=TRANSLATION_TIMEOUT to every aiohttp.ClientSession.post() call. Handle asyncio.TimeoutError and aiohttp.ServerTimeoutError specifically — raise TranslationError('Translation request timed out after 60s') with an appropriate user message. Add the timeout constant to backend/app/core/config.py as AZURE_TRANSLATOR_TIMEOUT_SECONDS=60 so it can be configured per environment. Add similar timeout patterns to any other aiohttp usage in the codebase.",
@@ -2551,7 +2551,7 @@
         "updatedAt": "2026-05-07T21:14:54.394Z"
       },
       {
-        "id": 207,
+        "id": "207",
         "title": "Add Stripe webhook idempotency using event deduplication table",
         "description": "Stripe retries webhooks that do not receive a timely 2xx response. The current webhook handler has no idempotency protection — duplicate delivery updates subscription tiers twice and can double-execute billing state transitions. A processed_webhook_events table with a unique constraint on stripe_event_id prevents this.",
         "details": "Create Alembic migration adding a processed_webhook_events table: id (UUID PK), stripe_event_id (VARCHAR unique not null), event_type (VARCHAR), processed_at (TIMESTAMPTZ default now()). In backend/app/api/routes/subscriptions.py webhook handler, before processing: query for existing stripe_event_id. If found, return HTTP 200 immediately (Stripe requires 2xx to stop retries). If not found, insert the event ID within the same transaction as the subscription tier update (atomic). Add a cleanup job (or Alembic migration with trigger) to delete records older than 30 days to prevent table bloat. Write integration tests using Stripe webhook test fixtures.",
@@ -2563,7 +2563,7 @@
         "updatedAt": "2026-05-07T07:33:09.979Z"
       },
       {
-        "id": 208,
+        "id": "208",
         "title": "Implement Azure Translator monthly quota metering and enforcement",
         "description": "Azure Translator free tier allows 2M characters/month. There is no quota tracking in the codebase — mid-month exhaustion causes silent translation failures for all users with no graceful degradation. Users have no warning that the service is near capacity.",
         "details": "In backend/app/services/translation_service.py, track character counts in Redis using a monthly key: translator:chars:{YYYY-MM}. Before each translation, read current count. If count >= AZURE_TRANSLATOR_QUOTA_LIMIT (configurable, default 1_900_000 to leave 5% buffer), return HTTP 429 with message 'Monthly translation quota reached — resets on [first of next month]'. After successful translation, increment Redis counter by character count with EXPIRE set to end of month. Add a daily monitoring alert: if count > 80% of limit, log a WARNING and (optionally) send admin notification. Add GET /api/v1/admin/usage/translator endpoint (admin-only) showing current month usage and percentage. Store AZURE_TRANSLATOR_QUOTA_LIMIT in config.py.",
@@ -2578,7 +2578,7 @@
         "updatedAt": "2026-05-08T10:45:37.071Z"
       },
       {
-        "id": 209,
+        "id": "209",
         "title": "Add APScheduler job failure alerting and health monitoring",
         "description": "The weekly recurring transaction generation job in main.py catches exceptions and logs them, but no alert fires. A failed job goes unnoticed until a user reports missing transactions — potentially a week later. No mechanism exists to detect or recover from silent job failures.",
         "details": "In backend/app/main.py, wrap _run_recurring_generation with enhanced error handling: on exception, send admin alert email via the existing email service (or log to Sentry with level=ERROR and extra={'job': 'recurring_generation', 'alert': True}). Add job execution tracking to Redis: after each run, SET scheduler:last_run:{job_name} to current timestamp with no expiry. Add a health check endpoint that reads these timestamps and flags jobs that have not run in 2x their expected interval (e.g., recurring_generation not run in 14 days). Add a POST /api/v1/admin/jobs/{job_name}/trigger endpoint (admin-only) to manually re-trigger failed jobs. Update APScheduler job to log count=0 as a WARNING (successful run with no transactions is suspicious).",
@@ -2592,7 +2592,7 @@
         "updatedAt": "2026-05-07T21:33:51.848Z"
       },
       {
-        "id": 210,
+        "id": "210",
         "title": "Enforce translation confidence threshold gate before serving results",
         "description": "Low-confidence Azure Translator results are returned as authoritative translations without warning. HeimPath users make real property investment decisions based on translated German legal documents (Kaufvertrag, Grundbuch). A translation confidence of 40% on a legal clause should block display or show a prominent warning — not silently serve potentially wrong text. This is the most significant client safety risk.",
         "details": "In backend/app/services/translation_service.py, add confidence threshold enforcement after receiving Azure response: if any clause confidence_score < TRANSLATION_CONFIDENCE_THRESHOLD (configurable, default 0.70), set requires_manual_review=True on that clause. At document level, if more than 20% of clauses have low confidence, set document.requires_review=True. Add requires_manual_review field to DocumentTranslation and DocumentClause models via Alembic migration. Update API response schemas (DocumentTranslationResponse, ClauseResponse) to include requires_manual_review: bool. Update frontend document viewer to display a prominent warning banner when requires_manual_review=True. Legal term risk detection must run on the original German text (not translated), not after translation, to avoid compounding uncertainty. Add TRANSLATION_CONFIDENCE_THRESHOLD to config.py.",
@@ -2606,7 +2606,7 @@
         "updatedAt": "2026-05-08T06:03:53.747Z"
       },
       {
-        "id": 211,
+        "id": "211",
         "title": "Fix partial document translation save on mid-batch Azure Translator failure",
         "description": "If Azure Translator fails mid-batch during document processing, partial translations are saved to the database and the document may be incorrectly marked COMPLETED. Subsequent clause analysis (Anthropic) then runs on incomplete translated text, producing unreliable risk assessments for users.",
         "details": "In backend/app/services/document_service.py, wrap the entire translation + analysis pipeline in a single database transaction. If any translation batch fails, roll back all partial translations (do not commit intermediate results). Set document.status = DocumentStatus.FAILED with descriptive error_message. Never mark a document as COMPLETED if translation coverage is less than 100% of expected clauses. Add a coverage check: translated_clause_count / expected_clause_count >= 0.95 before allowing COMPLETED status. Add a partial_translation_coverage field to DocumentTranslation model (float 0.0-1.0) so admins can inspect partial work. Ensure the asyncio exception handling in process_document() does not swallow partial state — use a single commit at the end of successful full processing only.",
@@ -2621,7 +2621,7 @@
         "updatedAt": "2026-05-08T11:21:41.371Z"
       },
       {
-        "id": 212,
+        "id": "212",
         "title": "Add market data staleness detection and TTL enforcement",
         "description": "Market comparison data shown to users in property evaluations has no staleness check. Stale market data (weeks or months old) presented alongside property prices can mislead investors about current market conditions. For a platform serving foreign investors making large financial decisions, this is a medium-severity client safety issue.",
         "details": "In backend/app/services/market_comparison_service.py (and related services), add a data_as_of timestamp field to all market data responses. Add a MARKET_DATA_MAX_AGE_DAYS=30 config setting. In the API response schema, include data_freshness: dict with last_updated and is_stale fields. If market data is older than MARKET_DATA_MAX_AGE_DAYS, include a disclaimer in the response: 'Market data last updated X days ago — verify current prices independently'. On the frontend, display a staleness warning badge on market comparison components when is_stale=True. Add a background job or manual trigger to refresh market data. Ensure market data queries include created_at/updated_at filters to surface the most recent records.",
@@ -2633,7 +2633,7 @@
         "updatedAt": "2026-05-07T09:03:13.732Z"
       },
       {
-        "id": 213,
+        "id": "213",
         "title": "Verify and document Neon pgBouncer connection pooling mode",
         "description": "The database connection pool is sized based on the assumption of transaction-pooling mode in Neon pgBouncer. If pgBouncer is operating in session mode (the default), the actual connection ceiling is 5x lower than calculated. This can cause unexplained connection exhaustion under moderate load with no clear error message.",
         "details": "Verify Neon pgBouncer mode via Neon console or by running SHOW server_version; and checking pgBouncer stats. If in session mode: either switch to transaction mode in Neon settings, or reduce pool sizes to (_POOL_SIZE=1, _POOL_MAX_OVERFLOW=1) to avoid exceeding Neon connection limits. If in transaction mode: document this as confirmed in backend/app/core/db.py comment. Add a startup assertion that reads db pool configuration and logs the effective max connections at INFO level: logger.info('DB pool: size=%d, overflow=%d, effective_max=%d * WEB_CONCURRENCY', ...). Update the db.py comment to accurately reflect the Neon tier connection limits. Consider adding a /api/v1/admin/db-pool-stats endpoint showing current pool checkout count.",
@@ -2647,7 +2647,7 @@
         "updatedAt": "2026-05-08T14:19:36.255Z"
       },
       {
-        "id": 214,
+        "id": "214",
         "title": "Add global FastAPI exception handler for unhandled 500 errors",
         "description": "FastAPI has no global exception handler for unhandled exceptions. Unexpected errors surface as unstructured 500 responses with limited context for debugging. Sentry only captures errors that bubble past the ASGI layer, missing errors swallowed inside route handlers. A global handler ensures all 500s are captured, logged, and return a consistent client response.",
         "details": "In backend/app/main.py, add a global exception handler using @app.exception_handler(Exception). The handler should: log the full traceback at ERROR level, capture to Sentry with request context (URL, method, user_id if available), return a standardized JSON response with status 500: {'detail': 'An unexpected error occurred. Our team has been notified.', 'request_id': str(uuid.uuid4())}. Include the request_id in Sentry capture for correlation. Add a separate handler for HTTPException to ensure consistent error format. Add @app.exception_handler(RequestValidationError) to format 422 errors consistently. Test that Sentry receives the error with request context attached.",
@@ -2659,7 +2659,7 @@
         "updatedAt": "2026-05-08T12:22:19.894Z"
       },
       {
-        "id": 215,
+        "id": "215",
         "title": "Add per-query database statement timeout to prevent slow query hangs",
         "description": "No per-query timeout is configured. A single slow database query (unoptimized N+1, full table scan, or lock contention) can hold a connection for an indefinite period, gradually exhausting the connection pool and degrading all other requests without any visibility into which query is the culprit.",
         "details": "In backend/app/core/db.py, add connect_args with statement_timeout for PostgreSQL: connect_args={'options': f'-c statement_timeout={DB_STATEMENT_TIMEOUT_MS}ms'} where DB_STATEMENT_TIMEOUT_MS defaults to 10000 (10 seconds). Add DB_STATEMENT_TIMEOUT_MS to config.py. For document processing routes (longer-running), use execution_options(timeout=60) per-session. Add exception handling for sqlalchemy.exc.OperationalError with 'statement timeout' in message — return HTTP 504 with 'Database query timed out'. Add similar statement_timeout to the async engine in database.py. Log query timeouts to Sentry at WARNING level with the route path for identifying slow endpoints.",
@@ -2673,7 +2673,7 @@
         "updatedAt": "2026-05-12T14:52:19.368Z"
       },
       {
-        "id": 216,
+        "id": "216",
         "title": "Add request timeout middleware to prevent indefinite endpoint hangs",
         "description": "FastAPI endpoints have no per-request timeout. Slow database queries, blocked external API calls, or runaway processing can hang a request indefinitely, holding open connections and blocking worker threads. Under concurrent load, this causes cascading resource exhaustion.",
         "details": "Add a TimeoutMiddleware to backend/app/main.py using anyio or asyncio.wait_for. Set DEFAULT_REQUEST_TIMEOUT=30 seconds for most endpoints. Add DOCUMENT_PROCESSING_TIMEOUT=120 seconds for /documents and /translations routes. Use route path matching in middleware to apply different timeouts. On timeout, cancel the request task and return HTTP 504 with message 'Request timed out — please try again'. Log timeouts to Sentry with endpoint path. Store timeout values in config.py. Consider using starlette-timeout package or implementing as ASGI middleware. Ensure timeout does not fire on WebSocket connections (if any exist).",
@@ -2687,7 +2687,7 @@
         "updatedAt": "2026-05-12T14:52:16.258Z"
       },
       {
-        "id": 217,
+        "id": "217",
         "title": "Add refresh token rotation race condition guard",
         "description": "The refresh token rotation grace window is 30 seconds for concurrent requests. Under load, two simultaneous refresh requests could both pass the JTI blacklist check within the grace period, both issue new tokens, and both invalidate each other — logging users out unexpectedly. A distributed lock prevents this race.",
         "details": "In backend/app/services/auth_service.py, acquire a Redis lock keyed on the refresh token JTI before performing the blacklist check + new token issuance: use redis.set(f'refresh_lock:{jti}', '1', nx=True, ex=35) (35s to cover the grace period). If lock acquisition fails, wait 100ms and retry once — on second failure, return HTTP 429 with 'Token refresh in progress, please retry'. Release the lock after issuing new tokens. This prevents two concurrent refresh requests from both succeeding. Add a unit test simulating concurrent refresh with the same token. Consider using the existing Redis client's lock() method if available, or implement with SET NX EX pattern.",
@@ -2701,7 +2701,7 @@
         "updatedAt": "2026-05-12T17:51:19.444Z"
       },
       {
-        "id": 218,
+        "id": "218",
         "title": "Add JSON request body size limit middleware",
         "description": "FastAPI allows arbitrary JSON request body sizes by default. The document upload endpoint enforces a 20MB file size limit, but all JSON endpoints (including financial calculator inputs, profile updates, search queries) have no size limits. A malicious actor can send a multi-megabyte JSON payload causing memory pressure.",
         "details": "Add a ContentSizeLimitMiddleware to backend/app/main.py that rejects requests with Content-Length greater than MAX_JSON_BODY_SIZE_BYTES (default 1MB = 1_048_576 bytes). Return HTTP 413 Request Entity Too Large for oversized requests. Exempt the /documents/upload endpoint (which handles multipart with its own 20MB limit). Add MAX_JSON_BODY_SIZE_BYTES to config.py. Use starlette ContentSizeLimitMiddleware if available, or implement as ASGI middleware reading Content-Length header. Log rejected requests at WARNING level with client IP and endpoint path.",
@@ -2713,7 +2713,7 @@
         "updatedAt": "2026-05-08T12:59:43.439Z"
       },
       {
-        "id": 219,
+        "id": "219",
         "title": "Decouple APScheduler from web worker process",
         "description": "APScheduler runs inside the FastAPI web worker process in main.py. A memory leak or uncaught exception in the weekly recurring transaction job can destabilize the web worker, causing request failures unrelated to the scheduler. In a multi-worker setup (WEB_CONCURRENCY > 1), the scheduler also runs once per worker, potentially triggering jobs multiple times.",
         "details": "Move the APScheduler recurring transaction job to a dedicated Celery beat schedule (requires task 201 Celery implementation). In compose.yml, add a celery-beat service separate from the celery worker. Remove the APScheduler import and scheduler.start() from backend/app/main.py lifespan. Replace with a Celery periodic task: @app.on_after_finalize.connect + app.conf.beat_schedule. This also makes the job observable via Celery Flower monitoring. Alternatively, if Celery is not yet available, add a leader-election check using Redis SETNX to ensure only one worker instance runs the scheduler (SET scheduler:leader {pod_name} NX EX 86400).",
@@ -2727,7 +2727,7 @@
         "updatedAt": "2026-05-15T19:01:46.672Z"
       },
       {
-        "id": 220,
+        "id": "220",
         "title": "Add TanStack Query retry and staleTime defaults to prevent excessive refetching",
         "description": "Most TanStack Query hooks use no staleTime configuration, causing every component mount to trigger a background refetch. Under poor network conditions, failed queries are also not retried by default. This creates unnecessary API load and a poor UX where stale data flickers on every navigation.",
         "details": "In frontend/src/query/queryKeys.ts or the QueryClient configuration file, set global defaults: defaultOptions: { queries: { staleTime: 5 * 60 * 1000 (5 minutes), retry: 2, retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000), gcTime: 10 * 60 * 1000 } }. Override with shorter staleTime for real-time data (notifications: 30s, document status: 10s). Override with staleTime: Infinity for near-static data (glossary, article categories: currently hardcoded to 30min in useArticleCategories only). Add explicit enabled: !!param guards to all queries that depend on a parameter (e.g., useDocument(id) should have enabled: !!id). Audit all 14 query hook files for missing enabled guards.",
@@ -2739,7 +2739,7 @@
         "updatedAt": "2026-05-08T13:24:24.844Z"
       },
       {
-        "id": 221,
+        "id": "221",
         "title": "Fix auth cookie sync after server-side logout across tabs",
         "description": "The frontend useAuth hook checks for a logged_in cookie to determine authentication state synchronously. If a user is logged out server-side (token expiry, forced logout, account suspension), the cookie check may remain stale — the user sees authenticated UI until their next full page reload or JWT verification fails on an API call.",
         "details": "In frontend/src/hooks/useAuth.ts, add a BroadcastChannel listener (or storage event) so that logout in one tab invalidates auth state in other open tabs. On 401 response from any API call, clear auth state immediately and redirect to login. Add a periodic session validation check: every 5 minutes, call GET /api/v1/users/me silently — on 401, trigger logout flow. In the mutation hooks for logout, invalidate all TanStack Query cache on success (queryClient.clear()). Ensure the logged_in cookie is HttpOnly=false (readable by JS) only for the boolean flag — the actual JWT remains HttpOnly. Document the cookie's purpose and limitations in a code comment.",
@@ -2751,7 +2751,7 @@
         "updatedAt": "2026-05-15T18:57:29.138Z"
       },
       {
-        "id": 222,
+        "id": "222",
         "title": "Enable Sentry error tracking in staging environment",
         "description": "Sentry integration is only configured for production. Staging errors are invisible, making it difficult to catch reliability issues before they reach production. Given the reliability gaps identified in this assessment, staging should be the first environment where errors surface with full context.",
         "details": "In backend/app/main.py Sentry initialization, change the condition from ENVIRONMENT == 'production' to ENVIRONMENT in ('staging', 'production'). Use a separate Sentry DSN for staging (or same DSN with environment tag). Set sentry_sdk.init(..., environment=settings.ENVIRONMENT, ...) so Sentry dashboard can filter by environment. Add SENTRY_DSN to .env.example with staging placeholder comment. In frontend Sentry initialization (if present), apply the same staging inclusion. Set sample_rate=1.0 for staging (capture all errors) vs traces_sample_rate=0.1 for production. Add SENTRY_DSN to the staging Azure Container App environment variables in Terraform.",
@@ -2763,7 +2763,7 @@
         "updatedAt": "2026-05-12T14:52:16.301Z"
       },
       {
-        "id": 223,
+        "id": "223",
         "title": "Add server-side range validation for financial calculator inputs",
         "description": "Financial calculator endpoints (property cost, ROI, mortgage) accept user-supplied numeric inputs with no server-side range validation. Extreme values (property price of 1 or 999_999_999_999) produce mathematically valid but nonsensical results. Users may misinterpret calculation results based on erroneous inputs.",
         "details": "In backend/app/schemas/calculator.py (or equivalent calculator schemas), add Field validators with min/max ranges: property_price: float = Field(..., gt=0, le=100_000_000) (max 100M EUR), down_payment_percent: float = Field(..., ge=0, le=100), loan_term_years: int = Field(..., ge=1, le=50), interest_rate: float = Field(..., ge=0, le=30), monthly_rent: float = Field(..., ge=0, le=100_000). Add a @model_validator to check cross-field logic: down_payment cannot exceed property_price. Return HTTP 422 with descriptive validation messages for out-of-range inputs. Add constants file (e.g., backend/app/constants/calculator.py) defining GERMAN_PROPERTY_PRICE_MAX_EUR = 100_000_000 with explanatory comments. Mirror these limits in frontend form validation.",
@@ -2775,7 +2775,7 @@
         "updatedAt": "2026-05-12T15:07:17.583Z"
       },
       {
-        "id": 224,
+        "id": "224",
         "title": "Sanitize Pydantic validation error messages to avoid exposing internal field names",
         "description": "The frontend extractErrorMessage function returns raw Pydantic validation array item errDetail[0]?.msg. Pydantic 422 error responses include internal field path information (e.g., body.hashed_password, body.stripe_customer_id) that reveals database schema structure. This is a minor information disclosure risk.",
         "details": "In backend/app/main.py, add a custom @app.exception_handler(RequestValidationError) that intercepts 422 errors. Map internal field names to user-friendly field names using a sanitization dict (e.g., 'hashed_password' -> 'password', 'stripe_customer_id' -> omit). Return simplified error messages: {'detail': [{'field': 'email', 'message': 'Invalid email format'}]} without exposing body.field.path structure. In frontend/src/utils.ts extractErrorMessage, update to use the sanitized field name from the new format. Add to global exception handler task (214) or implement as standalone. Add unit tests verifying no internal field names in 422 responses.",
@@ -2789,7 +2789,7 @@
         "updatedAt": "2026-05-08T14:08:02.756Z"
       },
       {
-        "id": 225,
+        "id": "225",
         "title": "Implement backwards-compatible Alembic migration discipline for zero-downtime deploys",
         "description": "The prestart container runs Alembic migrations on every deploy. If a migration adds a NOT NULL column without a default, the old container still running will fail to write rows, causing data loss. Azure Container Apps rolling deploy means old and new containers run simultaneously during migration. No documented backwards-compatibility policy exists.",
         "details": "Add a migrations/README.md documenting the 3-phase migration strategy: Phase 1 deploy — add nullable column or with default (old code works). Phase 2 deploy — backfill existing rows, add NOT NULL constraint. Phase 3 deploy — remove old column if any. Add a pre-commit hook or CI check that flags migrations adding NOT NULL columns without server_default. Add a check in the prestart script: if migration fails, exit with code 1 to prevent the new container from starting (already done via depends_on). Add a migration naming convention check to CI: alembic revision should include JIRA/task number. Add a rollback runbook to docs/ covering how to revert the last migration on Neon. Document which migrations are destructive (DROP COLUMN, DROP TABLE) requiring maintenance windows.",
@@ -2801,7 +2801,7 @@
         "updatedAt": "2026-05-07T09:49:40.930Z"
       },
       {
-        "id": 226,
+        "id": "226",
         "title": "Fix WEB_CONCURRENCY default in production Docker image",
         "description": "The backend Dockerfile CMD defaults WEB_CONCURRENCY to 1 (sh -c \"fastapi run --workers ${WEB_CONCURRENCY:-1}\"). If the environment variable is not set in the Azure Container App, the production API runs single-threaded, significantly under-utilizing available CPU and causing unnecessary request queuing under moderate load.",
         "details": "In backend/Dockerfile, change the default WEB_CONCURRENCY from 1 to 2: CMD [\"sh\", \"-c\", \"fastapi run --workers ${WEB_CONCURRENCY:-2} app/main.py\"]. Verify compose.yml already sets WEB_CONCURRENCY=2 explicitly — good. Verify the Azure Container App Terraform definition sets WEB_CONCURRENCY as an environment variable. Add WEB_CONCURRENCY to .env.example with recommended values for each environment (local=1, staging=2, production=2). Add a startup log line confirming the worker count: logger.info('Starting with %s workers', os.environ.get('WEB_CONCURRENCY', 2)). Recalculate DB pool sizing with WEB_CONCURRENCY=2: (3+5) * 2 = 16 connections per replica — ensure this fits within Neon tier limits.",
@@ -2815,7 +2815,7 @@
         "updatedAt": "2026-05-12T11:39:59.488Z"
       },
       {
-        "id": 227,
+        "id": "227",
         "title": "Add Redis circuit breaker to prevent auth blocking on Redis degradation",
         "description": "Redis operations in auth_service.py and rate_limit_service.py have no circuit breaker. If Redis is slow (not down — down is handled by the fakeredis fallback), every authentication request blocks waiting for Redis timeout. Under Redis degradation, login/logout/rate-check operations can each take seconds, effectively DDoS-ing auth endpoints.",
         "details": "Add a redis_breaker CircuitBreaker instance in backend/app/core/circuit_breakers.py (from task 203): redis_breaker = CircuitBreaker(fail_max=10, reset_timeout=15). Wrap all Redis operations in redis_client.py with @redis_breaker. When circuit is open: for rate limiting, ALLOW the request (fail-open, log at WARNING). For token blacklist checks, DENY the operation if invalidating (fail-safe for logout) and ALLOW for validation (fail-open, accept the risk). Log all circuit state transitions at WARNING to Sentry. Add a redis_circuit_state to the /health check endpoint. Set Redis operation timeout: redis.set(..., socket_timeout=0.5) for all Redis client calls (500ms max wait).",
@@ -2830,7 +2830,7 @@
         "updatedAt": "2026-05-08T11:57:34.102Z"
       },
       {
-        "id": 228,
+        "id": "228",
         "title": "Evaluate Azure Key Vault for secrets management",
         "description": "All secrets (STRIPE_SECRET_KEY, ANTHROPIC_API_KEY, AZURE_TRANSLATOR_KEY, SECRET_KEY, POSTGRES_PASSWORD) are stored as plain text environment variables in Azure Container Apps and the local .env file. If env var logging is accidentally enabled or a container is compromised, all secrets are exposed simultaneously.",
         "details": "Research and evaluate Azure Key Vault for secret storage. Create an ADR (Architecture Decision Record) in docs/adr/ covering: cost (Key Vault standard tier ~$0.03/10K operations), complexity (requires managed identity setup), benefits (audit logs, secret rotation, access policies). If approved: provision Azure Key Vault via Terraform in infra/terraform/. Configure Managed Identity for the Container App with Key Vault Reader role. Update container app to reference Key Vault secrets via @Microsoft.KeyVault() references in environment variables. Start with the highest-sensitivity secrets: STRIPE_SECRET_KEY, ANTHROPIC_API_KEY. Leave DB password and REDIS_PASSWORD as direct env vars initially (lower risk). Add Key Vault access monitoring in Azure Monitor.",
@@ -2842,7 +2842,7 @@
         "updatedAt": "2026-05-15T18:40:43.519Z"
       },
       {
-        "id": 229,
+        "id": "229",
         "title": "Add graceful degradation for DB connection pool exhaustion",
         "description": "When the DB connection pool times out (after 30s), requests fail with sqlalchemy.exc.TimeoutError which bubbles as an unstructured 500. There is no retry, circuit breaker, or graceful 503 response. Under spike traffic, pool exhaustion cascades — every queued request hits the same timeout wall simultaneously, compounding load rather than shedding it.",
         "details": "In backend/app/api/deps.py, wrap the session yielding with exception handling for sqlalchemy.exc.TimeoutError: catch it and raise HTTPException(status_code=503, detail='Service temporarily unavailable — please retry in a moment', headers={'Retry-After': '5'}). Add a DB pool health check to the /api/v1/utils/health endpoint: attempt pool.checkin() or a simple SELECT 1 with a 2s timeout. If pool is exhausted, health check returns 503 (enabling Azure Container Apps load balancer to stop sending traffic). Add POOL_EXHAUSTION_BACKOFF_SECONDS=5 to config.py. Log pool exhaustion events to Sentry at WARNING with pool stats (current checkout count vs max). Consider adding a pool event listener via @event.listens_for(engine, 'checkout') to track pool pressure over time.",
@@ -2856,7 +2856,7 @@
         "updatedAt": "2026-05-12T11:25:29.904Z"
       },
       {
-        "id": 230,
+        "id": "230",
         "title": "Make notification delivery failures observable and retryable",
         "description": "Document translation completion triggers a notification, but notification service failures are silently swallowed in a bare except block. The document is marked COMPLETED and the user is never informed — they must manually check back. No retry mechanism or visibility into delivery failures exists.",
         "details": "In backend/app/services/document_service.py, replace the bare except around notification creation with specific exception handling. On notification failure: log at ERROR level to Sentry (not just logger.exception), include document_id and user_id in context. Add a failed_notification_at timestamp field to the Document model via Alembic migration. Add a retry mechanism: on first notification failure, set a retry_notification_at = now() + 5 minutes. Add a background Celery task (or APScheduler job polling every 10 minutes) that queries documents with failed_notification_at IS NOT NULL and retry_notification_at <= now() and retries delivery up to 3 times. After 3 failures, mark notification_status='failed' and surface in admin dashboard. This pattern prevents silent notification loss without making document COMPLETED status dependent on notification delivery.",
@@ -2871,7 +2871,7 @@
         "updatedAt": "2026-05-12T18:34:20.732Z"
       },
       {
-        "id": 231,
+        "id": "231",
         "title": "[Reliability] P1: Add pybreaker dependency",
         "description": "Add pybreaker circuit-breaker library to backend/pyproject.toml and sync the workspace lock file.",
         "details": "File: backend/pyproject.toml. Add \"pybreaker>=1.2.0,<2.0.0\" to [project.dependencies]. Run uv sync from workspace root (NOT from backend/) to update root uv.lock — root uv.lock is authoritative per project conventions. Verify: cd backend && python -c \"import pybreaker; print(pybreaker.__version__)\".",
@@ -2883,7 +2883,7 @@
         "updatedAt": "2026-05-07T09:49:38.866Z"
       },
       {
-        "id": 232,
+        "id": "232",
         "title": "[Reliability] P1: Add 4 reliability settings to config.py",
         "description": "Extend Settings class in backend/app/core/config.py with four new reliability-related configuration fields after MAX_PAGES_PREMIUM.",
         "details": "Add after MAX_PAGES_PREMIUM: TRANSLATION_CONFIDENCE_THRESHOLD: float = 0.70 | AZURE_TRANSLATOR_TIMEOUT_SECONDS: int = 60 | MAX_JSON_BODY_SIZE_BYTES: int = 1_048_576 (1 MB JSON limit) | DB_STATEMENT_TIMEOUT_MS: int = 10_000 (10-second query timeout). These are read from environment variables by pydantic-settings. Do NOT add model_validators — they have safe defaults.",
@@ -2895,7 +2895,7 @@
         "updatedAt": "2026-05-07T09:49:38.957Z"
       },
       {
-        "id": 233,
+        "id": "233",
         "title": "[Reliability] P2: Create circuit_breakers.py",
         "description": "Create backend/app/core/circuit_breakers.py with module-level pybreaker singletons for Stripe, Azure Translator, and Anthropic. Must NOT import from app.services to avoid circular imports.",
         "details": "Create three pybreaker.CircuitBreaker singletons: stripe_breaker, translator_breaker, anthropic_breaker — each with fail_max=5, reset_timeout=60. Add a _LoggingListener that logs state changes (WARNING) and failures (ERROR). Only import pybreaker and logging. Import as: from app.core.circuit_breakers import stripe_breaker. Use breaker.call() for sync, breaker.call_async() for async at call sites.",
@@ -2909,7 +2909,7 @@
         "updatedAt": "2026-05-07T10:27:20.045Z"
       },
       {
-        "id": 234,
+        "id": "234",
         "title": "[Reliability] P2: Create reliability.py with tenacity retry decorators",
         "description": "Create backend/app/core/reliability.py with named tenacity retry decorator instances for Stripe, Azure Translator, and Anthropic. Tenacity is already in pyproject.toml — do not add it again.",
         "details": "Define three predicate functions: _is_transient_stripe_error (stripe.APIConnectionError|APITimeoutError|RateLimitError), _is_transient_translator_error (aiohttp.ClientConnectionError or TranslationError with 429/503/504 in message — lazy import to avoid circular), _is_transient_anthropic_error (anthropic.APIConnectionError|APITimeoutError|RateLimitError). Create retry decorators: stripe_retry (stop=3 attempts, wait=exponential_jitter initial=1 max=10), translator_retry (stop=3, initial=1 max=15), anthropic_retry (stop=2, initial=2 max=20). All use reraise=True and before_sleep_log.",
@@ -2923,7 +2923,7 @@
         "updatedAt": "2026-05-07T10:27:20.096Z"
       },
       {
-        "id": 235,
+        "id": "235",
         "title": "[Reliability] P2: Create ASGI middleware.py (request logging + content size limit)",
         "description": "Create backend/app/core/middleware.py with two ASGI middlewares: RequestLoggingMiddleware and ContentSizeLimitMiddleware.",
         "details": "RequestLoggingMiddleware: generate UUID4 request ID, set scope['state']['request_id'], append X-Request-ID response header, log 'request started method/path' on receive and 'request completed status elapsed_ms' on send. ContentSizeLimitMiddleware: for application/json requests only — read Content-Length header; return 413 JSON {detail: 'Request body too large'} if > settings.MAX_JSON_BODY_SIZE_BYTES; skip multipart/form-data entirely; if no Content-Length header pass through. Both are class-based ASGI middlewares.",
@@ -2937,7 +2937,7 @@
         "updatedAt": "2026-05-07T10:27:20.150Z"
       },
       {
-        "id": 236,
+        "id": "236",
         "title": "[Reliability] P3: Create AuditLog SQLAlchemy model",
         "description": "Create backend/app/models/audit_log.py with the AuditLog table for regulatory-grade audit trail. Audit records must survive user deletion.",
         "details": "Class AuditLog(UUIDPrimaryKeyMixin, TimestampMixin, Base), __tablename__='audit_log'. Columns: user_id UUID FK to user.id with ondelete='SET NULL' nullable=True index=True; action String(100) non-null index=True; resource_type String(50) nullable index=True; resource_id String(100) nullable; ip_address String(45) nullable (45 chars for IPv6); request_id String(36) nullable; status String(20) non-null default='success'; metadata JSONB nullable. ondelete=SET NULL is critical — audit records must outlive users for regulatory compliance.",
@@ -2949,7 +2949,7 @@
         "updatedAt": "2026-05-07T10:27:20.161Z"
       },
       {
-        "id": 237,
+        "id": "237",
         "title": "[Reliability] P3: Add confidence columns to DocumentTranslation model",
         "description": "Add requires_manual_review and translation_confidence_score columns to DocumentTranslation in backend/app/models/document.py.",
         "details": "Add to DocumentTranslation class: requires_manual_review = Column(Boolean, nullable=False, default=False, server_default='false') and translation_confidence_score = Column(Float, nullable=True). Import Boolean and Float from sqlalchemy. server_default='false' ensures backwards compatibility — existing rows get False without migration backfill. translation_confidence_score is nullable so existing rows correctly show NULL (confidence unknown, not zero). These fields are populated by document_service.process_document() after translation completes.",
@@ -2961,7 +2961,7 @@
         "updatedAt": "2026-05-07T10:27:20.170Z"
       },
       {
-        "id": 238,
+        "id": "238",
         "title": "[Reliability] P3: Register AuditLog in models/__init__.py",
         "description": "Import AuditLog from app.models.audit_log and add it to __all__ in backend/app/models/__init__.py so Alembic autogenerate detects the new table.",
         "details": "Add: from app.models.audit_log import AuditLog. Add 'AuditLog' to __all__. Place import alphabetically with other model imports. Alembic env.py imports all models via app.models — AuditLog must be in __all__ for autogenerate to detect it.",
@@ -2975,7 +2975,7 @@
         "updatedAt": "2026-05-07T10:27:20.175Z"
       },
       {
-        "id": 239,
+        "id": "239",
         "title": "[Reliability] P3: Create Alembic migration for reliability safeguards",
         "description": "Create a reversible Alembic migration that adds audit_log table and two new columns on document_translation.",
         "details": "Run: python -m alembic revision --autogenerate -m 'reliability_safeguards' from backend/. upgrade(): op.add_column('document_translation', sa.Column('requires_manual_review', sa.Boolean(), nullable=False, server_default='false')); op.add_column('document_translation', sa.Column('translation_confidence_score', sa.Float(), nullable=True)); op.create_table('audit_log', all columns, FK user_id with ondelete=SET NULL); create indexes on user_id, action, resource_type, created_at. downgrade(): drop indexes, drop audit_log table, drop both columns from document_translation. Verify: alembic upgrade head then downgrade -1 then upgrade head again.",
@@ -2991,7 +2991,7 @@
         "updatedAt": "2026-05-07T10:27:20.182Z"
       },
       {
-        "id": 240,
+        "id": "240",
         "title": "[Reliability] P4: Create audit_service.py with fire-and-forget log_action()",
         "description": "Create backend/app/services/audit_service.py with action constants and a log_action() function that NEVER raises under any circumstances.",
         "details": "Define ACTION_* constants: document.upload, document.delete, document.share, translation.start, translation.complete, translation.failed, payment.checkout_created, payment.webhook_received, payment.subscription_upgraded, user.password_reset, user.email_verified. Function: log_action(session: Session, *, action, user_id=None, resource_type=None, resource_id=None, status='success', metadata=None, request=None) -> None. Extract ip_address from request.client.host and request_id from request.state.request_id. Entire body wrapped in try/except — swallow all exceptions and log them. On DB error: rollback inside nested try/except. Uses sync Session (sqlmodel) not async.",
@@ -3007,7 +3007,7 @@
         "updatedAt": "2026-05-07T10:49:58.993Z"
       },
       {
-        "id": 241,
+        "id": "241",
         "title": "[Reliability] P4: Hard-fail Redis in non-local environments",
         "description": "Modify backend/app/services/redis_client.py to raise RuntimeError instead of silently falling back to fakeredis in staging/production environments.",
         "details": "In get_redis() except block: if settings.ENVIRONMENT \\!= 'local': raise RuntimeError(f'Redis unavailable at {settings.REDIS_URL} in {settings.ENVIRONMENT} environment — configure REDIS_URL or provision Redis.') from exc. Keep fakeredis fallback for local only (developer convenience). Problem: fakeredis is in-memory per-process — in production with multiple replicas, logout token blacklist and rate limits are ineffective across replicas. Update docstring to reflect new behavior. Test: staging env with Redis down raises RuntimeError; local env with Redis down falls back to fakeredis.",
@@ -3021,7 +3021,7 @@
         "updatedAt": "2026-05-07T10:27:20.187Z"
       },
       {
-        "id": 242,
+        "id": "242",
         "title": "[Reliability] P5: Harden translation_service.py (timeout + retry + CB + confidence gate + batch validation)",
         "description": "Add 60-second HTTP timeout, tenacity retries, circuit breaker protection, low-confidence review gating, and batch response length validation to backend/app/services/translation_service.py.",
         "details": "1. HTTP Timeout: add aiohttp.ClientTimeout(total=settings.AZURE_TRANSLATOR_TIMEOUT_SECONDS) to all ClientSession instantiations in _make_request, _make_batch_request, _make_detect_request. 2. Retry+CB: extract HTTP logic to _execute_translate_http(); wrap with translator_retry and translator_breaker.call_async(); catch pybreaker.CircuitBreakerError -> raise TranslationError('Azure Translator circuit open'). Apply same pattern to batch and detect methods. 3. Confidence gate in translate_with_warnings(): if result.confidence < settings.TRANSLATION_CONFIDENCE_THRESHOLD: requires_review = True (in addition to high-risk term check). 4. Batch length validation in batch_translate(): if len(response) \\!= len(texts): raise TranslationError(f'Batch response mismatch: sent {len(texts)}, received {len(response)}'). IMPORTANT: Avoid SonarCloud S1244 — no == or \\!= with floats; use < comparison only.",
@@ -3037,7 +3037,7 @@
         "updatedAt": "2026-05-07T10:27:20.197Z"
       },
       {
-        "id": 243,
+        "id": "243",
         "title": "[Reliability] P5: Add idempotency key, retry, and circuit breaker to payment_service.py",
         "description": "Harden Stripe integration in backend/app/services/payment_service.py with deterministic idempotency keys, tenacity retry, and circuit breaker protection.",
         "details": "1. Idempotency key in create_checkout_session(): idempotency_key = hashlib.sha256(f'checkout:{user_id}:{tier.value}'.encode()).hexdigest()[:40]; pass as idempotency_key= to stripe.checkout.Session.create(). Prevents duplicate sessions on double-click. 2. Retry+CB: wrap stripe.checkout.Session.create(), stripe.Customer.create(), stripe.billing_portal.Session.create() with stripe_retry decorator and stripe_breaker.call() (sync — Stripe SDK is synchronous). Catch pybreaker.CircuitBreakerError -> raise CheckoutSessionError('Stripe circuit breaker is open'). Keep existing stripe.StripeError -> PaymentError mapping for non-transient errors.",
@@ -3052,7 +3052,7 @@
         "updatedAt": "2026-05-07T10:27:20.204Z"
       },
       {
-        "id": 244,
+        "id": "244",
         "title": "[Reliability] P5: Single-transaction processing + confidence persistence in document_service.py",
         "description": "Restructure process_document() in backend/app/services/document_service.py for single final commit, add Anthropic circuit breaker, and persist confidence fields on DocumentTranslation.",
         "details": "1. Single-transaction: commit PROCESSING immediately; accumulate ALL results in local variables; single final commit with COMPLETED status + translation + both new fields. 2. Helpers: _compute_requires_review(translations) -> bool (any confidence < threshold); _compute_avg_confidence(translations) -> float|None (average, None if empty). 3. Anthropic CB: wrap analyze_clause_risks() and analyze_document_type() with anthropic_breaker.call_async() and anthropic_retry; catch CircuitBreakerError -> log warning and use heuristic fallback (clauses still have heuristic confidence). 4. Batch length validation before mapping translations to pages. 5. Set translation.requires_manual_review and translation.translation_confidence_score on the DocumentTranslation object before final commit. Avoid SonarCloud S1244 — no float == or !=.",
@@ -3069,7 +3069,7 @@
         "updatedAt": "2026-05-07T10:27:20.213Z"
       },
       {
-        "id": 245,
+        "id": "245",
         "title": "[Reliability] P5: Add property_price range validators to calculator schemas",
         "description": "Add le=100_000_000 upper bound to property_price in HiddenCostCalculationCreate and in the state comparison route query parameter in backend/app/schemas/calculator.py and the calculator routes.",
         "details": "File: backend/app/schemas/calculator.py — update HiddenCostCalculationCreate: property_price: float = Field(..., gt=0, le=100_000_000, description='Property price in EUR, max 100M'). The gt=0 already exists — only add le=. Also update the state comparison endpoint in backend/app/api/routes/calculators.py: property_price: float = Query(..., gt=0, le=100_000_000). This prevents nonsensical inputs producing misleading calculation outputs. Test: price=0 -> 422, price=-50000 -> 422, price=200_000_000 -> 422, price=1 -> valid, price=100_000_000 -> valid, state_code='BAY' (3 chars) -> 422.",
@@ -3081,7 +3081,7 @@
         "updatedAt": "2026-05-07T10:27:20.220Z"
       },
       {
-        "id": 246,
+        "id": "246",
         "title": "[Reliability] P6: Register middleware and global exception handler in main.py",
         "description": "Update backend/app/main.py to register both new ASGI middlewares, add a global 500 exception handler with request_id, and add Sentry capture to the APScheduler failure handler.",
         "details": "1. Register middlewares (LIFO — last added = outermost): add ContentSizeLimitMiddleware first, then RequestLoggingMiddleware; import from app.core.middleware. Execution order: CORS -> ContainerAppsProxy -> RequestLogging -> ContentSizeLimit. 2. Global exception handler: @app.exception_handler(Exception) async def global_exception_handler(request, exc) -> JSONResponse: get request_id from request.state or generate new UUID; logger.exception(...); return JSONResponse(status_code=500, content={'detail': 'An unexpected error occurred. Please try again.', 'request_id': request_id}). 3. Scheduler alerting: in _run_recurring_generation() except block add: if settings.SENTRY_DSN and settings.ENVIRONMENT \\!= 'local': import sentry_sdk; sentry_sdk.capture_exception().",
@@ -3096,7 +3096,7 @@
         "updatedAt": "2026-05-07T10:27:20.628Z"
       },
       {
-        "id": 247,
+        "id": "247",
         "title": "[Reliability] P6: Add rate limiting and audit logging to documents.py routes",
         "description": "Add per-user rate limiting (10 uploads/hour) and audit logging to upload and delete endpoints in backend/app/api/routes/documents.py.",
         "details": "Add Request param and sync SessionDep alongside existing AsyncSessionDep. Rate limiting with custom prefixes DOC_UPLOAD_ATTEMPT_PREFIX='api:ratelimit:doc_upload:attempts:' and DOC_UPLOAD_LOCKOUT_PREFIX='api:ratelimit:doc_upload:lockout:', limit=10, window=3600s. Check rate limit BEFORE file processing (fail fast). On limit exceeded raise HTTP 429. After successful upload: audit_service.log_action(db, action=ACTION_DOCUMENT_UPLOAD, user_id=current_user.id, resource_type='document', resource_id=str(document.id), request=request, metadata={'filename': file.filename, 'page_count': document.page_count}). After successful delete: audit_service.log_action with ACTION_DOCUMENT_DELETE. Audit only on success. Check actual rate_limit_service API and adapt call signature accordingly. SonarCloud S8410: use Annotated[] for Depends() params.",
@@ -3111,7 +3111,7 @@
         "updatedAt": "2026-05-07T10:27:20.802Z"
       },
       {
-        "id": 248,
+        "id": "248",
         "title": "[Reliability] P6: Add rate limiting to translations.py routes",
         "description": "Add per-user rate limiting (50 requests/hour) to translate_text and batch_translate endpoints in backend/app/api/routes/translations.py.",
         "details": "Apply same pattern as documents.py. Prefixes: TRANSLATION_ATTEMPT_PREFIX='api:ratelimit:translation:attempts:', TRANSLATION_LOCKOUT_PREFIX='api:ratelimit:translation:lockout:', limit=50, window=3600s. Apply to translate_text() and batch_translate() endpoints only — detect_language does NOT need rate limiting. Add Request param to both rate-limited endpoints. Key by user ID (not IP) for consistent per-user quota. SonarCloud S8410: use Annotated[] for Depends() params.",
@@ -3125,7 +3125,7 @@
         "updatedAt": "2026-05-07T10:27:20.818Z"
       },
       {
-        "id": 249,
+        "id": "249",
         "title": "[Reliability] P6: Structured health check endpoint in utils.py",
         "description": "Replace the boolean health check with a structured HealthCheckResponse in backend/app/api/routes/utils.py that checks DB, Redis, and circuit breaker states.",
         "details": "New HealthCheckResponse schema: status: Literal['healthy','degraded'], database: Literal['ok','error'], redis: Literal['ok','error'], circuit_breakers: dict[str,str] (name -> 'closed'|'open'|'half_open'). Endpoint: try SELECT 1 for DB check; try get_redis().ping() for Redis; read stripe_breaker.current_state.name, translator_breaker.current_state.name, anthropic_breaker.current_state.name. Return 'degraded' if any component errors. Return HTTP 200 even when degraded (monitoring systems need to read the body). No authentication required. SonarCloud S8409: remove response_model= if return annotation specifies it; prefer return annotation only.",
@@ -3141,7 +3141,7 @@
         "updatedAt": "2026-05-07T10:27:20.840Z"
       },
       {
-        "id": 250,
+        "id": "250",
         "title": "[Reliability] P6: Update frontend query client with exponential backoff and no 4xx retry",
         "description": "Replace retry:1 in frontend/src/query/client.ts with a smart retry policy: never retry 4xx client errors (deterministic), retry server errors up to 3 times with exponential backoff.",
         "details": "Add shouldRetry function: (failureCount, error) => if error instanceof ApiError && error.status >= 400 && status < 500 return false; return failureCount < 3. Add retryDelay function: (failureCount) => Math.min(1000 * 2 ** (failureCount - 1), 30_000). Backoff: 1s, 2s, 4s, capped at 30s. Replace retry:1 with retry:shouldRetry and retryDelay in QueryClient defaultOptions.queries. Verify existing 401 -> login redirect behavior is not broken.",
@@ -3153,7 +3153,7 @@
         "updatedAt": "2026-05-07T10:27:20.852Z"
       },
       {
-        "id": 251,
+        "id": "251",
         "title": "[Reliability] P6: Create React ErrorBoundary component",
         "description": "Create frontend/src/components/Common/ErrorBoundary/index.tsx — a class-based React error boundary that catches render errors, reports to Sentry, and shows a user-friendly fallback with Try Again and Reload Page buttons.",
         "details": "Must be a class component (React requirement for error boundaries). Interface IProps { children: ReactNode; fallback?: ReactNode }. Interface IState { hasError: boolean; eventId: string | null }. Implement getDerivedStateFromError() returning { hasError: true, eventId: null }. Implement componentDidCatch(error, info): call Sentry.captureException(error, {extra: {componentStack: info.componentStack}}) and setState({eventId}). Render: if hasError show fallback UI with Tailwind classes (no hardcoded hex), error message, Sentry eventId reference, Try Again button (resets state), Reload Page button (window.location.reload()); else return children. Custom fallback prop overrides default UI. SonarCloud S6759: use Readonly<IProps> in class signature. Default export at bottom. No React.FC, no any.",
@@ -3165,7 +3165,7 @@
         "updatedAt": "2026-05-07T10:27:20.887Z"
       },
       {
-        "id": 252,
+        "id": "252",
         "title": "[Reliability] P6: Wrap Outlet with ErrorBoundary in __root.tsx",
         "description": "Update frontend/src/routes/__root.tsx to wrap <Outlet /> with the new ErrorBoundary so React render errors show a fallback instead of a blank screen.",
         "details": "Import: import ErrorBoundary from '@/components/Common/ErrorBoundary'. In component return, wrap <Outlet /> with <ErrorBoundary><Outlet /></ErrorBoundary>. Do NOT remove the existing errorComponent — it handles TanStack Router async/loader errors. ErrorBoundary handles React render-phase errors. They are complementary. TypeScript must compile without errors.",
@@ -3179,7 +3179,7 @@
         "updatedAt": "2026-05-07T10:27:20.893Z"
       },
       {
-        "id": 253,
+        "id": "253",
         "title": "[Reliability] P7: Tests — audit_service.py (4 tests)",
         "description": "Create backend/tests/services/test_audit_service.py with 4 test cases covering the audit_service fire-and-forget behavior.",
         "details": "Tests required: (1) test_writes_audit_log_to_db: happy path — log_action writes a row with correct action to audit_log table. (2) test_never_raises_on_db_error: monkeypatch session.add to raise RuntimeError — verify no exception propagates from log_action. (3) test_extracts_ip_from_request: mock Request with client.host='1.2.3.4' and state.request_id='test-uuid-123' — verify ip_address and request_id are written correctly. (4) test_handles_none_user_id: call with user_id=None — verify row is created with null user_id. Use the existing sync DB session fixture from the test suite.",
@@ -3194,7 +3194,7 @@
         "updatedAt": "2026-05-07T10:49:59.061Z"
       },
       {
-        "id": 254,
+        "id": "254",
         "title": "[Reliability] P7: Tests — middleware.py (5 tests)",
         "description": "Create backend/tests/core/test_middleware.py with 5 tests covering request ID header and content size enforcement.",
         "details": "Tests required: (1) test_response_has_request_id_header: any request -> response has X-Request-ID header of length 36 (UUID4). (2) test_two_requests_get_different_ids: two sequential requests -> different X-Request-ID values. (3) test_small_json_passes: small JSON body -> not 413. (4) test_large_json_body_returns_413: 2MB Content-Type:application/json with Content-Length header -> 413 response. (5) test_multipart_passes_regardless_of_size: large multipart file upload -> not 413 (may be 400 for invalid PDF but never 413). Use FastAPI TestClient or httpx AsyncClient.",
@@ -3209,7 +3209,7 @@
         "updatedAt": "2026-05-07T10:27:20.901Z"
       },
       {
-        "id": 255,
+        "id": "255",
         "title": "[Reliability] P7: Tests — calculator property_price validation (6 tests)",
         "description": "Create backend/tests/services/test_calculator_validation.py with 6 boundary tests for the property_price field range validators.",
         "details": "Tests (direct schema instantiation via pydantic ValidationError): (1) test_property_price_zero_is_invalid: price=0 raises ValidationError. (2) test_property_price_negative_is_invalid: price=-50000 raises ValidationError. (3) test_property_price_over_100m_is_invalid: price=200_000_000 raises ValidationError. (4) test_property_price_one_is_valid: price=1 -> calc.property_price == 1. (5) test_property_price_100m_is_valid: price=100_000_000 -> valid. (6) test_state_code_three_chars_is_invalid: state_code='BAY' raises ValidationError. Also add an API-level test using TestClient for the state comparison endpoint with property_price=0 -> HTTP 422.",
@@ -3223,7 +3223,7 @@
         "updatedAt": "2026-05-07T10:27:20.912Z"
       },
       {
-        "id": 256,
+        "id": "256",
         "title": "[Reliability] P7: Tests — extend translation_service tests (5 new tests)",
         "description": "Add 5 new test cases to backend/tests/services/test_translation_service.py covering confidence gating, timeout, retry-on-503, and batch length mismatch.",
         "details": "New tests to add: (1) test_low_confidence_sets_requires_review: mock _make_request returning score=0.55 -> result.requires_review is True. (2) test_high_confidence_no_review: score=0.99, no high-risk terms in text -> requires_review is False. (3) test_timeout_raises_translation_error: mock _execute_translate_http raising aiohttp.ServerTimeoutError -> TranslationError raised. (4) test_retries_on_503: flaky function raises TranslationError('status 503') on first call, succeeds on second -> assert called twice (retry happened). (5) test_batch_response_length_mismatch_raises: mock _make_batch_request returning 3 items for 5 input texts -> TranslationError with 'Batch response mismatch'. All existing tests must continue to pass.",
@@ -3237,7 +3237,7 @@
         "updatedAt": "2026-05-07T10:27:20.919Z"
       },
       {
-        "id": 257,
+        "id": "257",
         "title": "[Reliability] P7: Tests — extend document route tests (upload rate limit 429)",
         "description": "Add test_upload_rate_limit_triggers_429 to backend/tests/api/routes/test_documents.py verifying that a rate-limited user gets HTTP 429 on document upload.",
         "details": "Test: monkeypatch rate_limit_service._check_limit to return an object with is_locked=True. POST to /api/v1/documents/upload with valid auth headers and a minimal PDF file. Assert response.status_code == 429 and 'rate limit' in response.json()['detail'].lower(). Adapt the mock to match the actual return type of _check_limit by reading rate_limit_service source first. Test must be deterministic — must not actually call Redis. All existing document tests must continue to pass.",
@@ -3252,7 +3252,7 @@
         "updatedAt": "2026-05-07T10:27:20.925Z"
       },
       {
-        "id": 258,
+        "id": "258",
         "title": "Integrate Resend email sending for user email verification",
         "description": "Add real transactional email sending using Resend so that users who register receive an email verification link. Currently email_verified is set to False on registration but no email is sent. This blocks login for users who require verified accounts.",
         "details": "1. Add resend Python SDK to pyproject.toml dependencies\n2. Add RESEND_API_KEY and EMAIL_FROM settings to config.py\n3. Create backend/app/services/email_service.py with a send_verification_email() function using Resend\n4. Generate a signed, time-limited verification token (HMAC-SHA256 over user_id + expiry, stored or stateless)\n5. On POST /api/v1/users/ (registration), call send_verification_email() after user creation\n6. Add GET /api/v1/auth/verify-email?token=... endpoint that validates the token and sets email_verified=True\n7. Add RESEND_API_KEY to .env.example\n8. Write unit tests: test_email_service.py (mock Resend SDK), test that verify-email endpoint sets email_verified=True, test expired/invalid token returns 400\n9. Gracefully degrade in local environment (log the verification URL instead of sending email when RESEND_API_KEY is not set)",
@@ -3264,7 +3264,7 @@
         "updatedAt": "2026-05-07T11:15:09.530Z"
       },
       {
-        "id": 259,
+        "id": "259",
         "title": "Fix Redis unavailable on staging — provision Redis and set REDIS_URL",
         "description": "Staging backend is falling back to in-memory fakeredis because REDIS_URL points to localhost:6379 which doesn't exist in Azure Container Apps. This means rate limiting and token blacklisting (logout) do not survive restarts and do not work across replicas. A real Redis instance must be provisioned and REDIS_URL set on the staging container app.",
         "details": "\n1. Provision a Redis instance for staging — options:\n   - Azure Cache for Redis (Basic C0 tier, ~$16/month) — recommended for production parity\n   - Upstash Redis (free tier: 10k requests/day) — cheaper for staging\n2. Get the Redis connection URL (format: redis://:password@host:6379)\n3. Set REDIS_URL on the staging container app:\n   az containerapp update --name heimpath-backend-staging --resource-group rg-heimpath-staging --set-env-vars REDIS_URL=redis://:password@host:6379\n4. Add REDIS_URL to Terraform staging.tf so it persists across infrastructure deployments\n5. Verify fix: check logs no longer show \"using in-memory fallback\" after restart\n",
@@ -3276,7 +3276,7 @@
         "updatedAt": "2026-05-07T11:15:42.165Z"
       },
       {
-        "id": 260,
+        "id": "260",
         "title": "Set up mail.heimpath.com subdomain for transactional emails",
         "description": "Resend Insights flagged two issues with the current email sending configuration: (1) emails are sent from noreply@heimpath.com which hurts deliverability because receiving mail servers cannot route bounce/spam feedback back to the sender, and (2) emails are sent from the root domain heimpath.com rather than a dedicated subdomain, meaning any reputation damage from transactional email (e.g. a spam incident) would also affect the root domain used for the website and marketing emails. This task addresses both by migrating to hello@mail.heimpath.com as the sending address.",
         "details": "## Steps\n\n### 1. Add mail.heimpath.com in Resend dashboard\n- Log into Resend → Domains → Add Domain\n- Enter `mail.heimpath.com`\n- Resend will generate a set of DNS records (MX, SPF TXT, DKIM CNAME records)\n\n### 2. Add DNS records to heimpath.com zone\nAdd the following record types provided by Resend to the heimpath.com DNS zone (likely managed in Azure DNS or the domain registrar):\n- **MX record**: `mail.heimpath.com` → Resend's MX value\n- **TXT record (SPF)**: `mail.heimpath.com` → `v=spf1 include:amazonses.com ~all` (or Resend's provided value)\n- **CNAME records (DKIM)**: typically 2-3 CNAME entries for DKIM signing\n\n### 3. Verify domain in Resend\n- Wait for Resend to verify DNS propagation (usually 5–30 minutes)\n- Domain status should change to \"Verified\" in the Resend dashboard\n\n### 4. Update EMAILS_FROM_EMAIL in all environments\nChange from `hello@heimpath.com` to `hello@mail.heimpath.com`:\n\n**Local `.env`:**\n```\nEMAILS_FROM_EMAIL=hello@mail.heimpath.com\n```\n\n**Azure staging (CLI):**\n```bash\naz containerapp update \\\n  --name heimpath-backend-staging \\\n  --resource-group rg-heimpath-staging \\\n  --set-env-vars \"EMAILS_FROM_EMAIL=hello@mail.heimpath.com\"\n```\n\n**Azure production (CLI):**\n```bash\naz containerapp update \\\n  --name heimpath-backend-prod \\\n  --resource-group rg-heimpath-prod \\\n  --set-env-vars \"EMAILS_FROM_EMAIL=hello@mail.heimpath.com\"\n```\n\n### 5. Verify in Resend\n- Send a test email via `/api/v1/utils/test-emails` (superuser only)\n- Confirm the email arrives from `hello@mail.heimpath.com`\n- Check Resend dashboard shows the email sent under the `mail.heimpath.com` domain\n- Confirm Resend Insights no longer flags the \"no-reply\" or \"use subdomain\" warnings",
@@ -3288,7 +3288,7 @@
         "updatedAt": "2026-05-15T08:22:41.163Z"
       },
       {
-        "id": 261,
+        "id": "261",
         "title": "Journey UX: Phase-First Navigation with Cross-Phase Access",
         "description": "Redesign JourneyDetail.tsx to make phases the primary navigation layer. Users navigate by phase (tab/pill bar), with full cross-phase access at all times — they can freely switch between Research, Preparation, Buying, Closing, and Ownership. The current active phase is highlighted and auto-selected on load. Each phase tab shows its completion status (progress %, or a checkmark when fully complete) so users always have context of the full journey scope. Within the selected phase, only that phase's steps are rendered.",
         "details": "**Files to change:**\n- `frontend/src/components/Journey/JourneyDetail.tsx` (primary)\n- `frontend/src/components/Journey/PhaseIconNav.tsx` (upgrade from decorative to primary nav)\n- `frontend/src/components/Journey/StepListView.tsx` (filter steps by selected phase)\n- `frontend/src/components/Journey/StepTabView.tsx` (assess whether this view is still needed or can be retired)\n\n**Implementation:**\n1. Add `selectedPhase` state to `JourneyDetail` — default to `journey.current_phase`\n2. Replace the current decorative `PhaseIconNav` with a clickable tab bar at the top of the steps area\n3. Each phase tab must show:\n   - Phase icon + label (Research, Preparation, Buying, Closing, Ownership)\n   - Completion indicator: progress bar or filled checkmark for 100% complete phases\n   - Visual distinction for: completed, active (current), upcoming phases\n4. Clicking a phase tab filters the step list to show only that phase's steps\n5. Steps from other phases are NOT shown, but the tabs for those phases remain accessible\n6. Preserve the existing phase step components (`StepListView`, `StepCard`) — just filter by selected phase\n7. Add a compact \"Journey Overview\" toggle or expandable summary that shows all phases and their step counts, for users who want the bird's-eye view\n8. On mobile, phase tabs should scroll horizontally (overflow-x: auto, no wrapping)\n9. Deep-link support: `?phase=preparation` query param should auto-select that phase\n10. When a phase is fully completed, auto-advance `selectedPhase` to the next incomplete phase\n\n**Phase completion status logic:**\n- Count steps in phase: completed / total\n- Show as: \"3/5 steps\" or a mini progress bar in the tab\n- Fully completed phase: amber checkmark + muted tab styling\n- Current phase: blue/primary styling\n- Future (locked) phases: gray with lock icon only if the previous phase is 0% complete\n\n**Do NOT:**\n- Hide phase tabs — all phases must always be accessible\n- Lock future phases (users can preview what's ahead, just can't complete steps out of order due to prerequisites)\n- Remove the existing journey overview sidebar\n\n**Testing:**\n- Unit test: `selectedPhase` state updates correctly on tab click\n- Unit test: step filtering returns only steps matching selected phase\n- Visual test: phase tab completion indicators reflect actual step completion rates\n- E2E: navigate between all phases and verify correct steps shown in each",
@@ -3300,7 +3300,7 @@
         "updatedAt": "2026-05-14T07:40:10.525Z"
       },
       {
-        "id": 262,
+        "id": "262",
         "title": "Journey UX: Active Step Focus Mode — Auto-Expand Current Step",
         "description": "Change the default step rendering in JourneyDetail so only the current active step is auto-expanded on load. All other steps in the selected phase render as compact rows (title + status badge only). Users can still manually expand any step by clicking it. This eliminates the wall-of-content problem where all steps appear open simultaneously, while preserving full access to any step.",
         "details": "**Files to change:**\n- `frontend/src/components/Journey/StepCard.tsx` (primary)\n- `frontend/src/components/Journey/StepListView.tsx` (pass active step ID)\n- `frontend/src/components/Journey/JourneyDetail.tsx` (determine and pass active step)\n\n**Implementation:**\n\n1. **Determine the active step** in `JourneyDetail`:\n   - Active step = the first `in_progress` step, OR if none, the first `not_started` step after the last `completed` step\n   - Use `journey.current_step_number` from the API as the source of truth\n   - Pass `activeStepId` down through context or props to `StepListView` → `StepCard`\n\n2. **Update `StepCard.tsx`**:\n   - Add prop: `defaultExpanded?: boolean`\n   - When `defaultExpanded=true` → card mounts in expanded state\n   - When `defaultExpanded=false` → card mounts collapsed (compact row: phase badge + title + status only)\n   - User can still click any card header to expand/collapse manually\n   - Do NOT auto-collapse when a different card is expanded — allow multiple to be open (user-controlled)\n   - Compact row height should be ~52px (single line: icon + title + status badge)\n\n3. **In `StepListView`**: pass `defaultExpanded={step.id === activeStepId}` to each `StepCard`\n\n4. **Scroll behavior**: on page load (or phase change), smooth-scroll to the active step card\n\n5. **Visual treatment for active step**:\n   - Keep the existing `ring-2` border for the active step\n   - Add a subtle left accent bar (3px, blue) on the active step card for extra clarity\n   - Completed steps: compact by default, muted amber background (existing), no auto-expand\n\n6. **\"Show all\" toggle**: Add a small text link below the step list — \"Expand all steps\" / \"Collapse all\" — for power users who want the old behavior\n\n**Do NOT:**\n- Auto-collapse a step when another is expanded (accordion behavior is frustrating)\n- Change the expand/collapse animation (keep existing 300ms transition)\n- Remove access to any step content\n\n**Testing:**\n- Unit test: correct step is identified as active based on journey state\n- Unit test: `defaultExpanded` prop controls initial mount state\n- Snapshot: compact row renders correctly (no task list, no content visible)\n- Visual: only 1 step expanded on initial load\n- Verify manual expand/collapse still works for all other steps",
@@ -3313,7 +3313,7 @@
         "subtasks": []
       },
       {
-        "id": 263,
+        "id": "263",
         "title": "Journey UX: \"What to Do Today\" Sticky Next-Step Widget",
         "description": "Add a sticky card at the top of the JourneyDetail page that tells users exactly what to focus on right now. The card shows the current step name, the next 1–2 pending tasks, overall journey progress, and a \"Continue\" CTA that scrolls to and highlights the active step. This is the single most important orientation tool for returning users who need to re-engage after days away.",
         "details": "**New component:** `frontend/src/components/Journey/NextStepWidget.tsx`\n**Modified:** `frontend/src/components/Journey/JourneyDetail.tsx` (render widget above phase nav)\n\n**Widget content:**\n```\n┌────────────────────────────────────────────────────────┐\n│  Phase badge: [PREPARATION]         Progress: 42%  ●●●○○ │\n│  ▶ Step 6: Check Your Finances                         │\n│  ☐ Calculate your available savings                    │\n│  ☐ Review monthly income vs expenses                   │\n│                          [Continue →]                  │\n└────────────────────────────────────────────────────────┘\n```\n\n**Implementation:**\n\n1. **Data sources** (all available from `JourneyDetailResponse`):\n   - Current step: `journey.current_step_number` + find matching step in `steps[]`\n   - Next tasks: first 2 incomplete tasks from the active step (`is_completed = false`)\n   - Progress %: from `GET /journeys/{id}/progress` or compute on frontend as `completed_steps / total_steps * 100`\n   - Phase: `journey.current_phase`\n\n2. **Widget behavior:**\n   - Sticky: `position: sticky; top: 64px` (below navbar)\n   - `z-index` above step cards but below modals\n   - Collapses to a compact bar when user scrolls down past it (show phase + step title only)\n   - Expand on click/hover to show full widget\n   - When journey is 100% complete: replace with a completion celebration card (\"Your journey is complete! 🎉 Add property to portfolio\")\n   - When no active step (all done in a phase): show phase completion state + next phase CTA\n\n3. **\"Continue\" button:**\n   - Scrolls smoothly to the active `StepCard`\n   - Triggers `defaultExpanded=true` on the active step (if it somehow got collapsed)\n   - Switches `selectedPhase` to match the active step's phase (in case user was browsing another phase)\n\n4. **Visual design:**\n   - White card with a blue left border accent\n   - Phase badge in phase color\n   - Progress dots (5 dots = 5 phases, filled = complete, half-filled = in-progress)\n   - Task items show as mini un-clickable checkboxes (tappable only from the main step card)\n   - Mobile: full width, no side margin\n\n5. **Empty states:**\n   - No current step (journey just created): \"Start your journey — complete Step 1 to begin\"\n   - Journey complete: \"All steps complete — add your property to your portfolio\"\n\n**Query integration:**\n- Reuse existing `useJourneyDetail` query — no new API calls needed\n- Widget is purely computed from the already-fetched journey detail data\n\n**Testing:**\n- Unit test: widget displays correct step, tasks, and progress for various journey states\n- Unit test: \"Continue\" CTA triggers scroll to active step\n- Test collapse behavior on scroll\n- Test all empty states (no step, journey complete)\n- Mobile: verify widget is full-width and readable",
@@ -3326,7 +3326,7 @@
         "subtasks": []
       },
       {
-        "id": 264,
+        "id": "264",
         "title": "Journey UX: Categorise Step Tasks into Actions, Resources, and Warnings",
         "description": "Reduce visible checkbox count by splitting tasks within each step into three categories: Action Items (things the user must do — rendered as checkboxes), Resources (external links and guides — rendered as clickable cards, not checkboxes), and Watch Out For (legal/risk notes — rendered as an amber callout block). This removes approximately 30–40% of checkboxes from the UI without losing any information.",
         "details": "**Backend changes:**\n- `backend/app/models/journey.py`: Add `task_category` enum column to `JourneyTask`\n  - Values: `action` (default), `resource`, `warning`\n- `backend/app/schemas/journey.py`: Add `task_category: TaskCategory` to `JourneyTaskResponse`\n- `backend/app/services/journey_service.py`: Assign `task_category` when creating tasks:\n  - Tasks with a `resource_url` → `resource`\n  - Tasks containing phrases like \"be aware\", \"note that\", \"important:\", \"check for\" → `warning`\n  - All others → `action` (default)\n  - Review all 31 step task definitions and assign categories explicitly (don't rely on heuristics alone — do a one-time manual audit of all task definitions and hard-code the correct category for each)\n- Alembic migration: add `task_category` column with default `action`\n\n**Frontend changes:**\n- `frontend/src/components/Journey/StepContent/StepBody.tsx` (primary):\n  - Split task list into three sections:\n    1. **Action Items** — existing `TaskCheckbox` component, same as today\n    2. **Resources** — new `ResourceCard` sub-component (see below)\n    3. **Watch Out For** — new `WarningCallout` sub-component (see below)\n  - Only render a section if it has items (don't show empty \"Resources\" header)\n  - Order: Actions → Resources → Warnings (warnings last so they don't block action)\n- `frontend/src/models/journey.ts`: Add `taskCategory: 'action' | 'resource' | 'warning'` to `JourneyTask`\n\n**New sub-components (inside StepContent/):**\n\n`ResourceCard.tsx`:\n```\n┌─────────────────────────────────────┐\n│ 📎 [Title]                    →     │\n│    [Short description]              │\n└─────────────────────────────────────┘\n```\n- Opens `resource_url` in a new tab\n- Not a checkbox — no completion state needed (it's informational)\n- Style: white card with border, hover state with subtle shadow\n\n`WarningCallout.tsx`:\n```\n┌─────────────────────────────────────┐\n│ ⚠ Watch out for                     │\n│   [Warning text]                    │\n│   [Warning text 2]                  │\n└─────────────────────────────────────┘\n```\n- Amber background (`bg-amber-50`), amber left border\n- No checkboxes — these are alerts, not to-dos\n- Group all warnings for the step into one callout block\n\n**Task progress calculation update:**\n- Only `action` category tasks count toward step completion progress\n- `resource` and `warning` tasks do NOT contribute to step completion %\n- Update `_sync_step_status_from_tasks()` in `journey_service.py` to filter by `task_category = 'action'`\n- Update frontend progress bar calculation in `StepBody.tsx` to filter the same way\n\n**Migration safety:**\n- Default all existing tasks to `action` — no data loss\n- Backfill: run a one-time update to set `resource` on tasks that have `resource_url IS NOT NULL`\n\n**Testing:**\n- Backend: verify tasks with resource_url get category=resource\n- Backend: verify step completion only counts action tasks\n- Frontend: verify three sections render correctly when all three categories present\n- Frontend: verify missing sections are hidden (no empty headers)\n- Frontend: verify ResourceCard opens correct URL\n- Frontend: verify progress bar ignores resource/warning tasks",
@@ -3340,7 +3340,7 @@
         "updatedAt": "2026-05-15T08:22:12.165Z"
       },
       {
-        "id": 265,
+        "id": "265",
         "title": "Journey UX: \"Tailored for You\" Badge on Conditionally-Generated Steps",
         "description": "Add a small badge or pill to any journey step that was conditionally generated based on the user's questionnaire answers (e.g. mortgage-only steps, rent-out investor steps, non-resident document steps). This explains why some users see different steps and builds trust that HeimPath has personalised their journey. Without this, users who compare journeys with friends are confused by the differences.",
         "details": "**Backend changes:**\n- `backend/app/models/journey.py`: Add `is_personalised: bool` column to `JourneyStep` (default False)\n- `backend/app/services/journey_service.py`: When generating steps, set `is_personalised=True` for any step that has a non-empty `conditions` dict\n- `backend/app/schemas/journey.py`: Add `is_personalised: bool` to `JourneyStepResponse` (and `JourneyStepSummary`)\n- Alembic migration: add `is_personalised` boolean column with default `False`\n- Backfill migration: for existing journeys, set `is_personalised=True` on steps whose `content_key` maps to a known conditional step (Steps 6, 7, 8, 18, 19, 22, 23, 29, 30, 31 for buying; steps that vary by financing/property_use/residency)\n\n**Frontend changes:**\n- `frontend/src/components/Journey/StepCard.tsx`:\n  - If `step.is_personalised === true`, render a small badge in the card header:\n    ```\n    [✦ For your situation]\n    ```\n  - Position: after the phase badge, before the step title\n  - Style: `bg-blue-50 text-blue-600 text-xs font-medium px-2 py-0.5 rounded-full border border-blue-200`\n  - Tooltip on hover/tap: \"This step was added based on your questionnaire answers\" (use existing tooltip component)\n\n- `frontend/src/models/journey.ts`: Add `is_personalised: boolean` to `JourneyStep`\n\n**Do NOT:**\n- Add this badge to tasks — only to steps\n- Show a tooltip that reveals the raw condition logic (\"only for mortgage buyers\") — keep it friendly and general\n- Apply this to more than ~30% of steps (if it's on too many it becomes meaningless)\n\n**Tooltip accessibility:**\n- Tooltip must be keyboard-accessible (focus trigger)\n- `aria-label` on the badge for screen readers: \"This step was personalised based on your profile\"\n\n**Testing:**\n- Backend: verify `is_personalised=True` set on steps with non-empty conditions dict\n- Backend: verify steps without conditions have `is_personalised=False`\n- Frontend: badge renders on conditional steps\n- Frontend: badge absent on non-conditional steps\n- Frontend: tooltip is accessible via keyboard focus\n- Frontend: badge does not break layout on mobile (wraps gracefully)",
@@ -3354,7 +3354,7 @@
         "updatedAt": "2026-05-15T07:30:01.965Z"
       },
       {
-        "id": 266,
+        "id": "266",
         "title": "Journey UX: Phase Completion Celebration Card Redesign",
         "description": "Redesign the existing PhaseCompletionCta component into a full-width, visually rich celebration card that makes completing a phase feel like a genuine milestone. A German property purchase takes 6–12 months — completing the Research phase or Preparation phase deserves meaningful acknowledgement. The new design should summarise what was accomplished in the phase, show a few key numbers (budget confirmed, notary chosen, etc.) and present a clear CTA to begin the next phase.",
         "details": "**Files to change:**\n- `frontend/src/components/Journey/PhaseCompletionCta.tsx` (redesign in place)\n- `frontend/src/components/Journey/JourneyDetail.tsx` (pass phase summary data to the card)\n\n**New card design:**\n\n```\n┌──────────────────────────────────────────────────────────────┐\n│  ✓  Research Phase Complete                                  │\n│                                                              │\n│  You've laid the foundation for your property purchase.      │\n│                                                              │\n│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐         │\n│  │  Budget     │  │  Location   │  │  5 Steps    │         │\n│  │  €450,000   │  │  Munich     │  │  Completed  │         │\n│  └─────────────┘  └─────────────┘  └─────────────┘         │\n│                                                              │\n│              [ Begin Preparation Phase → ]                   │\n└──────────────────────────────────────────────────────────────┘\n```\n\n**Phase-specific summary stats** (compute from journey data, no new API needed):\n\n| Phase Completed | Stat 1 | Stat 2 | Stat 3 |\n|-----------------|--------|--------|--------|\n| Research | Budget range | Target location | Market avg price/sqm (if available) |\n| Preparation | Financing type | Est. monthly payment (if mortgage) | Documents ready count |\n| Buying | Offer price | Notary name (if saved) | Contract review status |\n| Closing | Payment confirmed | Transfer tax paid | Land registry status |\n| Ownership | Insurance arranged | Registration complete | Next: portfolio |\n\n- Stats are optional — only show if the data is available in the journey object\n- Fallback: show \"X steps completed\" + \"Phase complete\" if no specific data available\n\n**Visual design:**\n- Full-width card spanning the step list column width\n- Background: subtle gradient (e.g. `from-blue-50 to-white` for Research, `from-indigo-50 to-white` for Preparation — match phase color)\n- Large checkmark icon (40px) in phase color\n- Headline: \"[Phase Name] Phase Complete\"\n- Body: 1 sentence of encouragement (phase-specific, not generic)\n- 2–3 stat mini-cards (white, with shadow, rounded)\n- CTA button: \"Begin [Next Phase] →\" in primary blue, full-width on mobile\n\n**Animation:**\n- On mount: fade-in + subtle scale-up (200ms)\n- Stat cards: stagger-in with 100ms delay each (use existing animation utilities if available)\n- Do NOT use confetti or heavy animations — keep it professional (this is a finance app)\n\n**When to show:**\n- Shown between phase groups in the step list when the previous phase is 100% complete (existing logic in `JourneyDetail` — keep this)\n- Also shown at the top of the NEXT phase's step view (first thing user sees when switching to the next phase)\n- Dismissed after the first step of the next phase is started (existing `is_phase_completion_visible` logic — keep this)\n\n**CTA behavior:**\n- \"Begin [Next Phase] →\" switches the phase tab selection to the next phase (calls `setSelectedPhase`)\n- Does NOT navigate away from the page\n\n**Testing:**\n- Render with all stat slots populated — verify layout\n- Render with no optional stats — verify graceful fallback\n- Test CTA switches to correct next phase\n- Test card is hidden once next phase has an in-progress step\n- Visual: all 5 phase completion variants look correct",
@@ -3368,7 +3368,7 @@
         "updatedAt": "2026-05-15T08:06:10.356Z"
       },
       {
-        "id": 267,
+        "id": "267",
         "title": "Journey UX: Consolidate Buying Journey from 31 Steps to ~19 Steps (Backend)",
         "description": "Reduce the buying journey from 31 steps to approximately 19 by merging logically related steps that represent the same moment in the purchase process. This is a backend-only task — it modifies journey_service.py step templates, updates step numbering, and requires an Alembic migration to handle existing journeys. The frontend content renderers are updated in a separate follow-on task (268).",
         "details": "**File:** `backend/app/services/journey_service.py`\n\n**Merges to implement:**\n\n| Old Steps | New Merged Step | New content_key | Rationale |\n|-----------|-----------------|-----------------|-----------|\n| Step 1 (Define Goals) + Step 2 (Understand Market) | \"Set Your Goals & Explore the Market\" | `property_goals_and_market` | Market insights are generated FROM step 1 input — they are one interaction, not two |\n| Step 3 (Find Property) + Step 4 (Evaluate Property) | \"Find & Evaluate Properties\" | `find_and_evaluate_property` | Both are the active property search period; evaluation is part of property selection |\n| Steps 6+7+8 (Finance Check + Mortgage Pre-Approval + Mortgage Comparison) | \"Secure Your Financing\" | `secure_financing` | All three are mortgage steps that happen in parallel, not sequence; conditional on financing_type=mortgage/mixed |\n| Steps 10+11 (Due Diligence + Make Offer) | \"Inspect, Evaluate & Make an Offer\" | `due_diligence_and_offer` | Due diligence directly informs the offer price — same active moment |\n| Steps 12+13 (Choose Notar + Review Contract) | \"Notary Selection & Contract Review\" | `notary_and_contract` | Choosing a notary and reviewing the purchase contract happen simultaneously |\n| Steps 15+16 (Complete Payment + Pay Transfer Tax) | \"Complete Payment & Transfer Tax\" | `payment_and_transfer_tax` | Both are post-signing payment obligations; sequential but part of the same \"close the deal\" moment |\n| Steps 25+26 (Ownership Registration + Insurance) | \"Register Property & Arrange Insurance\" | `registration_and_insurance` | Both happen within the first week of receiving keys |\n| Steps 27+28 (Property Management + Tax/Finance) | \"Set Up Property Management & Finance\" | `management_and_finance_setup` | Both are operational setup in the first month of ownership |\n\n**Steps that remain solo** (not merged — each is a meaningful standalone milestone):\n- Step 5: Learn About Buying Costs (stays — key financial education moment)\n- Step 9: Prepare Required Documents (stays — distinct, critical step)\n- Step 14: Sign at the Notary (stays — THE key milestone of the entire journey)\n- Step 17: Ownership Transfer (stays — completion of the legal process)\n- Step 18: Prepare Proof of Funds (stays — cash buyer equivalent of financing steps)\n- Step 19: Secure Final Loan Commitment (stays — mortgage final sign-off, pre-signing)\n- Step 22: Plan Property Management (rental investor — stays)\n- Step 23: Prepare Rental Tax Strategy (stays)\n- Steps 29-31: Rental investor ownership steps (stays)\n\n**Implementation:**\n\n1. **Update `_generate_buying_steps()`** in `journey_service.py`:\n   - Redefine the STEP_TEMPLATES list with the merged steps\n   - Merge task lists from both old steps into the new combined step\n   - Assign new sequential step numbers\n   - Keep all existing conditional logic intact (financing_type, property_use, has_german_residency conditions still apply at task level)\n   - Set `estimated_duration_days` to the sum of the two merged steps\n   - Combine `related_laws` lists (deduplicate)\n   - Combine `estimated_costs` dicts (merge keys, sum overlapping numeric values)\n\n2. **Alembic migration** for existing journeys:\n   - **Do NOT delete existing journey steps** — add a `journey_version: int` column (default 1) to the `Journey` model\n   - New journeys (version 2) use the new step templates\n   - Existing journeys (version 1) keep their old steps untouched\n   - The frontend will render both versions correctly (old steps still have valid content_keys)\n   - Document this versioning in a comment in the migration file\n\n3. **journey_service.py — generation guard:**\n   - When creating a new journey, set `journey_version=2`\n   - `_generate_buying_steps()` reads `journey.journey_version` — if v1, use old templates (for existing users); if v2, use new merged templates\n\n4. **Update `_personalize_buying_costs()`** — ensure it still runs for the merged Step 5 (Learn About Buying Costs, now part of a different step number)\n\n5. **Test data:** Create a test fixture with a v2 journey for integration tests\n\n**Migration safety rules:**\n- No existing user data is changed (journey_version=1 users keep their steps)\n- The migration is purely additive (new column + default value)\n- No step deletions, only new journey creation uses new templates\n\n**Testing:**\n- Unit test: v2 journey generation produces exactly the expected step list\n- Unit test: all conditional steps still generate correctly under v2\n- Unit test: merged steps contain all tasks from both source steps\n- Integration test: POST /journeys creates v2 journey with ~19 steps\n- Verify: existing v1 journeys are unchanged after migration",
@@ -3380,7 +3380,7 @@
         "updatedAt": "2026-05-15T19:00:40.811Z"
       },
       {
-        "id": 268,
+        "id": "268",
         "title": "Journey UX: Update Frontend Step Content Renderers for Merged Steps (v2)",
         "description": "Update the frontend STEP_CONTENT_REGISTRY in StepBody.tsx and create or update the corresponding React step content components to handle the new merged content_keys introduced in task 267. Each merged step needs a combined renderer that presents the content from both source steps in a clean, tabbed or sectioned layout without information loss.",
         "details": "**Files to change:**\n- `frontend/src/components/Journey/StepContent/StepBody.tsx` — update STEP_CONTENT_REGISTRY\n- Create or update the following step content components:\n\n**1. `PropertyGoalsAndMarket.tsx`** (replaces `PropertyGoalsForm` + `MarketInsights`)\n- content_key: `property_goals_and_market`\n- Layout: two-section card\n  - Section 1: \"Your Goals\" — renders PropertyGoalsForm (existing form for inputting goals)\n  - Section 2: \"Market Overview\" — renders MarketInsights (shown after goals are saved, same as today)\n- Transition: Section 2 unlocks/expands after user saves their goals (already existing behavior — just combine into one component file)\n- Reuse existing `PropertyGoalsForm` and `MarketInsights` as sub-components\n\n**2. `FindAndEvaluateProperty.tsx`** (replaces `StepContent` for find + `PropertyEvaluationSummary`)\n- content_key: `find_and_evaluate_property`\n- Layout: tabbed interface within the step\n  - Tab 1: \"Finding Properties\" — tips, platforms (ImmoScout24, Immowelt), what to look for at viewings\n  - Tab 2: \"Evaluating a Property\" — renders `PropertyEvaluationSummary` (link to calculator, key metrics)\n- Reuse `PropertyEvaluationSummary` for tab 2\n\n**3. `SecureFinancing.tsx`** (replaces `FinanceCheck` + `MortgagePreapproval` + `MortgageComparison`)\n- content_key: `secure_financing`\n- Layout: stepper within the step (3 sub-steps, not full steps)\n  - Sub-step 1: \"Check Your Finances\" — renders `FinanceCheck`\n  - Sub-step 2: \"Get Pre-Approved\" — renders `MortgagePreapproval`\n  - Sub-step 3: \"Compare Offers\" — renders `MortgageComparison`\n- User progresses through sub-steps; tasks from all three original steps are shown in order\n- Only shown if `journey.financing_type === 'mortgage' || 'mixed'`\n\n**4. `DueDiligenceAndOffer.tsx`** (replaces document review step + offer step)\n- content_key: `due_diligence_and_offer`\n- Layout: two-section\n  - Section 1: \"Due Diligence Checklist\" — renders `StepDocumentReview` (for due diligence)\n  - Section 2: \"Making Your Offer\" — checklist + guidance for offer submission\n- Both sections visible simultaneously (no tabs) — they're complementary\n\n**5. `NotaryAndContract.tsx`** (replaces notary selection + `StepDocumentReview` for contract)\n- content_key: `notary_and_contract`\n- Layout: two-section\n  - Section 1: \"Choose Your Notary\" — tips on finding a notary, what to ask\n  - Section 2: \"Review the Kaufvertrag\" — renders `StepDocumentReview`\n\n**6. `PaymentAndTransferTax.tsx`** (replaces payment step + transfer tax step)\n- content_key: `payment_and_transfer_tax`\n- Layout: checklist with two labeled groups\n  - Group 1: \"Complete Payment\" — wait for Auflassungsvormerkung, transfer funds\n  - Group 2: \"Pay Transfer Tax\" — receive assessment, pay Grunderwerbsteuer, get certificate\n- No tabs — linear sequence is clear\n\n**7. `RegistrationAndInsurance.tsx`** (replaces `OwnershipRegistration` + `OwnershipInsurance`)\n- content_key: `registration_and_insurance`\n- Layout: two-section\n  - Section 1: renders `OwnershipRegistration`\n  - Section 2: renders `OwnershipInsurance`\n\n**8. `ManagementAndFinanceSetup.tsx`** (replaces `OwnershipManagement` + `OwnershipTaxFinance`)\n- content_key: `management_and_finance_setup`\n- Layout: two-section\n  - Section 1: renders `OwnershipManagement`\n  - Section 2: renders `OwnershipTaxFinance`\n\n**STEP_CONTENT_REGISTRY update in StepBody.tsx:**\n```typescript\n// v2 merged keys\nproperty_goals_and_market: PropertyGoalsAndMarket,\nfind_and_evaluate_property: FindAndEvaluateProperty,\nsecure_financing: SecureFinancing,\ndue_diligence_and_offer: DueDiligenceAndOffer,\nnotary_and_contract: NotaryAndContract,\npayment_and_transfer_tax: PaymentAndTransferTax,\nregistration_and_insurance: RegistrationAndInsurance,\nmanagement_and_finance_setup: ManagementAndFinanceSetup,\n// v1 legacy keys — keep all existing entries for backwards compatibility\nproperty_goals: PropertyGoalsForm,\nmarket_insights: MarketInsights,\n...\n```\n\n**Backwards compatibility:**\n- Keep ALL existing content_key entries in the registry\n- v1 journey steps will continue to use old content_keys and old components\n- No changes to existing component files — only additions\n\n**Testing:**\n- Snapshot tests for all 8 new combined components\n- Verify backwards compatibility: v1 journey steps still render using old components\n- Visual: two-section layouts don't create visual confusion\n- Mobile: tabbed components work on small viewports\n- Verify `SecureFinancing` only renders for mortgage/mixed journeys",
@@ -3394,7 +3394,7 @@
         "updatedAt": "2026-05-15T18:19:50.762Z"
       },
       {
-        "id": 269,
+        "id": "269",
         "title": "Neon Compute Fix P1: Add pool limits and pool_recycle to async engine",
         "description": "The async SQLAlchemy engine in backend/app/core/database.py has no pool_size, max_overflow, or pool_recycle settings. This allows unlimited async connections and prevents Neon from autosuspending (Neon suspends compute after ~5 min of inactivity — open connections block that). Mirror the sync engine config from db.py.",
         "details": "**File:** `backend/app/core/database.py`\n\nAdd the following parameters to `create_async_engine()`:\n```python\nasync_engine = create_async_engine(\n    str(settings.ASYNC_DATABASE_URI),\n    echo=settings.ENVIRONMENT == \"local\",\n    pool_pre_ping=True,\n    connect_args=_async_connect_args,\n    pool_size=3,          # mirror sync engine\n    max_overflow=5,       # mirror sync engine\n    pool_timeout=30,      # mirror sync engine\n    pool_recycle=1800,    # recycle before Neon's 15-min idle drop\n)\n```\n\n`pool_recycle=1800` is critical: Neon drops idle connections after 15 minutes. Without recycling, SQLAlchemy holds stale connections, forcing reconnects and keeping compute awake. The sync engine in `backend/app/core/db.py` already has this correctly configured at lines 20-31 — match it.\n\n**Note:** The connect_args already sets `server_settings` for statement_timeout — keep that unchanged.",
@@ -3406,7 +3406,7 @@
         "updatedAt": "2026-06-13T14:53:41.000Z"
       },
       {
-        "id": 270,
+        "id": "270",
         "title": "Neon Compute Fix P1: Slow down scheduled tasks to allow Neon autosuspend",
         "description": "Two Celery beat tasks run every 5 and 10 minutes respectively, which prevents Neon from ever autosuspending (compute stays awake, burning CU hours around the clock). The cleanup-stuck-documents task runs every 5 min (288 DB queries/day) and retry-failed-notifications runs every 10 min (144 DB queries/day). Extending these intervals will allow Neon compute to sleep between runs.",
         "details": "**File:** `backend/app/tasks/scheduled_tasks.py`\n\nChange the Celery beat schedule:\n\n```python\n# BEFORE\n\"cleanup-stuck-documents\": {\n    \"schedule\": crontab(minute=\"*/5\"),   # every 5 min\n},\n\"retry-failed-notifications\": {\n    \"schedule\": crontab(minute=\"*/10\"),  # every 10 min\n},\n\n# AFTER\n\"cleanup-stuck-documents\": {\n    \"schedule\": crontab(minute=\"*/30\"),  # every 30 min — reduces from 288 to 48 DB hits/day\n},\n\"retry-failed-notifications\": {\n    \"schedule\": crontab(minute=0),       # hourly — reduces from 144 to 24 DB hits/day\n},\n```\n\nRationale: Neon free tier compute autosuspends after ~5 minutes of no connections. Tasks running every 5-10 minutes guarantee the compute never suspends. Documents stuck for more than 30 minutes or notifications delayed by an hour are still within acceptable SLA for these background jobs. The weekly recurring transaction job (Monday 02:00) is already fine — leave it unchanged.",
@@ -3418,7 +3418,7 @@
         "updatedAt": "2026-06-13T14:53:41.000Z"
       },
       {
-        "id": 271,
+        "id": "271",
         "title": "Neon Compute Fix P2: Deduplicate count queries in dashboard service",
         "description": "_count_total_calculations() in dashboard_service.py re-runs the same 3 queries that _get_recent_calculations() already ran, just to count them. This doubles the DB round-trips on every dashboard load. Fix it to reuse already-fetched data instead of hitting the DB again.",
         "details": "**File:** `backend/app/services/dashboard_service.py`\n\nCurrently `_count_total_calculations()` (lines ~411-425) runs:\n```python\nhc_count = session.exec(select(func.count()).where(...)).one()\nroi_count = session.exec(select(func.count()).where(...)).one()\nfin_count = session.exec(select(func.count()).where(...)).one()\n```\n\nBut `_get_recent_calculations()` already loaded the same records. Pass the results from `_get_recent_calculations()` into the count function instead:\n\n```python\n# In get_dashboard_overview(), collect the calcs list first\ncalcs = _get_recent_calculations(session, user_id, limit=5)\ntotal_calcs = len(calcs)  # use length of already-fetched list\n```\n\nIf the total count needs to be independent of the `limit=5` cap, change the approach: run a single `SELECT COUNT(*)` combined query using `UNION ALL` across the 3 tables, or add `include_count=True` param to `_get_recent_calculations()` that runs count queries in the same call and returns them alongside results.\n\nEither way, eliminate the duplicate 3-query round-trip.",
@@ -3433,7 +3433,7 @@
         "updatedAt": "2026-06-13T15:02:09.000Z"
       },
       {
-        "id": 272,
+        "id": "272",
         "title": "Neon Compute Fix P2: Consolidate dashboard timeline into fewer bulk queries",
         "description": "build_activity_timeline() in dashboard_service.py runs 7 separate sequential queries (one per activity type). These 7 round-trips keep the DB compute busy on every dashboard load. Consolidate into 2-3 queries using UNION or load all types in parallel.",
         "details": "**File:** `backend/app/services/dashboard_service.py`, lines 250-394\n\nCurrent pattern (7 separate queries in sequence):\n```python\nfor j in session.exec(j_stmt).all(): ...         # journeys\nfor step, _ in session.exec(cs_stmt).all(): ...   # completed steps\nfor doc in session.exec(doc_stmt).all(): ...       # documents\nfor hc in session.exec(hc_stmt).all(): ...         # hidden cost calcs\nfor roi in session.exec(roi_stmt).all(): ...       # ROI calcs\nfor fin in session.exec(fin_stmt).all(): ...       # financing assessments\nfor bm, _ in session.exec(bm_stmt).all(): ...     # law bookmarks\n```\n\n**Option A (recommended — simplest):** Cache the dashboard timeline response with a short TTL using a dict keyed by user_id in memory (or Redis if available). A 30-second cache means a user refreshing the page rapidly only triggers 1 DB read per 30 seconds.\n\n**Option B:** Combine the 3 calculator queries (hidden cost, ROI, financing) into one query using `UNION ALL` and a discriminator column, reducing 7 queries to 5.\n\n**Option C:** Run all 7 queries concurrently using `asyncio.gather()` if the service is refactored to be async.\n\nOption A is the lowest-risk change. Implement it first — add a `_timeline_cache: dict[str, tuple[float, list]]` module-level dict, check/set it with a 30s TTL around the 7-query block.",
@@ -3447,7 +3447,7 @@
         "updatedAt": "2026-06-13T15:02:09.000Z"
       },
       {
-        "id": 273,
+        "id": "273",
         "title": "Neon Compute Fix P3: Add selectinload to journey steps and document translation relationships",
         "description": "Journey steps and document translations use lazy loading. When code iterates over journey.steps or accesses document.translation, SQLAlchemy fires a separate query per object. Adding selectinload() to the key query sites eliminates these N+1 patterns.",
         "details": "**File 1:** `backend/app/services/journey_service.py`\n\nFind queries that load journeys and then access `.steps`. Add `selectinload`:\n```python\nfrom sqlalchemy.orm import selectinload\n\n# Wherever journeys are fetched for iteration over steps, e.g.:\nstmt = select(Journey).where(Journey.user_id == user_id).options(\n    selectinload(Journey.steps)\n)\n```\n\nSpecifically check `get_user_journeys()`, `get_progress()`, and `get_next_step()` — if any of these load a journey and then access `.steps`, add `selectinload(Journey.steps)` to the initial fetch.\n\n**File 2:** `backend/app/services/document_service.py`\n\nLines without selectinload that later access `document.translation` — add:\n```python\n.options(selectinload(Document.translation))\n```\nLines 617 and 737 already do this correctly — find and fix the remaining query sites that don't.\n\n**File 3:** `backend/app/services/dashboard_service.py`\n\nIn `build_activity_timeline()`, the journey and step queries load objects that may then access related fields. Review and add appropriate `selectinload()` calls.\n\n**Do not** add `lazy='selectin'` to the model relationship definition — that changes behavior globally. Prefer query-level `options(selectinload(...))` for targeted control.",
@@ -3461,7 +3461,7 @@
         "updatedAt": "2026-06-13T15:04:54.000Z"
       },
       {
-        "id": 274,
+        "id": "274",
         "title": "Install and Initialise PostgreSQL on VPS",
         "description": "Install PostgreSQL on the VPS and bootstrap the heimpath database, application user, and privileges for the Neon-to-self-hosted migration.",
         "details": "Install PostgreSQL via apt (apt update && apt install -y postgresql postgresql-contrib). Create the heimpath database. Create a dedicated heimpath_user with a strong, randomly generated password (do not reuse the postgres superuser). Grant privileges on the heimpath database and on the public schema to heimpath_user (GRANT ALL PRIVILEGES ON DATABASE heimpath TO heimpath_user; GRANT ALL ON SCHEMA public TO heimpath_user). Note and securely record the sync and async connection strings (postgresql://... and postgresql+asyncpg://...) for use in the next migration task.",
@@ -3473,7 +3473,7 @@
         "updatedAt": "2026-06-17T10:19:57.770Z"
       },
       {
-        "id": 275,
+        "id": "275",
         "title": "Security Hardening — listen_addresses, pg_hba.conf, dedicated app user",
         "description": "Lock down the self-hosted PostgreSQL instance so it is only reachable from localhost and authenticates the dedicated app user with scram-sha-256.",
         "details": "Set listen_addresses = 'localhost' in postgresql.conf so Postgres does not bind to public interfaces. Configure pg_hba.conf to use scram-sha-256 authentication for heimpath_user on localhost (127.0.0.1/32 and ::1/128) only. Reload Postgres (systemctl reload postgresql or SELECT pg_reload_conf()). Verify there is no public port exposure with 'ss -tlnp' (port 5432 should bind to 127.0.0.1/::1 only). Confirm the application .env uses heimpath_user and never the postgres superuser.",
@@ -3487,7 +3487,7 @@
         "updatedAt": "2026-06-17T10:19:57.883Z"
       },
       {
-        "id": 276,
+        "id": "276",
         "title": "Enable PostgreSQL Auto-Start on VPS Reboot",
         "description": "Ensure PostgreSQL and the dependent app services start automatically and in the correct order on VPS reboot.",
         "details": "Run 'systemctl enable postgresql' so Postgres starts on boot. Verify with 'systemctl is-enabled postgresql' (should report 'enabled'). Add 'Requires=postgresql.service' and 'After=postgresql.service' to the [Unit] section of the FastAPI and Celery systemd unit files so the application services wait for Postgres to be available before starting on boot. Reload systemd (systemctl daemon-reload) after editing the units.",
@@ -3501,7 +3501,7 @@
         "updatedAt": "2026-06-17T10:19:57.898Z"
       },
       {
-        "id": 277,
+        "id": "277",
         "title": "Migrate App from Neon to Self-Hosted Postgres",
         "description": "Cut the application over from Neon DB to the self-hosted localhost PostgreSQL instance and decommission Neon once stable.",
         "details": "Update DATABASE_URL and ASYNC_DATABASE_URL in the production environment to point at localhost:5432 (heimpath_user / heimpath database). Run 'alembic upgrade head' against the new database to apply the schema. If existing data must be preserved, dump from Neon (pg_dump) and restore into the self-hosted instance (pg_restore / psql). Restart all app services (FastAPI, Celery workers, beat). Validate the app against the new database. Once the new setup has been stable for 24 hours, revoke the Neon credentials and decommission the Neon project.",
@@ -3516,7 +3516,7 @@
         "updatedAt": "2026-06-17T10:19:57.907Z"
       },
       {
-        "id": 278,
+        "id": "278",
         "title": "Set Up Automated Local pg_dump Backup Cron",
         "description": "Schedule nightly compressed local backups of the self-hosted PostgreSQL database with retention and verified restores.",
         "details": "Create /backups/postgres/ owned by the postgres OS user. Add a cron job for the postgres user (crontab -u postgres) that runs nightly at 02:00 and dumps the heimpath database with gzip compression (pg_dump heimpath | gzip > /backups/postgres/heimpath_$(date +\\%F).sql.gz). Keep 7 days of backups and delete older ones (find /backups/postgres -name '*.sql.gz' -mtime +7 -delete). Test a restore of a recent dump into a temporary database to confirm the dump is valid and complete.",
@@ -3530,7 +3530,7 @@
         "updatedAt": "2026-06-17T10:27:42.643Z"
       },
       {
-        "id": 279,
+        "id": "279",
         "title": "Disk Usage Monitoring Cron Alert",
         "description": "Add a daily disk-usage monitoring script that alerts when the root filesystem fills up and tracks Postgres data directory growth.",
         "details": "Create /usr/local/bin/disk-check.sh that checks disk usage on / and appends an alert line to /var/log/disk-alert.log when usage exceeds 70%. The script should also log the PostgreSQL data directory size (du -sh on the data dir, e.g. /var/lib/postgresql) daily for trend tracking. Make the script executable (chmod +x). Schedule it at 08:00 daily via the root crontab.",
@@ -3544,7 +3544,7 @@
         "updatedAt": "2026-06-17T10:27:42.689Z"
       },
       {
-        "id": 280,
+        "id": "280",
         "title": "[DEFERRED] Offsite Backup to Cloudflare R2 or Google Drive",
         "description": "Document and later implement shipping nightly database dumps offsite via rclone to Cloudflare R2 or Google Drive. Deferred until local backups are stable.",
         "details": "Document the steps to install rclone, configure a Cloudflare R2 bucket (10GB free tier, no egress fees) or Google Drive as an rclone remote, and extend the nightly backup cron to ship the dump file offsite (rclone copy) after the local copy is made. Mark as DEFERRED — implement only after local backups have proven stable.",
@@ -3557,7 +3557,7 @@
         "subtasks": []
       },
       {
-        "id": 281,
+        "id": "281",
         "title": "Mortgage Eligibility Guide for Foreign Buyers",
         "description": "Add a new /mortgage-guide page that explains German mortgage eligibility criteria for foreign buyers by residency status, typical LTV ratios, required documents, and a contextual CTA to Hypofriend for binding pre-approval.",
         "details": "New frontend page at /mortgage-guide covering:\n1. Eligibility by residency status (German citizen, EU/EEA citizen, non-EU resident in Germany, non-resident foreigner) — LTV ratios, bank willingness, restrictions\n2. Required document checklist per residency category (Schufa, income proof, residence permit, tax ID)\n3. Typical mortgage process timeline (application → approval → notarisation)\n4. A CTA card linking to Hypofriend (non-affiliate fallback link: https://www.hypofriend.de) for binding pre-approval\n5. Link from the FinancingSelector wizard step so users who choose \"mortgage\" see a \"Learn more\" pointer\n\nImplementation:\n- New route added to TanStack Router config\n- New page component frontend/src/pages/MortgageGuide.tsx\n- New components: EligibilityTable, DocumentChecklist, TimelineSteps\n- Add \"Mortgage Guide\" link in navigation or from FinancingSelector\n- No backend changes required — fully static educational content",
@@ -3569,30 +3569,68 @@
         "updatedAt": "2026-06-17T12:59:15.165Z"
       },
       {
-        "id": 282,
+        "id": "282",
         "title": "Interactive Mortgage Affordability Calculator for Foreign Buyers",
         "description": "Add an interactive affordability calculator section to the /mortgage-guide page. Users input gross income, savings/equity, and residency status to get personalised estimates of max loan amount, required equity, and monthly payment — with a Hypofriend CTA.",
         "details": "New AffordabilityCalculator component embedded in /mortgage-guide page (new tab or section below the residency profiles).\n\nInputs:\n- Gross annual income (€) — with optional partner income toggle\n- Available equity/savings (€)\n- Residency status (German citizen, EU/EEA citizen, Non-EU resident, Non-resident foreigner) — reuse RESIDENCY_PROFILES LTV data\n- Target property price (€) — optional, enables reverse calc\n\nOutputs (calculated in real-time, no backend needed):\n- Maximum loan amount: income × 4.5 × (LTV/100), capped by equity available\n- Required minimum equity: property price × (1 - LTV/100) + closing costs (11% of price)\n- Estimated monthly payment: annuity formula at 3.8% p.a. over 25 years\n- Affordability verdict: green (can afford), amber (borderline, <20% buffer), red (cannot afford)\n- If target price entered: gap to affordability (how much more savings needed)\n\nLTV rates per residency (from RESIDENCY_PROFILES):\n- German citizen: 80%\n- EU/EEA citizen: 75%\n- Non-EU resident in Germany: 70%\n- Non-resident foreigner: 60%\n\nImplementation:\n- New file: frontend/src/components/MortgageGuide/AffordabilityCalculator.tsx\n- Add tab or collapsible section to MortgageGuidePage\n- Uses useState for form state, useMemo for derived calculations\n- Tailwind-only styling, colour tokens from Colors.ts\n- No API calls — fully static calculation\n- Add share/copy result button (copy summary text to clipboard)",
         "testStrategy": "Visual QA: enter inputs for each residency type, verify output changes in real-time. Edge cases: 0 equity, very high income, non-resident with low savings. tsc --noEmit passes. No regressions on existing mortgage guide sections.",
+        "status": "done",
+        "dependencies": [
+          "281"
+        ],
+        "priority": "high",
+        "subtasks": [],
+        "updatedAt": "2026-06-17T13:53:17.098Z"
+      },
+      {
+        "id": "283",
+        "title": "German Bank Account Opening Guide for Non-Residents",
+        "description": "Build a dedicated guide page at /mortgage-guide or /guides/bank-account explaining how foreign buyers can open a German bank account, which is a prerequisite for property purchase and mortgage approval.",
+        "details": "Create a new frontend guide page at /guides/bank-account modelled after the mortgage guide page (PR #355). Content sections: (1) Why you need a German bank account before buying property — mortgage disbursement, notary fee payments, and ongoing utility direct debits all require a German IBAN. (2) Bank comparison table: N26 (app-only, accepts non-residents in EU), Deutsche Bank (branch-based, accepts non-EU with appointment), DKB (online, EU residents only), Commerzbank (branch-based, accepts non-EU). Columns: accepts non-residents, account fee, minimum deposit, time to open, English support, online banking. (3) Required documents by citizenship: EU citizen (passport + address proof), non-EU resident (Aufenthaltstitel + Anmeldebescheinigung), non-EU non-resident (passport + home country bank statement + reason for opening). (4) Step-by-step process: online vs. branch application, VideoIdent (video identity verification) option, PostIdent fallback. (5) Timeline: typically 5–14 business days. (6) Call to action: link to Hypofriend for mortgage pre-qualification, link to journey bank-account step. Build as a React page component using the same card + section structure as MortgageGuide. Add route to TanStack Router. Add meta tags for SEO. Add link from the mortgage guide page and from the buying journey financing step.",
+        "testStrategy": "Manual: Navigate to /guides/bank-account, verify all sections render correctly on mobile and desktop. Check bank comparison table is readable on small screens. Verify internal links (mortgage guide, journey) navigate correctly. TypeScript: bunx tsc --noEmit passes.",
         "status": "pending",
         "dependencies": [
-          281
+          "281"
         ],
         "priority": "high",
         "subtasks": []
+      },
+      {
+        "id": "284",
+        "title": "Property Viewing Checklist — Interactive In-App Tool for Buyers",
+        "description": "Build an interactive property viewing checklist tool that foreign buyers can use during and after property viewings to systematically assess a property. The checklist is tied to a journey property and saves progress per viewing.",
+        "details": "Backend: Create a new PropertyViewing model (id, user_id, journey_id FK nullable, address, viewed_at date, notes text, checklist_data JSONB). Add Alembic migration. Create GET /api/v1/viewings (list user's viewings), POST /api/v1/viewings (create viewing record with address), PATCH /api/v1/viewings/{id} (update checklist state + notes), DELETE /api/v1/viewings/{id}. Checklist categories stored in JSONB: Structure (roof condition, facade cracks, basement moisture, windows/doors age), Utilities (heating type + age, hot water system, electrical panel age, broadband availability), Legal (Grundbuch excerpt available, Teilungserklärung for WEG, outstanding Hausgeld arrears, listed building status), Paperwork (Energieausweis provided, floor plan available, last renovation records), Neighbourhood (public transport distance, schools, supermarket, noise level). Each item: label, checked boolean, notes string. Frontend: Create a /tools/viewing-checklist page listing all viewings + a create button. Each viewing opens a detail view with accordion sections per category. Checkboxes with notes fields. Show completion % per category and overall. Add PDF export button (download checklist as branded PDF using window.print() with @media print CSS). Add link from Journey Step 3 (property search) sidebar. Store checklist state in TanStack Query with optimistic updates on each checkbox toggle.",
+        "testStrategy": "Backend: pytest tests for CRUD endpoints (create viewing, update checklist, delete). Frontend: TypeScript passes. Manual: create a viewing, fill checklist items, verify persistence across page reload, test PDF export renders correctly.",
+        "status": "pending",
+        "dependencies": [
+          "5"
+        ],
+        "priority": "high",
+        "subtasks": []
+      },
+      {
+        "id": "285",
+        "title": "Rent vs. Buy Decision Calculator for Foreign Buyers in Germany",
+        "description": "Build an interactive calculator that helps foreign buyers decide whether renting or buying makes financial sense in their specific situation, considering German-specific costs, tax treatment, and investment horizon.",
+        "details": "Frontend-only calculator (no backend needed — same pattern as affordability calculator). Inputs: property price (€), monthly rent for equivalent property (€), down payment (%), mortgage interest rate (%), loan term (years), planned holding period (years), property value growth rate p.a. (%), investment return on alternative (if not buying) (%), annual Hausgeld / Betriebskosten (€/month), annual maintenance budget (% of property value, default 1%), Grunderwerbsteuer (pre-filled from state selector), notary + registration fees (pre-filled, editable). Calculation logic: Buying scenario: total purchase cost (price + all buying costs), monthly mortgage payment (standard annuity formula), total monthly ownership cost (mortgage + Hausgeld + maintenance reserve), equity built after N years (property value × (1+g)^N minus remaining principal), net cost of buying = total payments made + buying costs - equity at exit. Renting scenario: total rent paid over N years, opportunity cost of down payment (compounded at investment return rate), net cost of renting = total rent + opportunity cost of down payment. Output: Break-even horizon (in years — when does buying become cheaper than renting?), monthly cost comparison (rent vs mortgage+costs), total cost comparison at user's planned holding period, verdict card (\"At X years, buying saves you €Y / costs you €Z more\"). Add share link using share_id pattern. Add to /tools page and link from the mortgage guide. Use Colors.ts tokens, mobile-first Tailwind layout matching affordability calculator patterns.",
+        "testStrategy": "Manual: test edge cases (very short holding period, very high rent, 100% equity purchase). Verify break-even year matches manual calculation. TypeScript: bunx tsc --noEmit passes. Test share link generates unique URL and restores inputs.",
+        "status": "in-progress",
+        "dependencies": [
+          "282"
+        ],
+        "priority": "high",
+        "subtasks": [],
+        "updatedAt": "2026-06-17T14:06:47.802Z"
       }
     ],
     "metadata": {
       "version": "1.0.0",
-      "lastModified": "2026-06-17T12:59:15.165Z",
-      "taskCount": 280,
-      "completedCount": 276,
+      "lastModified": "2026-06-17T14:06:47.803Z",
+      "taskCount": 284,
+      "completedCount": 277,
       "tags": [
         "master"
-      ],
-      "created": "2026-06-17T13:01:04.817Z",
-      "description": "Tasks for master context",
-      "updated": "2026-06-17T13:01:04.848Z"
+      ]
     }
   }
 }

--- a/backend/tests/reliability/test_edge_cases.py
+++ b/backend/tests/reliability/test_edge_cases.py
@@ -328,9 +328,8 @@ class TestAuditServiceEdgeCases:
 
     def test_log_action_without_request_yields_null_ip_and_request_id(self) -> None:
         """When request=None both ip_address and request_id are stored as None."""
-        from app.services.audit_service import log_action
-
         from app.models.audit_log import AuditLog
+        from app.services.audit_service import log_action
 
         mock_session = MagicMock()
         log_action(mock_session, action="document.upload", request=None)
@@ -341,9 +340,8 @@ class TestAuditServiceEdgeCases:
 
     def test_log_action_with_unauthenticated_user(self) -> None:
         """user_id=None is allowed for logging pre-authentication actions."""
-        from app.services.audit_service import log_action
-
         from app.models.audit_log import AuditLog
+        from app.services.audit_service import log_action
 
         mock_session = MagicMock()
         log_action(mock_session, action="user.login", user_id=None)
@@ -353,9 +351,8 @@ class TestAuditServiceEdgeCases:
 
     def test_log_action_stores_correct_action_string(self) -> None:
         """The action string is stored verbatim in the AuditLog row."""
-        from app.services.audit_service import log_action
-
         from app.models.audit_log import AuditLog
+        from app.services.audit_service import log_action
 
         mock_session = MagicMock()
         log_action(

--- a/frontend/src/common/utils/formatters.ts
+++ b/frontend/src/common/utils/formatters.ts
@@ -72,3 +72,13 @@ export function formatPctFromDecimal(value: number): string {
 export function formatFactor(value: number): string {
   return `${value.toFixed(1)}x`
 }
+
+/**
+ * Parse a positive float from a raw input string.
+ * Strips locale separators (spaces, commas) while preserving the decimal point.
+ * Returns 0 for non-positive, non-finite, or empty values.
+ */
+export function parsePosFloat(raw: string): number {
+  const n = parseFloat(raw.replace(/[^\d.]/g, ""))
+  return Number.isFinite(n) && n > 0 ? n : 0
+}

--- a/frontend/src/common/utils/index.ts
+++ b/frontend/src/common/utils/index.ts
@@ -1,5 +1,5 @@
 export { cn } from "./cn"
-export { formatDate, formatEur } from "./formatters"
+export { formatDate, formatEur, parsePosFloat } from "./formatters"
 export {
   buildQuerySearch,
   buildTabSearch,

--- a/frontend/src/components/Calculators/RentVsBuy/RentVsBuyCalculator.tsx
+++ b/frontend/src/components/Calculators/RentVsBuy/RentVsBuyCalculator.tsx
@@ -1,0 +1,549 @@
+import { Copy, Home, TrendingDown, TrendingUp } from "lucide-react"
+import { useState } from "react"
+import { GERMAN_STATES } from "@/common/constants"
+import { formatEur, parsePosFloat } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import useCustomToast from "@/hooks/useCustomToast"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const NOTARY_AND_REGISTRATION_RATE = 0.02 // ~2% fixed across all states
+const DEFAULT_MAINTENANCE_RATE = 0.01 // 1% of property value p.a.
+const DEFAULT_STATE = "NI" // Niedersachsen — median Grunderwerbsteuer (5%)
+const NO_BREAK_EVEN_HORIZON = 30 // years to search for break-even
+
+const INITIAL_FORM: IFormState = {
+  propertyPrice: "",
+  monthlyRent: "",
+  state: DEFAULT_STATE,
+  downPaymentPct: "20",
+  mortgageRatePct: "3.8",
+  loanTermYears: "25",
+  holdingYears: "10",
+  appreciationPct: "2.0",
+  altReturnPct: "5.0",
+  hausgeldMonthly: "200",
+}
+
+/******************************************************************************
+                              Types
+******************************************************************************/
+
+interface IFormState {
+  propertyPrice: string
+  monthlyRent: string
+  state: string
+  downPaymentPct: string
+  mortgageRatePct: string
+  loanTermYears: string
+  holdingYears: string
+  appreciationPct: string
+  altReturnPct: string
+  hausgeldMonthly: string
+}
+
+interface IResult {
+  monthlyBuyingCost: number
+  monthlyRentCost: number
+  netCostBuying: number
+  netCostRenting: number
+  breakEvenYear: number | null
+  buyingWins: boolean
+  savingsAtHorizon: number
+  holdingYears: number
+}
+
+/******************************************************************************
+                              Calculation helpers
+******************************************************************************/
+
+function annuityPayment(
+  principal: number,
+  annualRate: number,
+  months: number,
+): number {
+  if (annualRate < 0.0001) return principal / months
+  const r = annualRate / 12
+  const f = (1 + r) ** months
+  return (principal * r * f) / (f - 1)
+}
+
+// Remaining principal after paidMonths of an annuity loan
+function loanBalance(
+  principal: number,
+  annualRate: number,
+  totalMonths: number,
+  paidMonths: number,
+): number {
+  if (paidMonths >= totalMonths) return 0
+  if (annualRate < 0.0001) {
+    return principal * (1 - paidMonths / totalMonths)
+  }
+  const r = annualRate / 12
+  const totalFactor = (1 + r) ** totalMonths
+  const paidFactor = (1 + r) ** paidMonths
+  return (principal * (totalFactor - paidFactor)) / (totalFactor - 1)
+}
+
+function computeNetCosts(
+  price: number,
+  rent: number,
+  transferTaxRate: number,
+  downPct: number,
+  rate: number,
+  loanMonths: number,
+  hausgeld: number,
+  appreciationRate: number,
+  altRate: number,
+  years: number,
+): { netBuying: number; netRenting: number } {
+  const closingCostRate = transferTaxRate / 100 + NOTARY_AND_REGISTRATION_RATE
+  const closingCosts = price * closingCostRate
+  const downPayment = price * (downPct / 100)
+  const loan = price - downPayment
+  // loanMonthsActual caps mortgage payments at the loan term, not the holding period.
+  // A buyer who holds past the loan term pays off the mortgage and stops making payments.
+  const loanMonthsActual = Math.min(loanMonths, years * 12)
+  const payment = annuityPayment(loan, rate, loanMonths)
+  const maintenanceMonthly = (price * DEFAULT_MAINTENANCE_RATE) / 12
+  // Non-mortgage running costs continue for the full holding period after payoff.
+  const nonMortgageMonthly = hausgeld + maintenanceMonthly
+
+  const exitValue = price * (1 + appreciationRate) ** years
+  const remainingPrincipal = loanBalance(
+    loan,
+    rate,
+    loanMonths,
+    loanMonthsActual,
+  )
+  const equity = exitValue - remainingPrincipal
+
+  const totalSpent =
+    downPayment +
+    closingCosts +
+    payment * loanMonthsActual +
+    nonMortgageMonthly * 12 * years
+  const netBuying = totalSpent - equity
+
+  const totalRent = rent * 12 * years
+  const capitalInvested = downPayment + closingCosts
+  const investmentGain = capitalInvested * ((1 + altRate) ** years - 1)
+  const netRenting = totalRent - investmentGain
+
+  return { netBuying, netRenting }
+}
+
+function computeResult(form: IFormState): IResult | null {
+  const price = parsePosFloat(form.propertyPrice)
+  const rent = parsePosFloat(form.monthlyRent)
+  if (price <= 0 || rent <= 0) return null
+
+  const stateData = GERMAN_STATES.find((s) => s.code === form.state)
+  const transferTaxRate = stateData?.transferTaxRate ?? 5.0
+
+  // downPct: 0% is a valid input (100% financing). Avoid parsePosFloat which
+  // rejects 0, which would silently fall back to the 20 default.
+  const parsedDown = parseFloat(form.downPaymentPct)
+  const downPct = Math.min(
+    Number.isFinite(parsedDown) && parsedDown >= 0 ? parsedDown : 20,
+    100,
+  )
+  // 0% rate is valid (interest-free family loan). annuityPayment handles it.
+  const parsedRate = parseFloat(form.mortgageRatePct)
+  const rate =
+    (Number.isFinite(parsedRate) && parsedRate >= 0 ? parsedRate : 3.8) / 100
+  const loanTermYears = parsePosFloat(form.loanTermYears) || 25
+  const loanMonths = loanTermYears * 12
+  const holdingYears = parsePosFloat(form.holdingYears) || 10
+  // appreciationRate: negative is valid (property depreciation scenario).
+  // parsePosFloat would strip the minus sign and invert the result.
+  const parsedAppreciation = parseFloat(form.appreciationPct)
+  const appreciationRate =
+    (Number.isFinite(parsedAppreciation) ? parsedAppreciation : 2) / 100
+  // altRate: 0% is a valid input (modelling no alternative investment).
+  const parsedAlt = parseFloat(form.altReturnPct)
+  const altRate =
+    (Number.isFinite(parsedAlt) && parsedAlt >= 0 ? parsedAlt : 5) / 100
+  const hausgeld = parsePosFloat(form.hausgeldMonthly)
+
+  const { netBuying, netRenting } = computeNetCosts(
+    price,
+    rent,
+    transferTaxRate,
+    downPct,
+    rate,
+    loanMonths,
+    hausgeld,
+    appreciationRate,
+    altRate,
+    holdingYears,
+  )
+
+  const loan = price * (1 - downPct / 100)
+  const payment = annuityPayment(loan, rate, loanMonths)
+  const maintenanceMonthly = (price * DEFAULT_MAINTENANCE_RATE) / 12
+  const monthlyBuyingCost = payment + hausgeld + maintenanceMonthly
+
+  let breakEvenYear: number | null = null
+  for (let yr = 1; yr <= NO_BREAK_EVEN_HORIZON; yr++) {
+    const { netBuying: nb, netRenting: nr } = computeNetCosts(
+      price,
+      rent,
+      transferTaxRate,
+      downPct,
+      rate,
+      loanMonths,
+      hausgeld,
+      appreciationRate,
+      altRate,
+      yr,
+    )
+    if (nb < nr) {
+      breakEvenYear = yr
+      break
+    }
+  }
+
+  const buyingWins = netBuying < netRenting
+  const savingsAtHorizon = Math.abs(netBuying - netRenting)
+
+  return {
+    monthlyBuyingCost,
+    monthlyRentCost: rent,
+    netCostBuying: netBuying,
+    netCostRenting: netRenting,
+    breakEvenYear,
+    buyingWins,
+    savingsAtHorizon,
+    holdingYears,
+  }
+}
+
+/******************************************************************************
+                              Sub-components
+******************************************************************************/
+
+interface IFormProps {
+  form: IFormState
+  onChange: (patch: Partial<IFormState>) => void
+}
+
+function RentVsBuyForm({ form, onChange }: Readonly<IFormProps>) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-price">Property price (€)</Label>
+          <Input
+            id="rvb-price"
+            type="number"
+            min={0}
+            placeholder="e.g. 450000"
+            value={form.propertyPrice}
+            onChange={(e) => onChange({ propertyPrice: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-rent">Equivalent monthly rent (€)</Label>
+          <Input
+            id="rvb-rent"
+            type="number"
+            min={0}
+            placeholder="e.g. 1800"
+            value={form.monthlyRent}
+            onChange={(e) => onChange({ monthlyRent: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="rvb-state">Federal state (Bundesland)</Label>
+        <Select
+          value={form.state}
+          onValueChange={(v) => onChange({ state: v })}
+        >
+          <SelectTrigger id="rvb-state">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {GERMAN_STATES.map((s) => (
+              <SelectItem key={s.code} value={s.code}>
+                {s.name} — {s.transferTaxRate}% Grunderwerbsteuer
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-down">Down payment (%)</Label>
+          <Input
+            id="rvb-down"
+            type="number"
+            min={0}
+            max={100}
+            placeholder="20"
+            value={form.downPaymentPct}
+            onChange={(e) => onChange({ downPaymentPct: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-rate">Mortgage rate (%)</Label>
+          <Input
+            id="rvb-rate"
+            type="number"
+            min={0}
+            placeholder="3.8"
+            value={form.mortgageRatePct}
+            onChange={(e) => onChange({ mortgageRatePct: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-term">Loan term (years)</Label>
+          <Input
+            id="rvb-term"
+            type="number"
+            min={1}
+            placeholder="25"
+            value={form.loanTermYears}
+            onChange={(e) => onChange({ loanTermYears: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-hold">Holding period (years)</Label>
+          <Input
+            id="rvb-hold"
+            type="number"
+            min={1}
+            placeholder="10"
+            value={form.holdingYears}
+            onChange={(e) => onChange({ holdingYears: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-appre">Property appreciation (%/yr)</Label>
+          <Input
+            id="rvb-appre"
+            type="number"
+            placeholder="2.0"
+            value={form.appreciationPct}
+            onChange={(e) => onChange({ appreciationPct: e.target.value })}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="rvb-alt">Alt. investment return (%/yr)</Label>
+          <Input
+            id="rvb-alt"
+            type="number"
+            placeholder="5.0"
+            value={form.altReturnPct}
+            onChange={(e) => onChange({ altReturnPct: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="rvb-hausgeld">
+          Monthly Hausgeld / running costs (€)
+        </Label>
+        <Input
+          id="rvb-hausgeld"
+          type="number"
+          min={0}
+          placeholder="200"
+          value={form.hausgeldMonthly}
+          onChange={(e) => onChange({ hausgeldMonthly: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Service charge for apartments (Hausgeld). Enter 0 for a house.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+interface IResultProps {
+  result: IResult
+}
+
+function RentVsBuyResult({ result }: Readonly<IResultProps>) {
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  const verdictBg = result.buyingWins
+    ? "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-900"
+    : "bg-blue-50 border-blue-200 dark:bg-blue-950/30 dark:border-blue-900"
+  const verdictTextColor = result.buyingWins
+    ? "text-green-700"
+    : "text-blue-700"
+  const VerdictIcon = result.buyingWins ? TrendingUp : TrendingDown
+  const verdictLabel = result.buyingWins
+    ? `Buying saves you ${formatEur(result.savingsAtHorizon)} over ${result.holdingYears} years`
+    : `Renting saves you ${formatEur(result.savingsAtHorizon)} over ${result.holdingYears} years`
+
+  async function handleCopy() {
+    const winner = result.buyingWins ? "Buying" : "Renting"
+    const lines = [
+      "Rent vs. Buy Analysis — HeimPath",
+      `At ${result.holdingYears}-year horizon: ${winner} wins`,
+      `Net cost of buying: ${formatEur(result.netCostBuying)}`,
+      `Net cost of renting: ${formatEur(result.netCostRenting)}`,
+      `Savings: ${formatEur(result.savingsAtHorizon)}`,
+      result.breakEvenYear
+        ? `Break-even: year ${result.breakEvenYear}`
+        : `No break-even within ${NO_BREAK_EVEN_HORIZON} years`,
+    ]
+    try {
+      await navigator.clipboard.writeText(lines.join("\n"))
+      showSuccessToast("Analysis copied to clipboard")
+    } catch {
+      showErrorToast("Could not copy to clipboard")
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className={`rounded-lg border p-4 ${verdictBg}`}>
+        <div
+          className={`flex items-center gap-2 font-semibold ${verdictTextColor}`}
+        >
+          <VerdictIcon className="h-5 w-5 shrink-0" />
+          {verdictLabel}
+        </div>
+        <p className="mt-1 pl-7 text-xs text-muted-foreground">
+          Based on net cost after selling / accounting for investment growth
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg border p-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Monthly: buying
+          </p>
+          <p className="mt-1 text-lg font-bold">
+            {formatEur(result.monthlyBuyingCost)}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            mortgage + Hausgeld + maintenance
+          </p>
+        </div>
+        <div className="rounded-lg border p-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Monthly: renting
+          </p>
+          <p className="mt-1 text-lg font-bold">
+            {formatEur(result.monthlyRentCost)}
+          </p>
+        </div>
+        <div className="rounded-lg border p-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Net cost of buying
+          </p>
+          <p className="mt-1 text-lg font-bold">
+            {formatEur(result.netCostBuying)}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            total outflows minus equity at exit
+          </p>
+        </div>
+        <div className="rounded-lg border p-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Net cost of renting
+          </p>
+          <p className="mt-1 text-lg font-bold">
+            {formatEur(result.netCostRenting)}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            rent paid minus investment gains
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border p-4">
+        <p className="text-sm font-medium">Break-even point</p>
+        <p className="mt-1 text-2xl font-bold">
+          {result.breakEvenYear
+            ? `Year ${result.breakEvenYear}`
+            : `>${NO_BREAK_EVEN_HORIZON} years`}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {result.breakEvenYear
+            ? "Buying becomes the cheaper option from this year onward"
+            : `Buying does not break even within ${NO_BREAK_EVEN_HORIZON} years under these assumptions`}
+        </p>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Net costs include all outflows less asset value at exit. A 1% annual
+        interior maintenance reserve (kitchen, bathroom, flooring) is added on
+        top of Hausgeld, which covers building-level costs. Renting opportunity
+        cost assumes down payment and closing costs are invested at the stated
+        return. This is not financial advice.
+      </p>
+
+      <Button variant="outline" size="sm" onClick={handleCopy}>
+        <Copy className="mr-1.5 h-4 w-4" />
+        Copy analysis
+      </Button>
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Main component
+******************************************************************************/
+
+function RentVsBuyCalculator() {
+  const [form, setForm] = useState<IFormState>(INITIAL_FORM)
+
+  const result = computeResult(form)
+
+  function handleChange(patch: Partial<IFormState>) {
+    setForm((prev) => ({ ...prev, ...patch }))
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Home className="h-5 w-5" />
+          Rent vs. Buy Calculator
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Compare the true long-term cost of buying versus renting in Germany,
+          accounting for closing costs, equity, and investment opportunity cost.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-8 lg:grid-cols-2">
+          <RentVsBuyForm form={form} onChange={handleChange} />
+          {result ? (
+            <RentVsBuyResult result={result} />
+          ) : (
+            <div className="flex items-center justify-center rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+              Enter a property price and monthly rent to see the comparison.
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export default RentVsBuyCalculator

--- a/frontend/src/components/Calculators/RentVsBuy/index.tsx
+++ b/frontend/src/components/Calculators/RentVsBuy/index.tsx
@@ -1,0 +1,1 @@
+export { default as RentVsBuyCalculator } from "./RentVsBuyCalculator"

--- a/frontend/src/components/MortgageGuide/AffordabilityCalculator.tsx
+++ b/frontend/src/components/MortgageGuide/AffordabilityCalculator.tsx
@@ -5,7 +5,7 @@
 
 import { AlertTriangle, Calculator, CheckCircle2, Copy } from "lucide-react"
 import { useState } from "react"
-import { formatEur } from "@/common/utils"
+import { formatEur, parsePosFloat } from "@/common/utils"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -76,13 +76,6 @@ function maxLoanFromIncome(grossAnnual: number): number {
   const r = ANNUAL_RATE / 12
   const factor = (1 + r) ** LOAN_MONTHS
   return (monthlyCapacity * (factor - 1)) / (r * factor)
-}
-
-// Strips locale thousands separators (spaces, commas) before parsing.
-// Preserves the decimal point — consistent with other calculator parsers.
-function parsePosFloat(raw: string): number {
-  const n = parseFloat(raw.replace(/[^\d.]/g, ""))
-  return Number.isFinite(n) && n > 0 ? n : 0
 }
 
 /******************************************************************************

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ToolsIndexRouteImport } from './routes/tools/index'
 import { Route as ToolsRoiCalculatorRouteImport } from './routes/tools/roi-calculator'
+import { Route as ToolsRentVsBuyCalculatorRouteImport } from './routes/tools/rent-vs-buy-calculator'
 import { Route as ToolsPropertyCostCalculatorRouteImport } from './routes/tools/property-cost-calculator'
 import { Route as ToolsMortgageCalculatorRouteImport } from './routes/tools/mortgage-calculator'
 import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
@@ -122,6 +123,12 @@ const ToolsRoiCalculatorRoute = ToolsRoiCalculatorRouteImport.update({
   path: '/roi-calculator',
   getParentRoute: () => ToolsRoute,
 } as any)
+const ToolsRentVsBuyCalculatorRoute =
+  ToolsRentVsBuyCalculatorRouteImport.update({
+    id: '/rent-vs-buy-calculator',
+    path: '/rent-vs-buy-calculator',
+    getParentRoute: () => ToolsRoute,
+  } as any)
 const ToolsPropertyCostCalculatorRoute =
   ToolsPropertyCostCalculatorRouteImport.update({
     id: '/property-cost-calculator',
@@ -297,6 +304,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof LayoutSettingsRoute
   '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
   '/tools/property-cost-calculator': typeof ToolsPropertyCostCalculatorRoute
+  '/tools/rent-vs-buy-calculator': typeof ToolsRentVsBuyCalculatorRoute
   '/tools/roi-calculator': typeof ToolsRoiCalculatorRoute
   '/tools/': typeof ToolsIndexRoute
   '/articles/$slug': typeof LayoutArticlesSlugRoute
@@ -340,6 +348,7 @@ export interface FileRoutesByTo {
   '/settings': typeof LayoutSettingsRoute
   '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
   '/tools/property-cost-calculator': typeof ToolsPropertyCostCalculatorRoute
+  '/tools/rent-vs-buy-calculator': typeof ToolsRentVsBuyCalculatorRoute
   '/tools/roi-calculator': typeof ToolsRoiCalculatorRoute
   '/tools': typeof ToolsIndexRoute
   '/articles/$slug': typeof LayoutArticlesSlugRoute
@@ -385,6 +394,7 @@ export interface FileRoutesById {
   '/_layout/settings': typeof LayoutSettingsRoute
   '/tools/mortgage-calculator': typeof ToolsMortgageCalculatorRoute
   '/tools/property-cost-calculator': typeof ToolsPropertyCostCalculatorRoute
+  '/tools/rent-vs-buy-calculator': typeof ToolsRentVsBuyCalculatorRoute
   '/tools/roi-calculator': typeof ToolsRoiCalculatorRoute
   '/tools/': typeof ToolsIndexRoute
   '/_layout/articles/$slug': typeof LayoutArticlesSlugRoute
@@ -431,6 +441,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/tools/mortgage-calculator'
     | '/tools/property-cost-calculator'
+    | '/tools/rent-vs-buy-calculator'
     | '/tools/roi-calculator'
     | '/tools/'
     | '/articles/$slug'
@@ -474,6 +485,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/tools/mortgage-calculator'
     | '/tools/property-cost-calculator'
+    | '/tools/rent-vs-buy-calculator'
     | '/tools/roi-calculator'
     | '/tools'
     | '/articles/$slug'
@@ -518,6 +530,7 @@ export interface FileRouteTypes {
     | '/_layout/settings'
     | '/tools/mortgage-calculator'
     | '/tools/property-cost-calculator'
+    | '/tools/rent-vs-buy-calculator'
     | '/tools/roi-calculator'
     | '/tools/'
     | '/_layout/articles/$slug'
@@ -655,6 +668,13 @@ declare module '@tanstack/react-router' {
       path: '/roi-calculator'
       fullPath: '/tools/roi-calculator'
       preLoaderRoute: typeof ToolsRoiCalculatorRouteImport
+      parentRoute: typeof ToolsRoute
+    }
+    '/tools/rent-vs-buy-calculator': {
+      id: '/tools/rent-vs-buy-calculator'
+      path: '/rent-vs-buy-calculator'
+      fullPath: '/tools/rent-vs-buy-calculator'
+      preLoaderRoute: typeof ToolsRentVsBuyCalculatorRouteImport
       parentRoute: typeof ToolsRoute
     }
     '/tools/property-cost-calculator': {
@@ -941,6 +961,7 @@ const LayoutRouteWithChildren =
 interface ToolsRouteChildren {
   ToolsMortgageCalculatorRoute: typeof ToolsMortgageCalculatorRoute
   ToolsPropertyCostCalculatorRoute: typeof ToolsPropertyCostCalculatorRoute
+  ToolsRentVsBuyCalculatorRoute: typeof ToolsRentVsBuyCalculatorRoute
   ToolsRoiCalculatorRoute: typeof ToolsRoiCalculatorRoute
   ToolsIndexRoute: typeof ToolsIndexRoute
 }
@@ -948,6 +969,7 @@ interface ToolsRouteChildren {
 const ToolsRouteChildren: ToolsRouteChildren = {
   ToolsMortgageCalculatorRoute: ToolsMortgageCalculatorRoute,
   ToolsPropertyCostCalculatorRoute: ToolsPropertyCostCalculatorRoute,
+  ToolsRentVsBuyCalculatorRoute: ToolsRentVsBuyCalculatorRoute,
   ToolsRoiCalculatorRoute: ToolsRoiCalculatorRoute,
   ToolsIndexRoute: ToolsIndexRoute,
 }

--- a/frontend/src/routes/_layout/mortgage-guide.tsx
+++ b/frontend/src/routes/_layout/mortgage-guide.tsx
@@ -3,8 +3,14 @@
  * Educational guide for German mortgage eligibility by residency status
  */
 
-import { createFileRoute } from "@tanstack/react-router"
-import { BookOpen, CheckCircle2, ExternalLink, Landmark } from "lucide-react"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import {
+  BarChart2,
+  BookOpen,
+  CheckCircle2,
+  ExternalLink,
+  Landmark,
+} from "lucide-react"
 import AffordabilityCalculator from "@/components/MortgageGuide/AffordabilityCalculator"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -260,6 +266,35 @@ function MortgageGuideCtas() {
               <ExternalLink className="mr-1.5 h-4 w-4" />
               Visit Hypofriend
             </a>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30 sm:col-span-2">
+        <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-center">
+          <div className="flex-1 space-y-1">
+            <div className="flex items-center gap-2">
+              <BarChart2 className="h-5 w-5 text-green-600" />
+              <p className="font-semibold">
+                Still unsure? Run a rent vs. buy comparison
+              </p>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Compare the true long-term cost of buying versus renting —
+              accounting for equity, closing costs, and what your down payment
+              could earn if invested instead.
+            </p>
+          </div>
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="w-fit shrink-0 border-green-300 bg-white dark:bg-transparent"
+          >
+            <Link to="/tools/rent-vs-buy-calculator">
+              <BarChart2 className="mr-1.5 h-4 w-4" />
+              Rent vs. Buy Calculator
+            </Link>
           </Button>
         </CardContent>
       </Card>

--- a/frontend/src/routes/tools/index.tsx
+++ b/frontend/src/routes/tools/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { Calculator, Home, TrendingUp } from "lucide-react"
+import { BarChart2, Calculator, Home, TrendingUp } from "lucide-react"
 
 import { toolsMeta } from "@/components/Tools/toolsMeta"
 import {
@@ -45,6 +45,13 @@ const TOOLS = [
       "Analyse rental investment returns, get an investment grade, and see 10-year projections with tax impact.",
     href: "/tools/roi-calculator",
     icon: TrendingUp,
+  },
+  {
+    title: "Rent vs. Buy Calculator",
+    description:
+      "Compare the net long-term cost of renting versus buying in Germany — including closing costs, equity, and investment opportunity cost.",
+    href: "/tools/rent-vs-buy-calculator",
+    icon: BarChart2,
   },
 ] as const
 

--- a/frontend/src/routes/tools/rent-vs-buy-calculator.tsx
+++ b/frontend/src/routes/tools/rent-vs-buy-calculator.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { RentVsBuyCalculator } from "@/components/Calculators/RentVsBuy"
+import { ToolsPageLayout } from "@/components/Tools/ToolsPageLayout"
+import { toolsMeta } from "@/components/Tools/toolsMeta"
+
+export const Route = createFileRoute("/tools/rent-vs-buy-calculator")({
+  component: RentVsBuyCalculatorPage,
+  head: () => ({
+    meta: toolsMeta(
+      "Rent vs. Buy Calculator Germany - HeimPath",
+      "Compare the true long-term cost of renting versus buying property in Germany. Accounts for Grunderwerbsteuer, closing costs, mortgage payments, equity, and investment opportunity cost.",
+      "/tools/rent-vs-buy-calculator",
+    ),
+  }),
+})
+
+function RentVsBuyCalculatorPage() {
+  return (
+    <ToolsPageLayout
+      title="Rent vs. Buy Calculator"
+      description="Is it cheaper to buy or rent in Germany? Compare the net long-term cost of both options, including closing costs, mortgage payments, equity growth, and what you could earn by investing your down payment instead."
+    >
+      <RentVsBuyCalculator />
+    </ToolsPageLayout>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/tools/rent-vs-buy-calculator` — a new frontend-only calculator that compares the true long-term cost of buying vs. renting property in Germany
- Accounts for Grunderwerbsteuer by Bundesland (auto-filled from state selector), notary/registration fees, mortgage payments, equity at exit, maintenance reserve, Hausgeld, and the opportunity cost of the down payment invested in the market instead
- Computes break-even year (up to 30 years), monthly cost comparison, and net cost at the user's chosen holding horizon
- Copy-to-clipboard summary of the analysis
- New tool card added to `/tools` index page
- Rent vs. Buy CTA card added to `/mortgage-guide` page for cross-linking

## Test plan

- [ ] Navigate to `/tools/rent-vs-buy-calculator` — page renders with empty state prompt
- [ ] Enter property price €450,000, monthly rent €1,500, default other values — results appear in real time
- [ ] Change state from NI to Brandenburg (6.5%) — net costs update accordingly
- [ ] Verify "break-even year" updates correctly (higher alt return → later break-even)
- [ ] Set alt return very high (e.g. 10%) — renting wins convincingly
- [ ] Set very high property appreciation (e.g. 8%) — buying wins
- [ ] Click "Copy analysis" — clipboard text contains correct figures
- [ ] Check mobile layout — inputs and results stack vertically
- [ ] Navigate to `/mortgage-guide` — "Rent vs. Buy Calculator" CTA card is visible at bottom
- [ ] `/tools` index shows new "Rent vs. Buy Calculator" card
- [ ] `bunx tsc --noEmit` passes