### PR TITLE
feat(seo): add SSG pre-rendering for public routes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,7 +74,7 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"><!--app-html--></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -31,6 +31,6 @@ server {
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;
-    try_files $uri /index.html =404;
+    try_files $uri $uri/ /index.html;
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -p tsconfig.build.json && vite build",
+    "build": "tsc -p tsconfig.build.json && vite build && vite build --ssr src/entry-server.tsx --outDir dist/server && node prerender.mjs",
     "lint": "biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true ./",
     "preview": "vite preview",
     "generate-client": "openapi-ts",

--- a/frontend/prerender.mjs
+++ b/frontend/prerender.mjs
@@ -70,7 +70,9 @@ for (const url of ROUTES) {
     }
 
     const outPath =
-      url === "/" ? resolve(scriptDir, "dist/index.html") : resolve(scriptDir, `dist${url}/index.html`)
+      url === "/"
+        ? resolve(scriptDir, "dist/index.html")
+        : resolve(scriptDir, `dist${url}/index.html`)
     mkdirSync(dirname(outPath), { recursive: true })
     writeFileSync(outPath, html)
     console.log(`  ✓ pre-rendered ${url}`)

--- a/frontend/prerender.mjs
+++ b/frontend/prerender.mjs
@@ -51,18 +51,21 @@ for (const url of ROUTES) {
     // 1. Replace generic <title> with route-specific one (if SSR produced one)
     // 2. Append any remaining SSR head tags before </head>
     // 3. Inject rendered body content into #root placeholder
-    let html = template.replace("<!--app-html-->", bodyHtml)
+    // Use replacer functions to prevent $ sequences in content (e.g. $$, $&)
+    // from being misinterpreted as String.replace capture-group specials.
+    let html = template.replace("<!--app-html-->", () => bodyHtml)
 
     if (headTags) {
       // Replace the fallback <title> with the SSR-rendered route-specific title
       const ssrTitle = headTags.match(/<title[^>]*>[\s\S]*?<\/title>/)
       if (ssrTitle) {
-        html = html.replace(/<title[^>]*>[\s\S]*?<\/title>/, ssrTitle[0])
+        html = html.replace(/<title[^>]*>[\s\S]*?<\/title>/, () => ssrTitle[0])
         headTags = headTags.replace(ssrTitle[0], "")
       }
       // Append remaining meta/link tags before </head>
       if (headTags.trim()) {
-        html = html.replace("</head>", `${headTags}\n  </head>`)
+        const remaining = headTags
+        html = html.replace("</head>", () => `${remaining}\n  </head>`)
       }
     }
 

--- a/frontend/prerender.mjs
+++ b/frontend/prerender.mjs
@@ -2,16 +2,16 @@
 // Run after `vite build` + `vite build --ssr`.
 // Output: dist/index.html, dist/tools/index.html, etc.
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { dirname } from "node:path"
+import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 // Suppress React's "act" warning in Node environment
 process.env.IS_REACT_ACT_ENVIRONMENT = "false"
 
-const _dirname = dirname(fileURLToPath(import.meta.url))
+const scriptDir = dirname(fileURLToPath(import.meta.url))
 const { render } = await import("./dist/server/entry-server.js")
 
-const template = readFileSync("./dist/index.html", "utf-8")
+const template = readFileSync(resolve(scriptDir, "dist/index.html"), "utf-8")
 
 const ROUTES = [
   "/",
@@ -26,12 +26,55 @@ const ROUTES = [
 ]
 
 for (const url of ROUTES) {
-  const appHtml = await render(url)
-  const html = template.replace("<!--app-html-->", appHtml)
-  const outPath = url === "/" ? "./dist/index.html" : `./dist${url}/index.html`
-  mkdirSync(dirname(outPath), { recursive: true })
-  writeFileSync(outPath, html)
-  console.log(`  ✓ pre-rendered ${url}`)
+  try {
+    const appHtml = await render(url)
+
+    // TanStack Router renders head tags (<title>, <meta>, <link>) as part of
+    // the renderToString output. Extract them and place them in <head> where
+    // they belong semantically, then inject only the body content into #root.
+    let headTags = ""
+    let bodyHtml = appHtml
+
+    // Extract <title>
+    bodyHtml = bodyHtml.replace(/<title[^>]*>[\s\S]*?<\/title>/g, (match) => {
+      headTags += match
+      return ""
+    })
+
+    // Extract <meta> and <link> elements (head-only in HTML)
+    bodyHtml = bodyHtml.replace(/<(?:meta|link)[^>]*\/?>/g, (match) => {
+      headTags += match
+      return ""
+    })
+
+    // Build the final HTML:
+    // 1. Replace generic <title> with route-specific one (if SSR produced one)
+    // 2. Append any remaining SSR head tags before </head>
+    // 3. Inject rendered body content into #root placeholder
+    let html = template.replace("<!--app-html-->", bodyHtml)
+
+    if (headTags) {
+      // Replace the fallback <title> with the SSR-rendered route-specific title
+      const ssrTitle = headTags.match(/<title[^>]*>[\s\S]*?<\/title>/)
+      if (ssrTitle) {
+        html = html.replace(/<title[^>]*>[\s\S]*?<\/title>/, ssrTitle[0])
+        headTags = headTags.replace(ssrTitle[0], "")
+      }
+      // Append remaining meta/link tags before </head>
+      if (headTags.trim()) {
+        html = html.replace("</head>", `${headTags}\n  </head>`)
+      }
+    }
+
+    const outPath =
+      url === "/" ? resolve(scriptDir, "dist/index.html") : resolve(scriptDir, `dist${url}/index.html`)
+    mkdirSync(dirname(outPath), { recursive: true })
+    writeFileSync(outPath, html)
+    console.log(`  ✓ pre-rendered ${url}`)
+  } catch (err) {
+    console.error(`  ✗ failed to pre-render ${url}:`, err.message)
+    process.exitCode = 1
+  }
 }
 
-console.log(`\nSSG complete — ${ROUTES.length} routes pre-rendered.`)
+console.log(`\nSSG complete — ${ROUTES.length} routes attempted.`)

--- a/frontend/prerender.mjs
+++ b/frontend/prerender.mjs
@@ -1,0 +1,37 @@
+// Pre-renders public routes to static HTML at build time (SSG).
+// Run after `vite build` + `vite build --ssr`.
+// Output: dist/index.html, dist/tools/index.html, etc.
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+// Suppress React's "act" warning in Node environment
+process.env.IS_REACT_ACT_ENVIRONMENT = "false"
+
+const _dirname = dirname(fileURLToPath(import.meta.url))
+const { render } = await import("./dist/server/entry-server.js")
+
+const template = readFileSync("./dist/index.html", "utf-8")
+
+const ROUTES = [
+  "/",
+  "/tools",
+  "/tools/mortgage-calculator",
+  "/tools/property-cost-calculator",
+  "/tools/rent-vs-buy-calculator",
+  "/tools/roi-calculator",
+  "/imprint",
+  "/privacy",
+  "/terms",
+]
+
+for (const url of ROUTES) {
+  const appHtml = await render(url)
+  const html = template.replace("<!--app-html-->", appHtml)
+  const outPath = url === "/" ? "./dist/index.html" : `./dist${url}/index.html`
+  mkdirSync(dirname(outPath), { recursive: true })
+  writeFileSync(outPath, html)
+  console.log(`  ✓ pre-rendered ${url}`)
+}
+
+console.log(`\nSSG complete — ${ROUTES.length} routes pre-rendered.`)

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -35,12 +35,16 @@ export function ThemeProvider({
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
+    () =>
+      (typeof window !== "undefined"
+        ? (localStorage.getItem(storageKey) as Theme)
+        : null) || defaultTheme,
   )
 
   const getResolvedTheme = useCallback((theme: Theme): "dark" | "light" => {
     if (theme === "system") {
-      return window.matchMedia("(prefers-color-scheme: dark)").matches
+      return typeof window !== "undefined" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
         ? "dark"
         : "light"
     }
@@ -52,6 +56,7 @@ export function ThemeProvider({
   )
 
   const updateTheme = useCallback((newTheme: Theme) => {
+    if (typeof window === "undefined") return
     const root = window.document.documentElement
 
     root.classList.remove("light", "dark")
@@ -73,6 +78,7 @@ export function ThemeProvider({
     updateTheme(theme)
     setResolvedTheme(getResolvedTheme(theme))
 
+    if (typeof window === "undefined") return
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
 
     const handleChange = () => {
@@ -93,7 +99,7 @@ export function ThemeProvider({
     theme,
     resolvedTheme,
     setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme)
+      if (typeof window !== "undefined") localStorage.setItem(storageKey, theme)
       setTheme(theme)
     },
   }

--- a/frontend/src/entry-server.tsx
+++ b/frontend/src/entry-server.tsx
@@ -1,0 +1,29 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  createMemoryHistory,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router"
+import { renderToString } from "react-dom/server"
+
+import { routeTree } from "./routeTree.gen"
+
+export async function render(url: string): Promise<string> {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  })
+  const memoryHistory = createMemoryHistory({ initialEntries: [url] })
+  const router = createRouter({
+    routeTree,
+    history: memoryHistory,
+    defaultPreloadStaleTime: 0,
+  })
+  await router.load()
+  return renderToString(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -21,6 +21,7 @@ import useCustomToast from "./useCustomToast"
  * (e.g. in TanStack Router `beforeLoad`) without touching localStorage.
  */
 const isLoggedIn = () => {
+  if (typeof document === "undefined") return false
   return document.cookie.split(";").some((c) => c.trim() === "logged_in=1")
 }
 

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -8,7 +8,7 @@ import NotFound from "@/components/Common/NotFound"
 export const Route = createRootRoute({
   component: () => (
     <>
-      {typeof document !== "undefined" && <HeadContent />}
+      <HeadContent />
       <ErrorBoundary>
         <Outlet />
       </ErrorBoundary>

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -8,7 +8,7 @@ import NotFound from "@/components/Common/NotFound"
 export const Route = createRootRoute({
   component: () => (
     <>
-      <HeadContent />
+      {typeof document !== "undefined" && <HeadContent />}
       <ErrorBoundary>
         <Outlet />
       </ErrorBoundary>


### PR DESCRIPTION
## Summary

- Implements Static Site Generation (SSG) for 9 public routes using Vite's built-in SSR mode + a post-build pre-render script
- Google now sees full HTML content without executing JavaScript
- No runtime Node.js server needed — nginx serves pre-rendered static files

**Root cause**: React SPA served a bare `<div id="root"></div>` to all requests. Googlebot saw an empty page.

**Fix**: At build time, each public route is rendered to HTML via `renderToString` and written to `dist/route/index.html`. Nginx picks these up via `try_files $uri $uri/ /index.html`.

**Files changed:**
- `frontend/src/entry-server.tsx` (new) — SSR entry point using TanStack Router + `createMemoryHistory`
- `frontend/prerender.mjs` (new) — post-build script rendering `/`, `/tools/*`, `/imprint`, `/privacy`, `/terms`
- `frontend/src/components/theme-provider.tsx` — SSR guards on `localStorage` and `window.matchMedia`
- `frontend/src/hooks/useAuth.ts` — SSR guard on `document.cookie` in `isLoggedIn()`
- `frontend/src/routes/__root.tsx` — make `<HeadContent />` client-only to keep tags in `<head>`
- `frontend/index.html` — add `<!--app-html-->` placeholder for SSR injection
- `frontend/nginx.conf.template` — add `$uri/` to `try_files` so directory indexes are served
- `frontend/package.json` — build script runs SSR build + prerender after client build

## Test plan

- [ ] `cd frontend && bun run build` completes without errors and logs "SSG complete — 9 routes pre-rendered"
- [ ] `dist/index.html` contains actual HeimPath landing page HTML (header, hero section) inside `#root`
- [ ] `dist/tools/index.html` contains tools page HTML
- [ ] Disable JavaScript in browser devtools, visit `bun run preview` — pages render visible content without JS
- [ ] Existing frontend functionality (auth, calculators, journeys) works normally with JS enabled