### PR TITLE
feat(calculators): add calculate button to hidden costs calculator

### DIFF
--- a/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
+++ b/frontend/src/components/Calculators/HiddenCostsCalculator.tsx
@@ -9,10 +9,11 @@ import {
   Euro,
   ExternalLink,
   Info,
+  Loader2,
   RefreshCw,
   Trash2,
 } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import {
   COST_DEFAULTS,
   GERMAN_STATES,
@@ -198,6 +199,9 @@ function HiddenCostsCalculator(props: IProps) {
     includeMoving: true,
   })
 
+  const [hasCalculated, setHasCalculated] = useState(false)
+  const [isCalculating, setIsCalculating] = useState(false)
+  const calculateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [saveName, setSaveName] = useState("")
   const [shareUrl, setShareUrl] = useState("")
 
@@ -207,6 +211,12 @@ function HiddenCostsCalculator(props: IProps) {
   const { data: savedCalcs } = useUserCalculations()
 
   const costs = useMemo(() => calculateCosts(inputs), [inputs])
+
+  const canCalculate =
+    !!inputs.propertyPrice &&
+    parseInt(inputs.propertyPrice, 10) > 0 &&
+    !!inputs.state &&
+    !!inputs.propertyType
 
   const updateInput = <K extends keyof CalculatorInputs>(
     key: K,
@@ -220,7 +230,28 @@ function HiddenCostsCalculator(props: IProps) {
     updateInput("propertyPrice", value)
   }
 
+  const handleCalculate = () => {
+    setIsCalculating(true)
+    calculateTimerRef.current = setTimeout(() => {
+      setIsCalculating(false)
+      setHasCalculated(true)
+    }, 400)
+  }
+
+  // Cancel in-flight timer on unmount so state is never set after unmount.
+  useEffect(() => {
+    return () => {
+      if (calculateTimerRef.current) clearTimeout(calculateTimerRef.current)
+    }
+  }, [])
+
   const handleReset = () => {
+    if (calculateTimerRef.current) {
+      clearTimeout(calculateTimerRef.current)
+      calculateTimerRef.current = null
+    }
+    setIsCalculating(false)
+    setHasCalculated(false)
     setInputs({
       propertyPrice: "",
       state: "BY",
@@ -408,6 +439,23 @@ function HiddenCostsCalculator(props: IProps) {
             </FormRow>
 
             <div className="flex gap-2">
+              <Button
+                onClick={handleCalculate}
+                disabled={!canCalculate || isCalculating}
+                className="flex-1 gap-2"
+              >
+                {isCalculating ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Calculating...
+                  </>
+                ) : (
+                  <>
+                    <Calculator className="h-4 w-4" />
+                    Calculate
+                  </>
+                )}
+              </Button>
               <Button variant="outline" onClick={handleReset} className="gap-2">
                 <RefreshCw className="h-4 w-4" />
                 Reset
@@ -427,7 +475,21 @@ function HiddenCostsCalculator(props: IProps) {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {costs ? (
+            {isCalculating ? (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <Loader2 className="mb-4 h-12 w-12 animate-spin text-muted-foreground" />
+                <p className="text-muted-foreground">
+                  Calculating your costs...
+                </p>
+              </div>
+            ) : !hasCalculated ? (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <Calculator className="mb-4 h-12 w-12 text-muted-foreground" />
+                <p className="text-muted-foreground">
+                  Fill in your property details and click Calculate
+                </p>
+              </div>
+            ) : costs ? (
               <div className="space-y-4">
                 <CostLineItem
                   label="Property Price"
@@ -539,9 +601,9 @@ function HiddenCostsCalculator(props: IProps) {
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-12 text-center">
-                <Calculator className="h-12 w-12 text-muted-foreground mb-4" />
+                <Calculator className="mb-4 h-12 w-12 text-muted-foreground" />
                 <p className="text-muted-foreground">
-                  Enter a property price to see the cost breakdown
+                  Enter a valid property price to see the cost breakdown
                 </p>
               </div>
             )}

--- a/frontend/tests/deep-interaction-qa.spec.ts
+++ b/frontend/tests/deep-interaction-qa.spec.ts
@@ -653,10 +653,19 @@ test.describe("TEST 9: property cost calculator inputs and calculation", () => {
     const comboboxes = page.locator('button[role="combobox"]')
     expect.soft(await comboboxes.count()).toBeGreaterThanOrEqual(2)
 
-    // Enter a price — triggers useMemo recalculation
+    // Enter a price then click Calculate to reveal the cost breakdown
     if (await priceInput.isVisible().catch(() => false)) {
       await priceInput.fill("350000")
-      await page.waitForTimeout(300)
+      await page.waitForTimeout(100)
+
+      // Click the Calculate button (results are gated behind it)
+      const calculateBtn = page.getByRole("button", { name: /^calculate$/i })
+      if (await calculateBtn.isVisible().catch(() => false)) {
+        await calculateBtn.click()
+      }
+
+      // Wait for the 400ms loading animation to complete
+      await page.waitForTimeout(600)
 
       // Cost breakdown heading should appear
       const totalCostHeading = page.getByText("Total Cost of Ownership", {


### PR DESCRIPTION
## Summary
- Adds an explicit **Calculate** button to `HiddenCostsCalculator` — previously results appeared instantly from `useMemo` with no user trigger, leaving users unsure when calculation was complete
- **Disabled state**: button disabled until `propertyPrice > 0` (state and propertyType both have defaults, so price is the effective gate)
- **Loading state**: 400ms spinner in both the button label ("Calculating...") and the results panel — gives clear feedback before the cost breakdown appears
- **Gate on first click**: results panel hidden on initial load (`hasCalculated=false`); shows only after first Calculate click; subsequent input changes update results live via the existing `useMemo`
- **Reset**: clears `hasCalculated` so results panel hides again
- Existing `calculateCosts` and `useMemo` logic untouched — this is a pure UX gate, not a calculation change

## Test plan
- [ ] Open `/tools/property-cost-calculator` — results panel shows "Fill in your property details and click Calculate"
- [ ] Button disabled with empty price; enables once price > 0 is entered
- [ ] Click Calculate: button shows spinner + "Calculating...", results panel shows spinner — both transition to results after ~400ms
- [ ] Change any input after calculating — results update live without re-clicking
- [ ] Click Reset — results panel hides, button re-disables
- [ ] `bunx tsc --noEmit` and `pre-commit run --all-files` pass