### PR TITLE
fix(mobile): add min-w-0 to grid col-span items to prevent content overflow

### DIFF
--- a/frontend/src/components/Dashboard/DashboardPage.tsx
+++ b/frontend/src/components/Dashboard/DashboardPage.tsx
@@ -99,8 +99,8 @@ function JourneyOverviewCard(props: { journey: JourneyOverview }) {
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-4">
-          <div>
-            <CardTitle>{journey.title}</CardTitle>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="truncate">{journey.title}</CardTitle>
             <CardDescription>
               Step {journey.currentStepNumber} of {journey.totalSteps}
               {journey.estimatedDaysRemaining != null && (
@@ -112,7 +112,7 @@ function JourneyOverviewCard(props: { journey: JourneyOverview }) {
           </div>
           <Badge
             variant="secondary"
-            className={PHASE_COLORS[journey.currentPhase]}
+            className={cn("shrink-0", PHASE_COLORS[journey.currentPhase])}
           >
             {PHASE_LABELS[journey.currentPhase] ?? journey.currentPhase}
           </Badge>
@@ -489,7 +489,7 @@ function DashboardSkeleton() {
         <Skeleton className="h-5 w-full max-w-96" />
       </div>
       <div className="grid gap-6 lg:grid-cols-3">
-        <div className="space-y-6 lg:col-span-2">
+        <div className="min-w-0 space-y-6 lg:col-span-2">
           <Skeleton className="h-64 w-full rounded-xl" />
           <div className="grid gap-4 md:grid-cols-3">
             <Skeleton className="h-40 rounded-xl" />
@@ -528,7 +528,7 @@ function DashboardPage(props: Readonly<IProps>) {
 
       <div className="grid gap-6 lg:grid-cols-3">
         {/* Left column: 2/3 width */}
-        <div className="space-y-6 lg:col-span-2">
+        <div className="min-w-0 space-y-6 lg:col-span-2">
           {data.hasJourney && data.journey ? (
             <>
               <JourneyOverviewCard journey={data.journey} />

--- a/frontend/src/components/Journey/JourneyDetail.tsx
+++ b/frontend/src/components/Journey/JourneyDetail.tsx
@@ -168,7 +168,7 @@ function JourneyDetailSkeleton() {
       </div>
       <Skeleton className="h-12 w-full" />
       <div className="grid gap-6 lg:grid-cols-3">
-        <div className="space-y-4 lg:col-span-2">
+        <div className="min-w-0 space-y-4 lg:col-span-2">
           {["overview", "phase", "steps"].map((k) => (
             <Skeleton key={k} className="h-48 w-full" />
           ))}
@@ -398,7 +398,7 @@ function JourneyDetail(props: IProps) {
       <JourneyProvider journey={journey}>
         <div className="grid gap-6 lg:grid-cols-3">
           {/* Steps — phase tab bar is the primary navigation */}
-          <div className="space-y-4 lg:col-span-2">
+          <div className="min-w-0 space-y-4 lg:col-span-2">
             <StepTabView
               steps={journey.steps}
               activeStepNumber={journey.current_step_number}

--- a/frontend/src/components/Professionals/ProfessionalDetail.tsx
+++ b/frontend/src/components/Professionals/ProfessionalDetail.tsx
@@ -146,7 +146,7 @@ function ProfessionalDetail(props: Readonly<IProps>) {
 
       <div className="grid gap-6 lg:grid-cols-3">
         {/* Main content */}
-        <div className="lg:col-span-2 space-y-6">
+        <div className="min-w-0 lg:col-span-2 space-y-6">
           {/* Description */}
           {professional.description && (
             <Card>


### PR DESCRIPTION
## Summary

- Add `min-w-0` to `lg:col-span-2` grid items in `DashboardPage`, `JourneyDetail`, and `ProfessionalDetail`
- Add `min-w-0 flex-1` + `truncate`/`shrink-0` to `JourneyOverviewCard` header within the dashboard grid
- Fixes horizontal content overflow on iPhone-sized viewports (393px) confirmed via Playwright investigation

## Root Cause

CSS Grid items use their intrinsic content width by default. Without `min-w-0`, a `col-span-2` item can grow to 575px+ instead of being constrained to the grid track — causing cards to overflow the viewport on small screens. `overflow-x-hidden` on the body (PR #372) masked the symptom but the grid items were still mis-sized.

## Test plan

- [ ] Run Playwright mobile viewport QA on iPhone 16 (393px) — confirm no card overflow
- [ ] Verify Dashboard, Journey Detail, and Professional Detail pages render correctly on mobile
- [ ] Confirm no visual regressions on desktop (`lg:` breakpoint and above)