### PR TITLE
feat(landing): embed property cost calculator on homepage

### DIFF
--- a/frontend/src/components/Landing/FreeToolsSection.tsx
+++ b/frontend/src/components/Landing/FreeToolsSection.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router"
-import { ArrowRight, Calculator, Home, TrendingUp } from "lucide-react"
+import { ArrowRight, Home, TrendingUp } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -17,14 +17,6 @@ import { AnimateIn } from "./AnimateIn"
 ******************************************************************************/
 
 const FREE_TOOLS = [
-  {
-    icon: Calculator,
-    title: "Property Cost Calculator",
-    description:
-      "Estimate Grunderwerbsteuer, notary fees, agent commission, and all closing costs before you make an offer.",
-    href: "/tools/property-cost-calculator",
-    color: "text-blue-600 bg-blue-50 dark:bg-blue-950/40 dark:text-blue-400",
-  },
   {
     icon: Home,
     title: "Mortgage Calculator",
@@ -60,17 +52,16 @@ function FreeToolsSection() {
               No sign-up required
             </span>
             <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
-              Try Our Free Property Tools
+              More Free Property Tools
             </h2>
             <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
-              Get a clear financial picture before you commit — our calculators
-              are free to use and built specifically for buying property in
-              Germany.
+              Plan your mortgage and analyse rental yields — free, no account
+              needed.
             </p>
           </div>
         </AnimateIn>
 
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-6 sm:grid-cols-2">
           {FREE_TOOLS.map((tool) => (
             <AnimateIn key={tool.href}>
               <Card className="flex h-full flex-col">

--- a/frontend/src/components/Landing/HomepageCalculatorSection.tsx
+++ b/frontend/src/components/Landing/HomepageCalculatorSection.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@tanstack/react-router"
 import { HiddenCostsCalculator } from "@/components/Calculators/HiddenCostsCalculator"
 import { AnimateIn } from "./AnimateIn"
 
@@ -27,19 +26,6 @@ function HomepageCalculatorSection() {
         </AnimateIn>
 
         <HiddenCostsCalculator />
-
-        <AnimateIn>
-          <p className="mt-8 text-center text-sm text-muted-foreground">
-            <Link
-              to="/signup"
-              className="font-medium text-primary hover:underline"
-            >
-              Create a free account
-            </Link>{" "}
-            to save results, compare properties, and unlock your guided buying
-            journey.
-          </p>
-        </AnimateIn>
       </div>
     </section>
   )
@@ -49,4 +35,4 @@ function HomepageCalculatorSection() {
                               Export
 ******************************************************************************/
 
-export { HomepageCalculatorSection }
+export default HomepageCalculatorSection

--- a/frontend/src/components/Landing/HomepageCalculatorSection.tsx
+++ b/frontend/src/components/Landing/HomepageCalculatorSection.tsx
@@ -1,0 +1,52 @@
+import { Link } from "@tanstack/react-router"
+import { HiddenCostsCalculator } from "@/components/Calculators/HiddenCostsCalculator"
+import { AnimateIn } from "./AnimateIn"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Embeds the property cost calculator on the landing page — no sign-up required. */
+function HomepageCalculatorSection() {
+  return (
+    <section className="border-y bg-muted/30 py-16 md:py-24" id="calculator">
+      <div className="mx-auto max-w-7xl px-4 md:px-6">
+        <AnimateIn>
+          <div className="mb-10 text-center md:mb-14">
+            <span className="mb-3 inline-block rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+              Free · No sign-up required
+            </span>
+            <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
+              Calculate Your True Purchase Cost
+            </h2>
+            <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
+              Grunderwerbsteuer, notary, land registry, and agent commission —
+              see every cost before you make an offer.
+            </p>
+          </div>
+        </AnimateIn>
+
+        <HiddenCostsCalculator />
+
+        <AnimateIn>
+          <p className="mt-8 text-center text-sm text-muted-foreground">
+            <Link
+              to="/signup"
+              className="font-medium text-primary hover:underline"
+            >
+              Create a free account
+            </Link>{" "}
+            to save results, compare properties, and unlock your guided buying
+            journey.
+          </p>
+        </AnimateIn>
+      </div>
+    </section>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { HomepageCalculatorSection }

--- a/frontend/src/components/Landing/LandingPage.tsx
+++ b/frontend/src/components/Landing/LandingPage.tsx
@@ -3,6 +3,7 @@ import { CtaSection } from "./CtaSection"
 import { FeaturesSection } from "./FeaturesSection"
 import { FreeToolsSection } from "./FreeToolsSection"
 import { HeroSection } from "./HeroSection"
+import { HomepageCalculatorSection } from "./HomepageCalculatorSection"
 import { HowItWorksSection } from "./HowItWorksSection"
 import { LandingFooter } from "./LandingFooter"
 import { LandingHeader } from "./LandingHeader"
@@ -19,6 +20,7 @@ function LandingPage() {
       <LandingHeader />
       <main className="flex-1">
         <HeroSection />
+        <HomepageCalculatorSection />
         <FeaturesSection />
         <PropertyEvaluationCtaSection />
         <HowItWorksSection />

--- a/frontend/src/components/Landing/LandingPage.tsx
+++ b/frontend/src/components/Landing/LandingPage.tsx
@@ -1,13 +1,20 @@
+import { lazy, Suspense } from "react"
 import { AdvantagesSection } from "./AdvantagesSection"
 import { CtaSection } from "./CtaSection"
 import { FeaturesSection } from "./FeaturesSection"
 import { FreeToolsSection } from "./FreeToolsSection"
 import { HeroSection } from "./HeroSection"
-import { HomepageCalculatorSection } from "./HomepageCalculatorSection"
 import { HowItWorksSection } from "./HowItWorksSection"
 import { LandingFooter } from "./LandingFooter"
 import { LandingHeader } from "./LandingHeader"
 import { PropertyEvaluationCtaSection } from "./PropertyEvaluationCtaSection"
+
+// Lazy-loaded so jsPDF and the calculator's auth-aware hooks are excluded from
+// the homepage's SSG/SSR render (Suspense renders the fallback during
+// renderToString, avoiding isLoggedIn() hydration mismatches for logged-in users).
+const HomepageCalculatorSection = lazy(
+  () => import("./HomepageCalculatorSection"),
+)
 
 /******************************************************************************
                               Components
@@ -20,7 +27,13 @@ function LandingPage() {
       <LandingHeader />
       <main className="flex-1">
         <HeroSection />
-        <HomepageCalculatorSection />
+        <Suspense
+          fallback={
+            <div className="border-y bg-muted/30 py-16 md:py-24 min-h-[640px]" />
+          }
+        >
+          <HomepageCalculatorSection />
+        </Suspense>
         <FeaturesSection />
         <PropertyEvaluationCtaSection />
         <HowItWorksSection />


### PR DESCRIPTION
## Summary

- Embeds the full `HiddenCostsCalculator` (Grunderwerbsteuer + all closing costs) directly on the landing page below the hero section
- Visitors can calculate total purchase costs immediately without navigating away or signing up
- Unauthenticated users see a sign-up CTA in place of the save/share controls (pre-existing `SaveShareSection` behaviour)
- Existing `/tools/property-cost-calculator` page and all other tool pages are unchanged

Fixes GrowthOS finding `paywall` (fix request #6): every URL beyond the homepage required authentication — visitors could not try anything without signing up.

## Test plan

- [ ] Visit homepage — calculator section appears below the hero, before features
- [ ] Enter a property price and select a state — cost breakdown renders immediately
- [ ] Verify no login prompt or redirect is triggered
- [ ] Verify the sign-up CTA appears in the results panel for unauthenticated users
- [ ] Log in and verify save/share controls appear as normal
- [ ] Confirm `/tools/property-cost-calculator` still works independently