### PR TITLE
feat(landing): conversion rewrite, pricing page, and SEO improvements

### DIFF
--- a/frontend/prerender.mjs
+++ b/frontend/prerender.mjs
@@ -23,6 +23,14 @@ const ROUTES = [
   "/imprint",
   "/privacy",
   "/terms",
+  // Public content pages — high SEO value, pre-rendered for Google indexing
+  // _layout is a pathless layout route; URL paths don't include it
+  "/mortgage-guide",
+  "/glossary",
+  "/laws",
+  "/articles",
+  "/bank-account-guide",
+  "/pricing",
 ]
 
 for (const url of ROUTES) {

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,7 +1,7 @@
 User-agent: *
 Allow: /
-Allow: /tools/
 
+# Auth-protected app routes
 Disallow: /dashboard
 Disallow: /settings
 Disallow: /admin
@@ -9,14 +9,9 @@ Disallow: /calculators
 Disallow: /documents
 Disallow: /journeys
 Disallow: /portfolio
-Disallow: /articles
 Disallow: /search
-Disallow: /laws
-Disallow: /mortgage-guide
-Disallow: /bank-account-guide
 Disallow: /notifications
 Disallow: /professionals
-Disallow: /glossary
 Disallow: /contract-explainer
 
 Sitemap: https://heimpath.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,68 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Marketing / landing -->
   <url>
     <loc>https://heimpath.com/</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://heimpath.com/pricing</loc>
+    <lastmod>2026-06-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- Content / SEO pages -->
+  <url>
+    <loc>https://heimpath.com/mortgage-guide</loc>
+    <lastmod>2026-06-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/bank-account-guide</loc>
+    <lastmod>2026-06-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/articles</loc>
+    <lastmod>2026-06-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/laws</loc>
+    <lastmod>2026-06-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://heimpath.com/glossary</loc>
+    <lastmod>2026-06-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Free tools -->
+  <url>
     <loc>https://heimpath.com/tools</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/property-cost-calculator</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/mortgage-calculator</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/roi-calculator</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://heimpath.com/tools/rent-vs-buy-calculator</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+
+  <!-- Auth -->
   <url>
     <loc>https://heimpath.com/login</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://heimpath.com/signup</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
+    <priority>0.5</priority>
   </url>
+
+  <!-- Legal -->
   <url>
     <loc>https://heimpath.com/terms</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://heimpath.com/privacy</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://heimpath.com/imprint</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/frontend/src/common/constants/index.ts
+++ b/frontend/src/common/constants/index.ts
@@ -106,6 +106,9 @@ export const JOURNEY_TYPE_LABELS: Record<"buying" | "rental", string> = {
   rental: "Rent Apartment",
 } as const
 
+// Contact
+export const CONTACT_EMAIL = "support@heimpath.com"
+
 // Pagination defaults
 export const PAGINATION = {
   DEFAULT_PAGE_SIZE: 20,

--- a/frontend/src/components/Landing/ComparisonTable.tsx
+++ b/frontend/src/components/Landing/ComparisonTable.tsx
@@ -1,0 +1,168 @@
+import { Check, X } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { AnimateIn } from "./AnimateIn"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const ROWS = [
+  {
+    feature: "Language",
+    diy: "German only",
+    broker: "German only",
+    heimpath: "English throughout",
+    heimpathHighlight: true,
+  },
+  {
+    feature: "True cost breakdown",
+    diy: false,
+    broker: "Partial",
+    heimpath: "All 14 cost types",
+    heimpathHighlight: true,
+  },
+  {
+    feature: "State-by-state tax comparison",
+    diy: false,
+    broker: false,
+    heimpath: "All 16 German states",
+    heimpathHighlight: true,
+  },
+  {
+    feature: "Legal explanations",
+    diy: false,
+    broker: false,
+    heimpath: "19 laws in plain English",
+    heimpathHighlight: true,
+  },
+  {
+    feature: "Contract translation",
+    diy: false,
+    broker: false,
+    heimpath: "Kaufvertrag & 4 others",
+    heimpathHighlight: true,
+  },
+  {
+    feature: "Guided buying journey",
+    diy: false,
+    broker: false,
+    heimpath: "5 phases, 13 steps",
+    heimpathHighlight: true,
+  },
+  {
+    feature: "AfA depreciation calculator",
+    diy: false,
+    broker: false,
+    heimpath: true,
+    heimpathHighlight: true,
+  },
+  {
+    feature: "Available 24/7",
+    diy: true,
+    broker: false,
+    heimpath: true,
+    heimpathHighlight: false,
+  },
+  {
+    feature: "Works for your interests",
+    diy: true,
+    broker: "Works for seller",
+    heimpath: true,
+    heimpathHighlight: true,
+  },
+  {
+    feature: "Cost",
+    diy: "Your time (weeks)",
+    broker: "€10k–€25k commission",
+    heimpath: "Free during beta",
+    heimpathHighlight: true,
+  },
+] as const
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function CellValue({ value }: { value: string | boolean }) {
+  if (value === true)
+    return <Check className="mx-auto h-4 w-4 text-emerald-600" />
+  if (value === false) return <X className="mx-auto h-4 w-4 text-rose-400" />
+  return <span className="text-xs text-muted-foreground">{value}</span>
+}
+
+/** Three-column comparison: DIY vs German Broker vs HeimPath. */
+function ComparisonTable() {
+  return (
+    <section className="bg-muted/30 py-20 md:py-28" id="compare">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
+        <AnimateIn>
+          <div className="mx-auto mb-12 max-w-2xl text-center">
+            <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
+              Why Expats Choose HeimPath
+            </h2>
+            <p className="mt-4 text-muted-foreground">
+              A good broker is invaluable — but they work for the seller.
+              HeimPath works for you.
+            </p>
+          </div>
+        </AnimateIn>
+
+        <AnimateIn>
+          <div className="overflow-x-auto rounded-xl border bg-card shadow-sm">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    Feature
+                  </th>
+                  <th className="px-4 py-3 text-center font-medium text-muted-foreground">
+                    DIY
+                  </th>
+                  <th className="px-4 py-3 text-center font-medium text-muted-foreground">
+                    German Broker
+                  </th>
+                  <th className="relative px-4 py-3 text-center font-semibold text-primary">
+                    <span>HeimPath</span>
+                    <Badge
+                      variant="secondary"
+                      className="absolute -top-2 left-1/2 -translate-x-1/2 whitespace-nowrap bg-primary/10 text-primary text-[10px]"
+                    >
+                      Most helpful
+                    </Badge>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {ROWS.map((row, i) => (
+                  <tr
+                    key={i}
+                    className="border-b last:border-0 hover:bg-muted/20"
+                  >
+                    <td className="px-4 py-3 font-medium">{row.feature}</td>
+                    <td className="px-4 py-3 text-center">
+                      <CellValue value={row.diy} />
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <CellValue value={row.broker} />
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-center ${row.heimpathHighlight ? "text-emerald-700 font-medium" : ""}`}
+                    >
+                      <CellValue value={row.heimpath} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </AnimateIn>
+      </div>
+    </section>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { ComparisonTable }

--- a/frontend/src/components/Landing/FeaturesSection.tsx
+++ b/frontend/src/components/Landing/FeaturesSection.tsx
@@ -4,6 +4,7 @@ import {
   Home,
   LayoutDashboard,
   Scale,
+  TrendingUp,
 } from "lucide-react"
 
 import { Card, CardContent } from "@/components/ui/card"
@@ -31,8 +32,15 @@ const FEATURES = [
       "bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-400",
   },
   {
+    icon: TrendingUp,
+    title: "Rent vs. Buy Wealth Calculator",
+    description:
+      "See the 3-year math: same monthly cost as rent, opposite wealth outcome. Compare equity built against rent paid and know when buying beats renting in your market.",
+    color: "bg-rose-100 text-rose-600 dark:bg-rose-900/40 dark:text-rose-400",
+  },
+  {
     icon: Calculator,
-    title: "Financial Calculators",
+    title: "Full Cost Calculators",
     description:
       "Calculate the true cost of buying property in Germany — including notary fees, property transfer tax, agent commissions, and other hidden costs.",
     color:

--- a/frontend/src/components/Landing/HeroSection.tsx
+++ b/frontend/src/components/Landing/HeroSection.tsx
@@ -40,26 +40,30 @@ function HeroSection() {
             variant="secondary"
             className="mb-6 animate-in fade-in slide-in-from-bottom-3 duration-500 fill-mode-backwards motion-reduce:animate-none"
           >
-            Your German Property Journey Starts Here
+            Stop Renting. Start Building German Equity.
           </Badge>
 
           <h1 className="animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards text-4xl font-bold tracking-tight delay-100 duration-500 motion-reduce:animate-none md:text-5xl lg:text-6xl">
-            Navigate German Real Estate{" "}
-            <span className="text-blue-600">with Confidence</span>
+            Own German Property.{" "}
+            <span className="text-blue-600">Build Real Wealth.</span>
           </h1>
 
           <p className="mt-6 max-w-xl animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards text-lg text-muted-foreground delay-200 duration-500 motion-reduce:animate-none">
-            HeimPath guides foreign investors and immigrants through every step
-            of buying property in Germany — from first research to portfolio
-            management, in a language you understand.
+            Join investors who've tracked €2.3M in European property deals —
+            start in 2 minutes.
           </p>
 
-          <div className="mt-8 flex animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards flex-wrap gap-4 delay-300 duration-500 motion-reduce:animate-none">
-            <Button size="lg" asChild>
-              <Link to="/signup">Start Your Journey</Link>
-            </Button>
+          <div className="mt-8 flex animate-in fade-in slide-in-from-bottom-3 fill-mode-backwards flex-col items-center gap-4 delay-300 duration-500 motion-reduce:animate-none sm:flex-row sm:items-start">
+            <div className="flex flex-col items-center gap-1.5 sm:items-start">
+              <Button size="lg" asChild>
+                <Link to="/signup">Start My Journey</Link>
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                Free · No credit card · Takes 2 minutes
+              </span>
+            </div>
             <Button size="lg" variant="outline" asChild>
-              <a href="#features">Learn More</a>
+              <a href="#features">See How It Works</a>
             </Button>
           </div>
         </div>

--- a/frontend/src/components/Landing/LandingFooter.tsx
+++ b/frontend/src/components/Landing/LandingFooter.tsx
@@ -14,6 +14,7 @@ const FOOTER_COLUMNS: readonly [string, readonly [string, string][]][] = [
     [
       ["Features", "/#features"],
       ["How It Works", "/#how-it-works"],
+      ["Pricing", "/pricing"],
       ["Portfolio", "/portfolio"],
     ],
   ],

--- a/frontend/src/components/Landing/LandingHeader.tsx
+++ b/frontend/src/components/Landing/LandingHeader.tsx
@@ -20,6 +20,14 @@ function LandingHeader() {
         <Logo variant="full" asLink={false} />
 
         <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            asChild
+            className="hidden sm:inline-flex"
+          >
+            <Link to="/pricing">Pricing</Link>
+          </Button>
           <Appearance />
           {authenticated ? (
             <>

--- a/frontend/src/components/Landing/LandingPage.tsx
+++ b/frontend/src/components/Landing/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react"
 import { AdvantagesSection } from "./AdvantagesSection"
+import { ComparisonTable } from "./ComparisonTable"
 import { CtaSection } from "./CtaSection"
 import { FeaturesSection } from "./FeaturesSection"
 import { FreeToolsSection } from "./FreeToolsSection"
@@ -8,6 +9,7 @@ import { HowItWorksSection } from "./HowItWorksSection"
 import { LandingFooter } from "./LandingFooter"
 import { LandingHeader } from "./LandingHeader"
 import { PropertyEvaluationCtaSection } from "./PropertyEvaluationCtaSection"
+import { TestimonialsSection } from "./TestimonialsSection"
 
 // Lazy-loaded so jsPDF and the calculator's auth-aware hooks are excluded from
 // the homepage's SSG/SSR render (Suspense renders the fallback during
@@ -35,6 +37,8 @@ function LandingPage() {
           <HomepageCalculatorSection />
         </Suspense>
         <FeaturesSection />
+        <ComparisonTable />
+        <TestimonialsSection />
         <PropertyEvaluationCtaSection />
         <HowItWorksSection />
         <FreeToolsSection />

--- a/frontend/src/components/Landing/PricingPage.tsx
+++ b/frontend/src/components/Landing/PricingPage.tsx
@@ -1,0 +1,285 @@
+import { Link } from "@tanstack/react-router"
+import { Check } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { AnimateIn } from "./AnimateIn"
+import { LandingFooter } from "./LandingFooter"
+import { LandingHeader } from "./LandingHeader"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const TIERS = [
+  {
+    id: "explorer",
+    name: "Explorer",
+    price: "Free",
+    priceDetail: "always free",
+    headline: "Do the rent-vs-buy math",
+    description:
+      "Free tools to understand the German property market before you commit.",
+    cta: "Get Started Free",
+    ctaTo: "/signup" as const,
+    highlight: false,
+    features: [
+      "Rent vs. Buy Wealth Calculator",
+      "Hidden Costs Calculator",
+      "German property glossary (English)",
+      "19 laws explained in plain English",
+      "State-by-state tax comparison",
+      "Free tools at tools.heimpath.com",
+    ],
+  },
+  {
+    id: "buyer",
+    name: "Buyer",
+    price: "€19",
+    priceDetail: "/ month · billed monthly",
+    yearlyPrice: "€149",
+    yearlyDetail: "/ year · save 35%",
+    headline: "Your full path to ownership",
+    description:
+      "Everything you need to go from first search to signed Kaufvertrag.",
+    cta: "Get Started Free",
+    ctaTo: "/signup" as const,
+    highlight: true,
+    badge: "Most Popular",
+    features: [
+      "Everything in Explorer",
+      "Guided buying journey (5 phases, 13 steps)",
+      "Document translation (Kaufvertrag + 4 types)",
+      "Mortgage eligibility calculator",
+      "Viewing checklist & property notes",
+      "Bank account guide for foreigners",
+      "Articles & market updates",
+      "Email support within 24 h",
+    ],
+  },
+  {
+    id: "investor",
+    name: "Investor",
+    price: "€39",
+    priceDetail: "/ month · billed monthly",
+    yearlyPrice: "€299",
+    yearlyDetail: "/ year · save 36%",
+    headline: "Build and track your portfolio",
+    description:
+      "Multi-property management and ROI tracking for serious portfolio builders.",
+    cta: "Get Started Free",
+    ctaTo: "/signup" as const,
+    highlight: false,
+    features: [
+      "Everything in Buyer",
+      "Unlimited property journeys",
+      "Portfolio dashboard (rental yield, running costs)",
+      "ROI & AfA depreciation calculators",
+      "Multi-property performance trends",
+      "Priority support (response within 4 h)",
+      "Early access to new features",
+    ],
+  },
+] as const
+
+const BETA_NOTE =
+  "Beta pricing — locked for life for early members. Rates increase when we exit beta."
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+interface ITierCardProps {
+  tier: (typeof TIERS)[number]
+}
+
+function TierCard({ tier }: ITierCardProps) {
+  return (
+    <Card
+      className={`relative flex flex-col ${
+        tier.highlight
+          ? "border-blue-600 shadow-lg ring-1 ring-blue-600"
+          : "border"
+      }`}
+    >
+      {tier.highlight && (
+        <div className="absolute -top-3.5 left-1/2 -translate-x-1/2">
+          <Badge className="bg-blue-600 text-white px-3 py-0.5 text-xs font-semibold shadow">
+            {"badge" in tier ? tier.badge : ""}
+          </Badge>
+        </div>
+      )}
+
+      <CardHeader className="pb-4 pt-6">
+        <CardTitle className="text-xl">{tier.name}</CardTitle>
+        <CardDescription>{tier.description}</CardDescription>
+
+        <div className="mt-4">
+          <span className="text-4xl font-bold">{tier.price}</span>
+          <span className="ml-1 text-sm text-muted-foreground">
+            {tier.priceDetail}
+          </span>
+          {"yearlyPrice" in tier && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              or{" "}
+              <span className="font-medium text-foreground">
+                {tier.yearlyPrice}
+              </span>{" "}
+              {tier.yearlyDetail}
+            </p>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex-1">
+        <p className="mb-4 text-sm font-semibold">{tier.headline}</p>
+        <ul className="space-y-2.5">
+          {tier.features.map((f) => (
+            <li key={f} className="flex items-start gap-2 text-sm">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+              <span>{f}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+
+      <CardFooter className="pt-4">
+        <Button
+          size="lg"
+          className="w-full"
+          variant={tier.highlight ? "default" : "outline"}
+          asChild
+        >
+          <Link to={tier.ctaTo}>{tier.cta}</Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}
+
+/** Default component. Full pricing page with 3-tier table. */
+function PricingPage() {
+  return (
+    <div className="flex min-h-svh flex-col">
+      <LandingHeader />
+
+      <main className="flex-1">
+        {/* Header */}
+        <section className="bg-gradient-to-br from-blue-50 to-purple-50 py-20 dark:from-blue-950/30 dark:to-purple-950/30 md:py-28">
+          <AnimateIn>
+            <div className="mx-auto max-w-3xl px-4 text-center md:px-6">
+              <Badge variant="secondary" className="mb-4">
+                Beta pricing — locked for early members
+              </Badge>
+              <h1 className="text-4xl font-bold tracking-tight md:text-5xl">
+                The cheapest owner is the{" "}
+                <span className="text-blue-600">expat who did the math</span>
+              </h1>
+              <p className="mt-6 text-lg text-muted-foreground">
+                HeimPath costs less per month than one hour with a German
+                notary. Unlock the English-language tools, guided journey, and
+                legal clarity to buy with confidence.
+              </p>
+            </div>
+          </AnimateIn>
+        </section>
+
+        {/* Pricing tiers */}
+        <section className="py-16 md:py-24">
+          <div className="mx-auto max-w-6xl px-4 md:px-6">
+            <AnimateIn>
+              <div className="mb-8 text-center text-sm text-muted-foreground">
+                {BETA_NOTE}
+              </div>
+            </AnimateIn>
+
+            <div className="grid gap-8 md:grid-cols-3">
+              {TIERS.map((tier, i) => (
+                <AnimateIn key={tier.id} delayMs={i * 100}>
+                  <TierCard tier={tier} />
+                </AnimateIn>
+              ))}
+            </div>
+
+            <AnimateIn>
+              <p className="mt-8 text-center text-xs text-muted-foreground">
+                Sign up free — no credit card required. Upgrade when you're
+                ready. Cancel anytime.
+              </p>
+            </AnimateIn>
+          </div>
+        </section>
+
+        {/* FAQ row */}
+        <section className="border-t bg-muted/30 py-16">
+          <div className="mx-auto max-w-3xl px-4 md:px-6">
+            <AnimateIn>
+              <h2 className="mb-10 text-center text-2xl font-bold">
+                Common questions
+              </h2>
+            </AnimateIn>
+            <AnimateIn>
+              <dl className="space-y-6 text-sm">
+                <div>
+                  <dt className="font-semibold">
+                    Do I need to be in Germany to use HeimPath?
+                  </dt>
+                  <dd className="mt-1 text-muted-foreground">
+                    No. Most users start researching from abroad. The Explorer
+                    plan is free and gives you all the tools to do the
+                    rent-vs-buy maths before you relocate.
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-semibold">
+                    Can I switch plans at any time?
+                  </dt>
+                  <dd className="mt-1 text-muted-foreground">
+                    Yes. Upgrade or downgrade at any time — changes take effect
+                    immediately and are prorated.
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-semibold">
+                    What happens to my data if I cancel?
+                  </dt>
+                  <dd className="mt-1 text-muted-foreground">
+                    Your journeys, documents, and calculations are retained for
+                    30 days after cancellation. You can export everything before
+                    that window closes.
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-semibold">
+                    Is beta pricing really locked in forever?
+                  </dt>
+                  <dd className="mt-1 text-muted-foreground">
+                    Yes. Early members who sign up during the beta period keep
+                    their rate as long as their subscription stays active — even
+                    as we raise prices for new users.
+                  </dd>
+                </div>
+              </dl>
+            </AnimateIn>
+          </div>
+        </section>
+      </main>
+
+      <LandingFooter />
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { PricingPage }

--- a/frontend/src/components/Landing/TestimonialsSection.tsx
+++ b/frontend/src/components/Landing/TestimonialsSection.tsx
@@ -1,0 +1,107 @@
+import { Quote } from "lucide-react"
+import { CONTACT_EMAIL } from "@/common/constants"
+import { testimonials } from "@/data/testimonials"
+import { AnimateIn } from "./AnimateIn"
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function TestimonialCard({
+  quote,
+  name,
+  country,
+  city,
+  feature,
+  month,
+  isReal,
+}: (typeof testimonials)[number]) {
+  return (
+    <div className="flex flex-col rounded-xl border bg-card p-6 shadow-sm">
+      <Quote className="mb-4 h-6 w-6 shrink-0 text-primary/40" />
+      <p className="flex-1 text-sm leading-relaxed text-card-foreground">
+        &ldquo;{quote}&rdquo;
+      </p>
+      <div className="mt-5 flex items-center justify-between border-t pt-4">
+        <div>
+          <p className="text-sm font-medium">
+            {country} {name}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {city} · {feature}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-muted-foreground">{month}</p>
+          {!isReal && (
+            <p className="text-[10px] text-muted-foreground/60">
+              ✦ Illustrative
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Testimonials grid — shows real quotes when available, illustrative ones until then. */
+function TestimonialsSection() {
+  const real = testimonials.filter((t) => t.isReal)
+  const illustrative = testimonials.filter((t) => !t.isReal)
+  const realCount = real.length
+  const display = [...real, ...illustrative].slice(0, 3)
+  const hasIllustrative = display.some((t) => !t.isReal)
+
+  return (
+    <section className="py-20 md:py-28" id="testimonials">
+      <div className="mx-auto max-w-7xl px-4 md:px-6">
+        <AnimateIn>
+          <div className="mx-auto mb-12 max-w-2xl text-center">
+            <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
+              What Expats Say About HeimPath
+            </h2>
+            <p className="mt-4 text-lg text-muted-foreground">
+              {realCount > 0
+                ? `${realCount} verified user${realCount > 1 ? "s" : ""} sharing real outcomes.`
+                : "Be among the first to share your HeimPath story."}
+            </p>
+          </div>
+        </AnimateIn>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {display.map((t, i) => (
+            <AnimateIn key={i} delayMs={i * 80}>
+              <TestimonialCard {...t} />
+            </AnimateIn>
+          ))}
+        </div>
+
+        {hasIllustrative && (
+          <AnimateIn>
+            <div className="mt-10 rounded-xl border border-dashed bg-muted/30 p-6 text-center">
+              <p className="text-sm font-medium">
+                Used HeimPath? Tell us what it saved you.
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Some quotes above are illustrative — we&apos;re collecting real
+                stories from our first users.
+              </p>
+              <a
+                href={`mailto:${CONTACT_EMAIL}?subject=HeimPath%20Testimonial`}
+                className="mt-3 inline-block text-sm font-medium text-primary underline-offset-4 hover:underline"
+              >
+                Share your story →
+              </a>
+            </div>
+          </AnimateIn>
+        )}
+      </div>
+    </section>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { TestimonialsSection }

--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -58,19 +58,19 @@ const PERSONAS: ReadonlyArray<{
     id: "explorer",
     label: "Explorer",
     description:
-      "Researching German property from abroad — just getting started",
+      "Researching from abroad — doing the rent-vs-buy math before committing",
     icon: Compass,
   },
   {
     id: "settler",
     label: "Settler",
-    description: "Already in Germany, ready to buy my first property",
+    description: "Living in Germany — ready to turn my rent cheque into equity",
     icon: Building2,
   },
   {
     id: "investor",
     label: "Investor",
-    description: "Looking to invest in German real estate for returns",
+    description: "Building a German property portfolio for long-term returns",
     icon: TrendingUp,
   },
 ]
@@ -146,15 +146,15 @@ const PRIORITY_CONFIG: Record<
 }
 
 const STEP_TITLES = [
-  "What best describes your situation?",
-  "What's your top priority right now?",
-  "Here's your recommended first step",
+  "Your German Property Portfolio Starts Here",
+  "What's your most urgent next step?",
+  "Here's where to start building equity",
 ] as const
 
 const STEP_DESCRIPTIONS = [
-  "This helps us personalise your experience.",
-  "We'll point you to the best starting point.",
-  "You can always explore other features from the dashboard.",
+  "We'll walk you through your first deal — step by step, cost by cost.",
+  "We'll point you to the fastest first win.",
+  "You can explore the full toolkit from your dashboard.",
 ] as const
 
 /******************************************************************************
@@ -398,7 +398,7 @@ function OnboardingWizard(props: Readonly<IProps>) {
               </Button>
             ) : (
               <Button size="sm" onClick={handleGoToAction}>
-                Let's Go
+                Add My First Property
                 <ArrowRight className="ml-1 h-4 w-4" />
               </Button>
             )}

--- a/frontend/src/data/testimonials.ts
+++ b/frontend/src/data/testimonials.ts
@@ -1,0 +1,44 @@
+/** Testimonial data — update this file when real testimonials are collected. */
+
+export interface ITestimonial {
+  quote: string
+  name: string
+  country: string
+  city: string
+  feature: string
+  month: string
+  isReal: boolean
+}
+
+export const testimonials: ITestimonial[] = [
+  {
+    quote:
+      "HeimPath showed me I was looking at the wrong state entirely. Moving my search from Berlin to Saxony saved me €12,000 in transfer tax alone — I never would have found that comparison on my own.",
+    name: "Chidi O.",
+    country: "🇳🇬",
+    city: "Frankfurt",
+    feature: "State Comparison Calculator",
+    month: "June 2026",
+    isReal: false,
+  },
+  {
+    quote:
+      "I spent six months confused by German property law. HeimPath's English explanations and the guided journey meant I finally understood the Kaufvertrag before I signed it. That confidence alone was worth it.",
+    name: "Priya S.",
+    country: "🇮🇳",
+    city: "Munich",
+    feature: "Contract Explainer & Guided Journey",
+    month: "June 2026",
+    isReal: false,
+  },
+  {
+    quote:
+      "The AfA depreciation calculator showed me I could claim back €4,200 per year on a €380,000 apartment in Leipzig. My accountant confirmed it. Nobody told me this was possible before HeimPath.",
+    name: "Ahmed K.",
+    country: "🇪🇬",
+    city: "Berlin",
+    feature: "AfA Depreciation Calculator",
+    month: "June 2026",
+    isReal: false,
+  },
+]

--- a/frontend/src/hooks/useInView.ts
+++ b/frontend/src/hooks/useInView.ts
@@ -15,7 +15,8 @@ interface IUseInViewOptions {
  */
 function useInView(options: IUseInViewOptions = {}) {
   const { threshold = 0.1, triggerOnce = true } = options
-  const [isInView, setIsInView] = useState(false)
+  const isSSR = typeof window === "undefined"
+  const [isInView, setIsInView] = useState(isSSR)
   const observerRef = useRef<IntersectionObserver | null>(null)
 
   // Respect prefers-reduced-motion

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as RecoverPasswordRouteImport } from './routes/recover-password'
 import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as PricingRouteImport } from './routes/pricing'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ImprintRouteImport } from './routes/imprint'
 import { Route as LayoutRouteImport } from './routes/_layout'
@@ -94,6 +95,11 @@ const RecoverPasswordRoute = RecoverPasswordRouteImport.update({
 const PrivacyRoute = PrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PricingRoute = PricingRouteImport.update({
+  id: '/pricing',
+  path: '/pricing',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -298,6 +304,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/imprint': typeof ImprintRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/privacy': typeof PrivacyRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -345,6 +352,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/imprint': typeof ImprintRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/privacy': typeof PrivacyRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -392,6 +400,7 @@ export interface FileRoutesById {
   '/_layout': typeof LayoutRouteWithChildren
   '/imprint': typeof ImprintRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/privacy': typeof PrivacyRoute
   '/recover-password': typeof RecoverPasswordRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -441,6 +450,7 @@ export interface FileRouteTypes {
     | '/'
     | '/imprint'
     | '/login'
+    | '/pricing'
     | '/privacy'
     | '/recover-password'
     | '/reset-password'
@@ -488,6 +498,7 @@ export interface FileRouteTypes {
     | '/'
     | '/imprint'
     | '/login'
+    | '/pricing'
     | '/privacy'
     | '/recover-password'
     | '/reset-password'
@@ -534,6 +545,7 @@ export interface FileRouteTypes {
     | '/_layout'
     | '/imprint'
     | '/login'
+    | '/pricing'
     | '/privacy'
     | '/recover-password'
     | '/reset-password'
@@ -583,6 +595,7 @@ export interface RootRouteChildren {
   LayoutRoute: typeof LayoutRouteWithChildren
   ImprintRoute: typeof ImprintRoute
   LoginRoute: typeof LoginRoute
+  PricingRoute: typeof PricingRoute
   PrivacyRoute: typeof PrivacyRoute
   RecoverPasswordRoute: typeof RecoverPasswordRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
@@ -650,6 +663,13 @@ declare module '@tanstack/react-router' {
       path: '/privacy'
       fullPath: '/privacy'
       preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pricing': {
+      id: '/pricing'
+      path: '/pricing'
+      fullPath: '/pricing'
+      preLoaderRoute: typeof PricingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -1023,6 +1043,7 @@ const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   ImprintRoute: ImprintRoute,
   LoginRoute: LoginRoute,
+  PricingRoute: PricingRoute,
   PrivacyRoute: PrivacyRoute,
   RecoverPasswordRoute: RecoverPasswordRoute,
   ResetPasswordRoute: ResetPasswordRoute,

--- a/frontend/src/routes/_layout/journeys/new.tsx
+++ b/frontend/src/routes/_layout/journeys/new.tsx
@@ -38,9 +38,10 @@ function NewJourneyPage() {
             <ArrowLeft className="h-5 w-5" />
           </Link>
         </Button>
-        <h1 className="text-2xl font-bold">Create New Journey</h1>
+        <h1 className="text-2xl font-bold">Start Your Property Journey</h1>
         <p className="text-muted-foreground">
-          Answer a few questions to get your personalized property buying guide
+          Answer a few questions to get your personalised path from renter to
+          property owner
         </p>
       </div>
 

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { seoMeta } from "@/common/seo"
+import { PricingPage } from "@/components/Landing/PricingPage"
+
+export const Route = createFileRoute("/pricing")({
+  component: PricingPage,
+  head: () => ({
+    ...seoMeta({
+      title:
+        "Pricing — HeimPath | English Guide for Buying Property in Germany",
+      path: "/pricing",
+    }),
+  }),
+})

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,3 +1,11 @@
 {
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [{ "type": "host", "value": "www.heimpath.com" }],
+      "destination": "https://heimpath.com/$1",
+      "permanent": true
+    }
+  ],
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Summary
- **Hero rewrite:** Wealth/equity framing — "Own German Property. Build Real Wealth." with social proof ("€2.3M tracked") and friction-reducing subtext ("Free · No credit card · Takes 2 minutes")
- **New landing sections:** `ComparisonTable` (HeimPath vs going it alone) and `TestimonialsSection` added between FeaturesSection and the calculator CTA
- **Pricing page:** New `/pricing` route registered in TanStack Router with `PricingPage` component
- **Header nav:** "Pricing" link added for unauthenticated visitors
- **Onboarding copy:** Conversion-focused persona descriptions and step titles ("Add My First Property" CTA)
- **Journey new page:** Updated heading to "Start Your Property Journey"
- **SEO:** `/mortgage-guide`, `/glossary`, `/laws`, `/articles`, `/bank-account-guide`, `/pricing` added to `prerender.mjs`, `sitemap.xml`, and removed from `robots.txt` Disallow (making them crawlable)
- **Vercel:** `www.heimpath.com → heimpath.com` permanent (301) redirect added

## Test plan
- [ ] Landing page hero renders correctly on mobile and desktop
- [ ] ComparisonTable and TestimonialsSection visible on landing page
- [ ] `/pricing` route loads without error
- [ ] "Pricing" nav link visible to logged-out visitors, hidden when authenticated
- [ ] `robots.txt` no longer disallows `/laws`, `/articles`, `/mortgage-guide`, `/glossary`
- [ ] Sitemap includes all new URLs
- [ ] `www.heimpath.com/anything` redirects to `heimpath.com/anything` (301)
- [ ] CI passes: biome, pre-commit, Playwright