### PR TITLE
fix(mobile): fix journey wizard overflow on 320-430px screens

### DIFF
--- a/frontend/src/components/Journey/JourneyGenerating.tsx
+++ b/frontend/src/components/Journey/JourneyGenerating.tsx
@@ -119,7 +119,7 @@ function JourneyGenerating(props: IProps) {
         </p>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="grid w-full grid-cols-2 gap-3 sm:grid-cols-4">
         {(Object.entries(PHASE_LABELS) as [JourneyPhase, string][])
           .filter(([phaseKey]) => phaseCounts[phaseKey] > 0)
           .map(([phaseKey, label]) => (

--- a/frontend/src/components/Journey/WizardStepIndicator.tsx
+++ b/frontend/src/components/Journey/WizardStepIndicator.tsx
@@ -78,19 +78,34 @@ function StepDot(props: {
 function WizardStepIndicator(props: IProps) {
   const { steps, currentStep, completedSteps, className } = props
 
+  const isSummary = currentStep > steps.length
+  const mobileLabel = isSummary
+    ? "Review"
+    : `Step ${currentStep} of ${steps.length}`
+
   return (
-    <div className={cn("flex items-start justify-center", className)}>
-      {steps.map((step, index) => (
-        <StepDot
-          key={step.id}
-          step={step}
-          isCurrent={step.id === currentStep}
-          isCompleted={
-            completedSteps ? completedSteps.has(step.id) : step.id < currentStep
-          }
-          isLast={index === steps.length - 1}
-        />
-      ))}
+    <div className={cn("space-y-1", className)}>
+      {/* Mobile: compact text label avoids connector-margin overflow on narrow viewports */}
+      <p className="text-center text-sm text-muted-foreground sm:hidden">
+        {mobileLabel}
+      </p>
+
+      {/* sm+: full dot-and-connector row */}
+      <div className="hidden sm:flex sm:items-start sm:justify-center">
+        {steps.map((step, index) => (
+          <StepDot
+            key={step.id}
+            step={step}
+            isCurrent={step.id === currentStep}
+            isCompleted={
+              completedSteps
+                ? completedSteps.has(step.id)
+                : step.id < currentStep
+            }
+            isLast={index === steps.length - 1}
+          />
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -364,7 +364,7 @@ function OnboardingWizard(props: Readonly<IProps>) {
           <DialogDescription>{STEP_DESCRIPTIONS[step]}</DialogDescription>
         </DialogHeader>
 
-        <div className="py-2">
+        <div className="overflow-x-hidden py-2">
           {step === 0 && (
             <PersonaStep selected={persona} onSelect={setPersona} />
           )}

--- a/frontend/tests/mobile-viewport-qa.spec.ts
+++ b/frontend/tests/mobile-viewport-qa.spec.ts
@@ -81,4 +81,21 @@ test.describe("Mobile viewport QA (393×852)", () => {
       "horizontal overflow on /articles at 393 px width",
     ).toBeNull()
   })
+
+  test("journeys/new: wizard renders with no horizontal overflow", async ({
+    page,
+  }) => {
+    await page.goto("/journeys/new")
+    await page.waitForLoadState("networkidle")
+
+    await expect(
+      page.getByRole("heading", { name: "Start Your Property Journey" }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    const offender = await firstOverflow(page)
+    expect(
+      offender,
+      "horizontal overflow on /journeys/new at 393 px width",
+    ).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary
- **Root cause diagnosed**: The 8-step buying wizard's `WizardStepIndicator` overflowed narrow viewports because 7 connector `mx-1` margins (7 × 8px = 56px) plus 8 fixed-width dot circles (8 × 32px = 256px) totalled 312px — exceeding the 272px available at 320px viewport width with standard page padding
- **`WizardStepIndicator`**: On mobile (`< sm`), renders a compact `"Step X of N"` text label instead of the full dot row. The dot row is `hidden sm:flex` (desktop only). Eliminates overflow at any step count — both 5-step rental and 8-step buying flows
- **`JourneyGenerating`**: Adds `w-full` to the phase count grid so it stays within its `flex-col items-center` parent on narrow viewports
- **`OnboardingWizard`**: Adds `overflow-x-hidden` safety guard to the inner step-content wrapper div
- **Playwright**: Adds `/journeys/new` mobile overflow assertion to `mobile-viewport-qa.spec.ts` at 393px viewport width

## Test plan
- [ ] Navigate to `/journeys/new` at 320px, 390px, 430px in DevTools — no horizontal scroll on any wizard step
- [ ] Buying wizard (8 steps): mobile shows "Step 1 of 8", "Step 2 of 8", ..., "Review" — desktop shows full dot row
- [ ] Rental wizard (5 steps): same responsive behaviour
- [ ] `/journeys/new` Playwright test passes at 393px
- [ ] `JourneyGenerating` complete screen renders phase grid within bounds on mobile
- [ ] Onboarding wizard dialog on mobile: no horizontal overflow