### PR TITLE
fix(mobile): prevent card overflow and fix FAB overlap on small screens

### DIFF
--- a/frontend/src/components/Journey/PhaseIconNav.tsx
+++ b/frontend/src/components/Journey/PhaseIconNav.tsx
@@ -60,7 +60,7 @@ function PhaseIconNav(props: IProps) {
   const { phases, activePhase, onPhaseClick } = props
 
   return (
-    <div className="-mx-1 flex gap-1.5 overflow-x-auto pb-1">
+    <div className="flex gap-1.5 overflow-x-auto pb-1">
       {phases.map((phase) => {
         const Icon = PHASE_ICONS[phase.key] ?? BookOpen
         const isActive = activePhase === phase.key

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -114,8 +114,12 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    overflow-x: clip;
+  }
   body {
-    @apply bg-background text-foreground overflow-x-hidden;
+    @apply bg-background text-foreground;
+    overflow-x: clip;
   }
   button,
   [role="button"] {

--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -311,7 +311,7 @@ function Layout() {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset className="overflow-hidden">
+      <SidebarInset className="min-w-0 overflow-x-clip">
         <header className="sticky top-0 z-10 flex h-16 shrink-0 items-center gap-2 bg-background px-4">
           <SidebarTrigger className="-ml-1 text-muted-foreground" />
           <div className="ml-auto flex items-center gap-2">
@@ -336,7 +336,7 @@ function Layout() {
             isSuccess={resendMutation.isSuccess}
           />
         )}
-        <main className="min-w-0 flex-1 p-6 md:p-8">
+        <main className="min-w-0 flex-1 p-6 pb-36 sm:pb-20 md:px-8 md:pt-8 md:pb-20">
           <div className="mx-auto max-w-7xl">
             <Outlet />
           </div>


### PR DESCRIPTION
## Summary

- Add overflow-x-hidden to the html element — applying it only to body is insufficient in some browsers
- Add min-w-0 overflow-x-hidden to SidebarInset flex item to prevent viewport overflow
- Remove -mx-1 from PhaseIconNav tab bar (was 8px wider than parent, causing layout overflow)
- Add pb-32 bottom padding on mobile so content clears the fixed feedback FAB

## Test plan

- [ ] Dashboard on mobile (390px) — cards stay within viewport
- [ ] Journey detail — tab bar scrolls within bounds, step text wraps
- [ ] Bottom of dashboard — View all links visible above FAB
- [ ] Bottom of journey — content not obscured by FAB