### PR TITLE
fix(qa): add rent vs buy calculator test with networkidle wait

### DIFF
--- a/frontend/tests/deep-interaction-qa.spec.ts
+++ b/frontend/tests/deep-interaction-qa.spec.ts
@@ -675,3 +675,52 @@ test.describe("TEST 10: mortgage calculator inputs and calculation", () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// TEST 11 — Rent vs Buy Calculator inputs and result
+// ---------------------------------------------------------------------------
+
+test.describe("TEST 11: rent vs buy calculator inputs and result", () => {
+  test("calculator inputs are visible and result verdict appears", async ({
+    page,
+  }) => {
+    await page.goto("/tools/rent-vs-buy-calculator")
+    await page.waitForLoadState("networkidle")
+
+    // Property price and monthly rent inputs (type="number")
+    const priceInput = page
+      .locator("#rvb-price")
+      .or(page.locator('input[placeholder*="450000"]'))
+      .first()
+    const rentInput = page
+      .locator("#rvb-rent")
+      .or(page.locator('input[placeholder*="1800"]'))
+      .first()
+
+    expect.soft(await priceInput.isVisible().catch(() => false)).toBe(true)
+    expect.soft(await rentInput.isVisible().catch(() => false)).toBe(true)
+
+    // Wait for DOM to settle
+    await page.waitForTimeout(300)
+
+    // Fill inputs — result updates reactively (no Calculate button needed)
+    if (await priceInput.isVisible().catch(() => false)) {
+      await priceInput.fill("450000")
+      await rentInput.fill("1800")
+      await page.waitForTimeout(300)
+
+      // Verdict text should appear ("Buying saves you" or "Renting saves you")
+      const verdict = page
+        .getByText(/saves you/i, { exact: false })
+        .or(page.getByText(/wins/i, { exact: false }))
+        .first()
+      expect.soft(await verdict.isVisible().catch(() => false)).toBe(true)
+
+      // Net cost rows should be visible
+      const netCostBuying = page.getByText(/net cost of buying/i, {
+        exact: false,
+      })
+      expect.soft(await netCostBuying.isVisible().catch(() => false)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Adds **TEST 11** to `deep-interaction-qa.spec.ts` for `/tools/rent-vs-buy-calculator`
- Fixes GrowthOS finding `qa-audit-3-calc-3`: Playwright timed out probing inputs without `networkidle`

## What the test does

1. Navigates to `/tools/rent-vs-buy-calculator` (public page, no auth)
2. Waits for `waitForLoadState("networkidle")` + 300ms settle
3. Asserts `#rvb-price` and `#rvb-rent` (`type="number"`) are visible
4. Fills in €450,000 price and €1,800/mo rent
5. Asserts the verdict ("saves you") and "Net cost of buying" appear reactively (this calculator has no Calculate button — results update on input change)

## Test plan

- [ ] `test-playwright` CI passes with TEST 11 included
- [ ] No regressions in existing tests 1–10