### PR TITLE
feat(seo): rewrite homepage title and meta description for keyword targeting

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HeimPath - Navigate German Real Estate with Confidence</title>
-    <meta name="description" content="Navigate German real estate with confidence. Guided property journeys, financial calculators, legal knowledge, and document translation for foreign investors and immigrants." />
+    <title>Buy Property in Germany as a Foreigner — HeimPath | English Guide &amp; Calculators</title>
+    <meta name="description" content="Calculate the exact cost of buying property in Germany as a foreigner — Grunderwerbsteuer, notary, mortgage. In English." />
 
     <!-- Open Graph (defaults — overridden per-route by TanStack Router head) -->
-    <meta property="og:title" content="HeimPath - Navigate German Real Estate with Confidence" />
-    <meta property="og:description" content="Navigate German real estate with confidence. Guided property journeys, financial calculators, legal knowledge, and document translation for foreign investors and immigrants." />
+    <meta property="og:title" content="Buy Property in Germany as a Foreigner — HeimPath | English Guide &amp; Calculators" />
+    <meta property="og:description" content="Calculate the exact cost of buying property in Germany as a foreigner — Grunderwerbsteuer, notary, mortgage. In English." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://heimpath.com" />
     <meta property="og:site_name" content="HeimPath" />
@@ -16,15 +16,15 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/jpeg" />
-    <meta property="og:image:alt" content="HeimPath — Navigate German Real Estate with Confidence" />
+    <meta property="og:image:alt" content="HeimPath — Buy Property in Germany as a Foreigner | English Guide &amp; Calculators" />
     <meta property="og:locale" content="en_US" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="HeimPath - Navigate German Real Estate with Confidence" />
-    <meta name="twitter:description" content="Navigate German real estate with confidence. Guided property journeys, financial calculators, legal knowledge, and document translation for foreign investors and immigrants." />
+    <meta name="twitter:title" content="Buy Property in Germany as a Foreigner — HeimPath | English Guide &amp; Calculators" />
+    <meta name="twitter:description" content="Calculate the exact cost of buying property in Germany as a foreigner — Grunderwerbsteuer, notary, mortgage. In English." />
     <meta name="twitter:image" content="https://heimpath.com/images/og-heimpath.jpg" />
-    <meta name="twitter:image:alt" content="HeimPath — Navigate German Real Estate with Confidence" />
+    <meta name="twitter:image:alt" content="HeimPath — Buy Property in Germany as a Foreigner | English Guide &amp; Calculators" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/assets/images/favicon.svg" />
@@ -55,7 +55,7 @@
       "url": "https://heimpath.com",
       "applicationCategory": "FinanceApplication",
       "operatingSystem": "Web",
-      "description": "Navigate German real estate with confidence. Guided property journeys, financial calculators, legal knowledge, and document translation for foreign investors and immigrants.",
+      "description": "Calculate the exact cost of buying property in Germany as a foreigner — Grunderwerbsteuer, notary, mortgage. In English.",
       "offers": {
         "@type": "Offer",
         "price": "0",

--- a/frontend/src/common/seo.ts
+++ b/frontend/src/common/seo.ts
@@ -10,13 +10,13 @@
 const SITE_URL = "https://heimpath.com"
 const SITE_NAME = "HeimPath"
 const DEFAULT_DESCRIPTION =
-  "Navigate German real estate with confidence. Guided property journeys, financial calculators, legal knowledge, and document translation for foreign investors and immigrants."
+  "Calculate the exact cost of buying property in Germany as a foreigner — Grunderwerbsteuer, notary, mortgage. In English."
 const DEFAULT_OG_IMAGE = `${SITE_URL}/images/og-heimpath.jpg`
 const DEFAULT_OG_IMAGE_WIDTH = "1200"
 const DEFAULT_OG_IMAGE_HEIGHT = "630"
 const DEFAULT_OG_IMAGE_TYPE = "image/jpeg"
 const DEFAULT_OG_IMAGE_ALT =
-  "HeimPath — Navigate German Real Estate with Confidence"
+  "HeimPath — Buy Property in Germany as a Foreigner | English Guide & Calculators"
 
 /******************************************************************************
                               Types

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,7 +7,8 @@ export const Route = createFileRoute("/")({
   component: LandingPage,
   head: () => ({
     ...seoMeta({
-      title: "HeimPath - Navigate German Real Estate with Confidence",
+      title:
+        "Buy Property in Germany as a Foreigner — HeimPath | English Guide & Calculators",
       path: "/",
     }),
   }),


### PR DESCRIPTION
## Summary

- Rewrites the homepage `<title>` from the brand tagline to a keyword-targeted string: **Buy Property in Germany as a Foreigner — HeimPath | English Guide & Calculators**
- Rewrites the homepage meta description to lead with the core value proposition: **Calculate the exact cost of buying property in Germany as a foreigner — Grunderwerbsteuer, notary, mortgage. In English.**
- Updates all derivative tags consistently: `og:title`, `og:description`, `twitter:title`, `twitter:description`, `og:image:alt`, `twitter:image:alt`, JSON-LD `WebApplication.description`
- Updates `DEFAULT_DESCRIPTION` and `DEFAULT_OG_IMAGE_ALT` constants in `seo.ts` so any route that falls back to defaults inherits the new copy

Fixes GrowthOS findings **meta_desc** (task #289) and **title_tag** (task #290).

## Test plan

- [ ] Verify `<title>` in page source matches new value
- [ ] Verify `<meta name="description">` content in page source matches new value
- [ ] Confirm all OG/Twitter tags updated consistently
- [ ] Confirm no existing page titles or descriptions regressed (per-route `seoMeta()` calls supply their own values and are unaffected)