### PR TITLE
feat(seo): add canonical URLs, fix sitemap and robots.txt

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -11,5 +11,12 @@ Disallow: /journeys
 Disallow: /portfolio
 Disallow: /articles
 Disallow: /search
+Disallow: /laws
+Disallow: /mortgage-guide
+Disallow: /bank-account-guide
+Disallow: /notifications
+Disallow: /professionals
+Disallow: /glossary
+Disallow: /contract-explainer
 
 Sitemap: https://heimpath.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,79 +2,55 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://heimpath.com/</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/property-cost-calculator</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/mortgage-calculator</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/roi-calculator</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/rent-vs-buy-calculator</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://heimpath.com/mortgage-guide</loc>
-    <lastmod>2026-06-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://heimpath.com/bank-account-guide</loc>
-    <lastmod>2026-06-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://heimpath.com/login</loc>
-    <lastmod>2026-04-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://heimpath.com/signup</loc>
-    <lastmod>2026-04-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://heimpath.com/terms</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://heimpath.com/privacy</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://heimpath.com/imprint</loc>
-    <lastmod>2026-04-22</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -37,6 +37,18 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://heimpath.com/login</loc>
+    <lastmod>2026-06-18</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/signup</loc>
+    <lastmod>2026-06-18</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
     <loc>https://heimpath.com/terms</loc>
     <lastmod>2026-06-18</lastmod>
     <changefreq>yearly</changefreq>

