### PR TITLE
feat(journey): show buying/rental type badge on journey card

### DIFF
--- a/frontend/src/common/constants/index.ts
+++ b/frontend/src/common/constants/index.ts
@@ -100,6 +100,12 @@ export const COST_DEFAULTS = {
   RENOVATION_ESTIMATE_PERCENT: 5.0, // Estimated renovation costs
 } as const
 
+// Journey type display labels — single source of truth used by card, summary, and selector
+export const JOURNEY_TYPE_LABELS: Record<"buying" | "rental", string> = {
+  buying: "Buy Property",
+  rental: "Rent Apartment",
+} as const
+
 // Pagination defaults
 export const PAGINATION = {
   DEFAULT_PAGE_SIZE: 20,

--- a/frontend/src/components/Journey/JourneyCard.tsx
+++ b/frontend/src/components/Journey/JourneyCard.tsx
@@ -8,6 +8,7 @@ import { ArrowRight, Calendar, MapPin, Trash2 } from "lucide-react"
 import {
   GERMAN_STATES,
   JOURNEY_PHASES,
+  JOURNEY_TYPE_LABELS,
   PHASE_COLORS,
   PROPERTY_TYPES,
 } from "@/common/constants"
@@ -65,16 +66,14 @@ function JourneyCard(props: IProps) {
       <CardHeader className="pb-3">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="min-w-0 flex-1 space-y-1">
-            <div className="flex items-center gap-2">
-              <CardTitle className="text-lg sm:text-xl">
-                {propertyLabel?.split(" ")[0]}
-              </CardTitle>
+            <CardTitle className="flex items-center gap-2 text-lg sm:text-xl">
+              {propertyLabel?.split(" ")[0]}
               {journey.journey_type && (
-                <Badge variant="outline" className="shrink-0 text-xs capitalize">
-                  {journey.journey_type === "buying" ? "Buying" : "Rental"}
+                <Badge variant="outline" className="shrink-0 text-xs">
+                  {JOURNEY_TYPE_LABELS[journey.journey_type]}
                 </Badge>
               )}
-            </div>
+            </CardTitle>
             <CardDescription className="flex items-center gap-1">
               <MapPin className="h-3.5 w-3.5 shrink-0" />
               {stateName}

--- a/frontend/src/components/Journey/JourneyCard.tsx
+++ b/frontend/src/components/Journey/JourneyCard.tsx
@@ -65,9 +65,16 @@ function JourneyCard(props: IProps) {
       <CardHeader className="pb-3">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="min-w-0 flex-1 space-y-1">
-            <CardTitle className="text-lg sm:text-xl">
-              {propertyLabel?.split(" ")[0]}
-            </CardTitle>
+            <div className="flex items-center gap-2">
+              <CardTitle className="text-lg sm:text-xl">
+                {propertyLabel?.split(" ")[0]}
+              </CardTitle>
+              {journey.journey_type && (
+                <Badge variant="outline" className="shrink-0 text-xs capitalize">
+                  {journey.journey_type === "buying" ? "Buying" : "Rental"}
+                </Badge>
+              )}
+            </div>
             <CardDescription className="flex items-center gap-1">
               <MapPin className="h-3.5 w-3.5 shrink-0" />
               {stateName}


### PR DESCRIPTION
## Summary
- Journey cards now display a "Buying" or "Rental" badge next to the property type title
- Uses the existing journey_type field on JourneyPublic (was present but unused in the card)
- Badge renders with variant="outline" so it is subtle but clearly readable

## Test plan
- [ ] Create a buying journey — card shows "Buying" badge
- [ ] Create a rental journey — card shows "Rental" badge
- [ ] Journeys without journey_type (older records) render without a badge — no crash