### PR TITLE
fix(rental): add government id to rental application document checklist

### DIFF
--- a/frontend/src/components/Journey/StepContent/RentalApplicationGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalApplicationGuide.tsx
@@ -3,7 +3,13 @@
  * Guidance on SCHUFA, Selbstauskunft, application documents, and cover letters
  */
 
-import { CreditCard, FileCheck, FileText, UserCheck } from "lucide-react"
+import {
+  CreditCard,
+  FileCheck,
+  FileText,
+  IdCard,
+  UserCheck,
+} from "lucide-react"
 
 import type { JourneyStep } from "@/models/journey"
 import { GuidanceCard } from "./GuidanceCard"
@@ -46,6 +52,12 @@ function RentalApplicationGuide(_props: Readonly<IProps>) {
             label: "Income Proof",
             detail:
               "Last 3 months' pay slips (Gehaltsabrechnungen) and/or employment contract. Landlords typically expect rent to be no more than 1/3 of your net income.",
+          },
+          {
+            icon: IdCard,
+            label: "Government ID",
+            detail:
+              "Passport or national ID card (Personalausweis) for all applicants. Non-EU residents should also bring their Aufenthaltstitel (residence permit). Landlords verify identity before handing over keys.",
           },
         ]}
         tip="Write a brief, friendly cover letter introducing yourself. Mention your profession, why you're moving, and that you're a reliable tenant. A personal touch can make the difference."


### PR DESCRIPTION
## Summary

Audited all rental journey wizard components for buyer-focused language (task #297). The existing code is already correct across the board:

- **`BudgetInput`** — already shows "What is your monthly rent budget?" / "Maximum monthly rent budget" when \`isRental=true\` ✓
- **`TimelineSelector`** — already shows "When do you want to move in?" / "Set a target date for your lease start" when \`isRental=true\` ✓
- **`JourneySummary`** — already labels "Monthly Budget" and "Target move-in date" for rental journeys ✓
- **`RentalContractReview`** — already shows Mietvertrag-specific clause guidance ✓

**One genuine gap found**: `RentalApplicationGuide` had SCHUFA, Mietschuldenfreiheitsbescheinigung, Selbstauskunft, and income proof (Gehaltsabrechnungen) — but was missing government ID (Personalausweis/Reisepass), which German landlords require from all applicants. The task spec explicitly calls this out. Added as the fifth document with a note for non-EU residents to also bring their Aufenthaltstitel.

## Test plan
- [ ] Walk through a new rental journey → Application step → confirm 5 documents listed including "Government ID"
- [ ] Non-EU resident note visible in the Government ID detail text
- [ ] Buying journey Application step unaffected (uses different \`documents_prep\` content key)
- [ ] \`bunx tsc --noEmit\` and \`pre-commit run --all-files\` pass