--- a/frontend/src/common/seo.ts
+++ b/frontend/src/common/seo.ts
@@ -107,4 +107,3 @@ function seoMeta(options: SeoOptions): SeoHead {
 ******************************************************************************/
 
 export { seoMeta }
-export type { SeoHead }

--- a/frontend/src/common/seo.ts
+++ b/frontend/src/common/seo.ts
@@ -27,6 +27,8 @@ type MetaTag =
   | { name: string; content: string }
   | { property: string; content: string }
 
+type LinkTag = { rel: string; href: string }
+
 interface SeoOptions {
   /** Page title — will be set as <title> and og:title */
   title: string
@@ -42,12 +44,18 @@ interface SeoOptions {
   ogType?: string
 }
 
+/** Return type for seoMeta — matches TanStack Router head() object shape. */
+interface SeoHead {
+  meta: MetaTag[]
+  links: LinkTag[]
+}
+
 /******************************************************************************
                               Functions
 ******************************************************************************/
 
-/** Build a complete SEO meta array for a TanStack Router head() function. */
-function seoMeta(options: SeoOptions) {
+/** Build a complete SEO head object for a TanStack Router head() function. */
+function seoMeta(options: SeoOptions): SeoHead {
   const {
     title,
     description = DEFAULT_DESCRIPTION,
@@ -87,7 +95,11 @@ function seoMeta(options: SeoOptions) {
     meta.push({ property: "og:url", content: canonicalUrl })
   }
 
-  return meta
+  const links: LinkTag[] = canonicalUrl
+    ? [{ rel: "canonical", href: canonicalUrl }]
+    : []
+
+  return { meta, links }
 }
 
 /******************************************************************************
@@ -95,3 +107,4 @@ function seoMeta(options: SeoOptions) {
 ******************************************************************************/
 
 export { seoMeta }
+export type { SeoHead }

--- a/frontend/src/components/Tools/toolsMeta.ts
+++ b/frontend/src/components/Tools/toolsMeta.ts
@@ -5,7 +5,7 @@
 
 import { seoMeta } from "@/common/seo"
 
-/** Build SEO meta array for a tools page. */
+/** Build SEO head object for a tools page. */
 function toolsMeta(title: string, description: string, path?: string) {
   return seoMeta({ title, description, path })
 }

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -36,15 +36,15 @@ export function ThemeProvider({
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
     () =>
-      (typeof window !== "undefined"
-        ? (localStorage.getItem(storageKey) as Theme)
-        : null) || defaultTheme,
+      (typeof globalThis.window === "undefined"
+        ? null
+        : (localStorage.getItem(storageKey) as Theme)) || defaultTheme,
   )
 
   const getResolvedTheme = useCallback((theme: Theme): "dark" | "light" => {
     if (theme === "system") {
-      return typeof window !== "undefined" &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches
+      return typeof globalThis.window !== "undefined" &&
+        globalThis.window.matchMedia("(prefers-color-scheme: dark)").matches
         ? "dark"
         : "light"
     }
@@ -56,14 +56,15 @@ export function ThemeProvider({
   )
 
   const updateTheme = useCallback((newTheme: Theme) => {
-    if (typeof window === "undefined") return
-    const root = window.document.documentElement
+    if (typeof globalThis.window === "undefined") return
+    const root = globalThis.window.document.documentElement
 
     root.classList.remove("light", "dark")
 
     if (newTheme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-        .matches
+      const systemTheme = globalThis.window.matchMedia(
+        "(prefers-color-scheme: dark)",
+      ).matches
         ? "dark"
         : "light"
 
@@ -78,8 +79,10 @@ export function ThemeProvider({
     updateTheme(theme)
     setResolvedTheme(getResolvedTheme(theme))
 
-    if (typeof window === "undefined") return
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    if (typeof globalThis.window === "undefined") return
+    const mediaQuery = globalThis.window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    )
 
     const handleChange = () => {
       if (theme === "system") {
@@ -99,7 +102,8 @@ export function ThemeProvider({
     theme,
     resolvedTheme,
     setTheme: (theme: Theme) => {
-      if (typeof window !== "undefined") localStorage.setItem(storageKey, theme)
+      if (typeof globalThis.window !== "undefined")
+        localStorage.setItem(storageKey, theme)
       setTheme(theme)
     },
   }

--- a/frontend/src/routes/_layout/bank-account-guide.tsx
+++ b/frontend/src/routes/_layout/bank-account-guide.tsx
@@ -23,7 +23,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 export const Route = createFileRoute("/_layout/bank-account-guide")({
   component: BankAccountGuidePage,
   head: () => ({
-    meta: seoMeta({
+    ...seoMeta({
       title:
         "German Bank Account for Non-Residents & Foreign Buyers - HeimPath",
       description:

--- a/frontend/src/routes/_layout/bank-account-guide.tsx
+++ b/frontend/src/routes/_layout/bank-account-guide.tsx
@@ -28,7 +28,6 @@ export const Route = createFileRoute("/_layout/bank-account-guide")({
         "German Bank Account for Non-Residents & Foreign Buyers - HeimPath",
       description:
         "How to open a German bank account as a foreign buyer or non-resident. Compare N26, DKB, Deutsche Bank and Commerzbank, required documents, and step-by-step process.",
-      path: "/bank-account-guide",
     }),
   }),
 })

--- a/frontend/src/routes/imprint.tsx
+++ b/frontend/src/routes/imprint.tsx
@@ -18,7 +18,7 @@ import { LandingHeader } from "@/components/Landing/LandingHeader"
 export const Route = createFileRoute("/imprint")({
   component: ImprintPage,
   head: () => ({
-    meta: seoMeta({
+    ...seoMeta({
       title: "Imprint - HeimPath",
       description:
         "Impressum (Imprint) for HeimPath pursuant to §5 TMG. Company information, contact details, and legal notices.",

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,7 +6,7 @@ import LandingPage from "@/components/Landing/LandingPage"
 export const Route = createFileRoute("/")({
   component: LandingPage,
   head: () => ({
-    meta: seoMeta({
+    ...seoMeta({
       title: "HeimPath - Navigate German Real Estate with Confidence",
       path: "/",
     }),

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -58,7 +58,7 @@ export const Route = createFileRoute("/login")({
     }
   },
   head: () => ({
-    meta: seoMeta({
+    ...seoMeta({
       title: "Log In - HeimPath",
       description:
         "Log in to your HeimPath account to continue your German property buying journey.",

--- a/frontend/src/routes/privacy.tsx
+++ b/frontend/src/routes/privacy.tsx
@@ -14,7 +14,7 @@ import { LandingHeader } from "@/components/Landing/LandingHeader"
 export const Route = createFileRoute("/privacy")({
   component: PrivacyPage,
   head: () => ({
-    meta: seoMeta({
+    ...seoMeta({
       title: "Privacy Policy - HeimPath",
       description:
         "HeimPath privacy policy. Learn how we collect, use, and protect your personal data in compliance with GDPR.",

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -77,7 +77,7 @@ export const Route = createFileRoute("/signup")({
     }
   },
   head: () => ({
-    meta: seoMeta({
+    ...seoMeta({
       title: "Sign Up - HeimPath",
       description:
         "Create a free HeimPath account to start your guided German property buying journey with personalised steps and financial tools.",

--- a/frontend/src/routes/terms.tsx
+++ b/frontend/src/routes/terms.tsx
@@ -13,7 +13,7 @@ import { LandingHeader } from "@/components/Landing/LandingHeader"
 export const Route = createFileRoute("/terms")({
   component: TermsPage,
   head: () => ({
-    meta: seoMeta({
+    ...seoMeta({
       title: "Terms of Service - HeimPath",
       description:
         "Terms of Service for HeimPath, the German real estate navigator for foreign investors and immigrants.",

--- a/frontend/src/routes/tools/index.tsx
+++ b/frontend/src/routes/tools/index.tsx
@@ -12,7 +12,7 @@ import {
 export const Route = createFileRoute("/tools/")({
   component: ToolsIndexPage,
   head: () => ({
-    meta: toolsMeta(
+    ...toolsMeta(
       "Free German Property Calculators - HeimPath",
       "Free calculators for buying property in Germany. Estimate hidden costs, mortgage payments, and rental ROI — no sign-up required.",
       "/tools",

--- a/frontend/src/routes/tools/mortgage-calculator.tsx
+++ b/frontend/src/routes/tools/mortgage-calculator.tsx
@@ -7,7 +7,7 @@ import { toolsMeta } from "@/components/Tools/toolsMeta"
 export const Route = createFileRoute("/tools/mortgage-calculator")({
   component: MortgageCalculatorPage,
   head: () => ({
-    meta: toolsMeta(
+    ...toolsMeta(
       "German Mortgage Calculator with Amortisation Schedule - HeimPath",
       "Calculate monthly mortgage payments for German property. View a full amortisation schedule and compare interest rates side by side.",
       "/tools/mortgage-calculator",

--- a/frontend/src/routes/tools/property-cost-calculator.tsx
+++ b/frontend/src/routes/tools/property-cost-calculator.tsx
@@ -7,7 +7,7 @@ import { toolsMeta } from "@/components/Tools/toolsMeta"
 export const Route = createFileRoute("/tools/property-cost-calculator")({
   component: PropertyCostCalculatorPage,
   head: () => ({
-    meta: toolsMeta(
+    ...toolsMeta(
       "German Property Purchase Cost Calculator - HeimPath",
       "Calculate the total cost of buying property in Germany. Includes transfer tax, notary fees, land registry, agent commission, and renovation estimates by state.",
       "/tools/property-cost-calculator",

--- a/frontend/src/routes/tools/rent-vs-buy-calculator.tsx
+++ b/frontend/src/routes/tools/rent-vs-buy-calculator.tsx
@@ -6,7 +6,7 @@ import { toolsMeta } from "@/components/Tools/toolsMeta"
 export const Route = createFileRoute("/tools/rent-vs-buy-calculator")({
   component: RentVsBuyCalculatorPage,
   head: () => ({
-    meta: toolsMeta(
+    ...toolsMeta(
       "Rent vs. Buy Calculator Germany - HeimPath",
       "Compare the true long-term cost of renting versus buying property in Germany. Accounts for Grunderwerbsteuer, closing costs, mortgage payments, equity, and investment opportunity cost.",
       "/tools/rent-vs-buy-calculator",

--- a/frontend/src/routes/tools/roi-calculator.tsx
+++ b/frontend/src/routes/tools/roi-calculator.tsx
@@ -7,7 +7,7 @@ import { toolsMeta } from "@/components/Tools/toolsMeta"
 export const Route = createFileRoute("/tools/roi-calculator")({
   component: ROICalculatorPage,
   head: () => ({
-    meta: toolsMeta(
+    ...toolsMeta(
       "German Rental Property ROI Calculator - HeimPath",
       "Analyse rental investment returns in Germany. Calculate gross yield, cap rate, cash-on-cash return, and view 10-year projections with German tax impact.",
       "/tools/roi-calculator",


### PR DESCRIPTION
## Summary

- `seoMeta()` now returns `{ meta, links }` — adds `<link rel="canonical">` for every page that declares a `path`. All 12 callers updated to spread the result into `head()`
- Fix `sitemap.xml`: removed auth-gated pages (`/mortgage-guide`, `/bank-account-guide`), updated all `lastmod` dates to today
- Fix `robots.txt`: added `Disallow` rules for all auth-gated `_layout` routes that were previously missing (mortgage-guide, bank-account-guide, laws, professionals, glossary, notifications, contract-explainer)

This is the second part of fixing zero Google indexing (task #287). The first part was SSR pre-rendering (PR #363).

## Test plan

- [ ] `cd frontend && bunx tsc --noEmit` — no type errors
- [ ] `bun run build` — all 9 routes pre-rendered, canonical `<link>` tag appears in pre-rendered HTML
- [ ] Check `dist/index.html` — `<link rel="canonical" href="https://heimpath.com/">` present in `<head>`
- [ ] Check `dist/tools/mortgage-calculator/index.html` — canonical href is `/tools/mortgage-calculator`
- [ ] `robots.txt` accessible at `https://heimpath.com/robots.txt` — all auth pages disallowed
- [ ] `sitemap.xml` at `https://heimpath.com/sitemap.xml` — only public pages, no auth-gated routes