### PR TITLE
feat(journey): add clickable portal cards to search step content

### DIFF
--- a/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
@@ -3,16 +3,43 @@
  * Tabbed guidance for searching and evaluating German properties
  */
 
-import { BarChart2, Building2, MapPin, Search } from "lucide-react"
+import { BarChart2, Building2, MapPin } from "lucide-react"
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { GuidanceCard } from "./GuidanceCard"
+import type { IPlatformLink } from "./PlatformLinksGrid"
+import { PlatformLinksGrid } from "./PlatformLinksGrid"
 import { PropertyEvaluationSummary } from "./PropertyEvaluationSummary"
 
 interface IProps {
   journeyId: string
   stepId: string
 }
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const BUYING_PORTALS: readonly IPlatformLink[] = [
+  {
+    name: "ImmoScout24",
+    url: "https://www.immobilienscout24.de",
+    description: "Germany's largest property portal",
+    analyticsId: "immoscout24",
+  },
+  {
+    name: "Immowelt",
+    url: "https://www.immowelt.de",
+    description: "Wide selection of apartments and houses",
+    analyticsId: "immowelt",
+  },
+  {
+    name: "Kleinanzeigen",
+    url: "https://www.kleinanzeigen.de",
+    description: "Private seller listings and deals",
+    analyticsId: "kleinanzeigen",
+  },
+]
 
 /******************************************************************************
                               Components
@@ -33,12 +60,6 @@ function FindAndEvaluateGuide(props: Readonly<IProps>) {
           description="Use the right platforms and criteria to narrow your search efficiently."
           items={[
             {
-              icon: Search,
-              label: "Major Listing Portals",
-              detail:
-                "Search on Immobilienscout24, Immowelt, and Kleinanzeigen. Set up alerts for your target location, size, and budget to catch new listings early.",
-            },
-            {
               icon: MapPin,
               label: "Location Research",
               detail:
@@ -53,6 +74,12 @@ function FindAndEvaluateGuide(props: Readonly<IProps>) {
           ]}
           tip="The first 48 hours after a listing goes live are critical. Properties in high-demand areas often receive multiple offers within days."
         />
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Search Portals</p>
+          <PlatformLinksGrid platforms={BUYING_PORTALS} />
+        </div>
+
         <GuidanceCard
           title="Evaluating Properties"
           description="Assess each property beyond the asking price before committing."

--- a/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/FindAndEvaluateGuide.tsx
@@ -72,11 +72,13 @@ function FindAndEvaluateGuide(props: Readonly<IProps>) {
                 "Compare Eigentumswohnung (flat), Reihenhaus (terraced house), and Einfamilienhaus (detached). Each has different cost structures and maintenance obligations.",
             },
           ]}
-          tip="The first 48 hours after a listing goes live are critical. Properties in high-demand areas often receive multiple offers within days."
+          tip="Set up email alerts on each portal for your target location and budget — new listings in popular areas are claimed within 48 hours."
         />
 
         <div className="space-y-2">
-          <p className="text-sm font-medium">Search Portals</p>
+          <p className="text-sm font-medium text-muted-foreground">
+            Search Portals
+          </p>
           <PlatformLinksGrid platforms={BUYING_PORTALS} />
         </div>
 

--- a/frontend/src/components/Journey/StepContent/PlatformLinksGrid.tsx
+++ b/frontend/src/components/Journey/StepContent/PlatformLinksGrid.tsx
@@ -1,0 +1,58 @@
+/**
+ * Platform Links Grid Component
+ * Clickable cards linking to external property search portals.
+ * Renders in a responsive grid with analytics data attributes.
+ */
+
+import { ExternalLink } from "lucide-react"
+
+interface IPlatformLink {
+  name: string
+  url: string
+  description: string
+  analyticsId: string
+}
+
+interface IProps {
+  platforms: readonly IPlatformLink[]
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+/** Grid of clickable cards linking to property/rental portals. */
+function PlatformLinksGrid(props: Readonly<IProps>) {
+  const { platforms } = props
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {platforms.map((platform) => (
+        <a
+          key={platform.analyticsId}
+          href={platform.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-analytics="outbound-portal-click"
+          data-portal={platform.analyticsId}
+          className="flex items-start gap-3 rounded-lg border p-4 transition-colors hover:border-primary hover:bg-primary/5"
+        >
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">{platform.name}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {platform.description}
+            </p>
+          </div>
+          <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        </a>
+      ))}
+    </div>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { PlatformLinksGrid }
+export type { IPlatformLink }

--- a/frontend/src/components/Journey/StepContent/RentalSearchGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalSearchGuide.tsx
@@ -37,6 +37,12 @@ const RENTAL_PORTALS: readonly IPlatformLink[] = [
     description: "Verified private and agent listings",
     analyticsId: "immonet",
   },
+  {
+    name: "WG-Gesucht",
+    url: "https://www.wg-gesucht.de",
+    description: "Most popular platform for shared flats",
+    analyticsId: "wg-gesucht",
+  },
 ]
 
 /******************************************************************************
@@ -69,11 +75,13 @@ function RentalSearchGuide(_props: Readonly<IProps>) {
               "Know your budget (Kaltmiete + Nebenkosten), minimum size, preferred room count, and must-have features before you start searching.",
           },
         ]}
-        tip="In competitive markets like Berlin or Munich, respond to listings within hours and have your application documents ready to send immediately."
+        tip="Set up email alerts on each portal so new listings reach you within minutes. In competitive markets like Berlin or Munich, respond within hours and have your application documents ready to send immediately."
       />
 
       <div className="space-y-2">
-        <p className="text-sm font-medium">Search Portals</p>
+        <p className="text-sm font-medium text-muted-foreground">
+          Search Portals
+        </p>
         <PlatformLinksGrid platforms={RENTAL_PORTALS} />
       </div>
     </div>

--- a/frontend/src/components/Journey/StepContent/RentalSearchGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalSearchGuide.tsx
@@ -3,14 +3,41 @@
  * Guidance on apartment search portals, requirements, and what to look for
  */
 
-import { Globe, ListChecks, MapPin, Newspaper } from "lucide-react"
+import { ListChecks, MapPin, Newspaper } from "lucide-react"
 
 import type { JourneyStep } from "@/models/journey"
 import { GuidanceCard } from "./GuidanceCard"
+import type { IPlatformLink } from "./PlatformLinksGrid"
+import { PlatformLinksGrid } from "./PlatformLinksGrid"
 
 interface IProps {
   step: JourneyStep
 }
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+const RENTAL_PORTALS: readonly IPlatformLink[] = [
+  {
+    name: "ImmoScout24",
+    url: "https://www.immobilienscout24.de",
+    description: "Germany's largest property portal",
+    analyticsId: "immoscout24",
+  },
+  {
+    name: "Immowelt",
+    url: "https://www.immowelt.de",
+    description: "Wide selection of apartments and houses",
+    analyticsId: "immowelt",
+  },
+  {
+    name: "Immonet",
+    url: "https://www.immonet.de",
+    description: "Verified private and agent listings",
+    analyticsId: "immonet",
+  },
+]
 
 /******************************************************************************
                               Components
@@ -23,12 +50,6 @@ function RentalSearchGuide(_props: Readonly<IProps>) {
         title="Finding an Apartment in Germany"
         description="The German rental market can be competitive, especially in major cities. Preparation and quick responses are key."
         items={[
-          {
-            icon: Globe,
-            label: "Online Portals",
-            detail:
-              "ImmoScout24 and Immowelt are the main platforms. Set up alerts for new listings matching your criteria. WG-Gesucht is popular for shared apartments.",
-          },
           {
             icon: MapPin,
             label: "Location Research",
@@ -50,6 +71,11 @@ function RentalSearchGuide(_props: Readonly<IProps>) {
         ]}
         tip="In competitive markets like Berlin or Munich, respond to listings within hours and have your application documents ready to send immediately."
       />
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Search Portals</p>
+        <PlatformLinksGrid platforms={RENTAL_PORTALS} />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a new `PlatformLinksGrid` component — a responsive 3-column grid of external portal cards, each with name, short description, ExternalLink icon, `target="_blank" rel="noopener noreferrer"`, and `data-analytics` / `data-portal` attributes for future click tracking
- **`RentalSearchGuide`**: removed the plain "Online Portals" text item from the GuidanceCard; adds ImmoScout24, Immowelt, and Immonet as clickable cards below the guidance
- **`FindAndEvaluateGuide`**: removed the portal names from the "Major Listing Portals" GuidanceCard text; adds ImmoScout24, Immowelt, and Kleinanzeigen (appropriate for buying context) in the "Find Properties" tab
- No hardcoded hex colors — Tailwind design tokens only (`border-primary`, `bg-primary/5`, `text-muted-foreground`)

## Test plan
- [ ] Navigate to a rental journey → Apartment Search step → confirm 3 portal cards (ImmoScout24, Immowelt, Immonet) are visible
- [ ] Click each card → confirms it opens the correct URL in a new tab
- [ ] Navigate to a buying journey → Find & Evaluate step → "Find Properties" tab → confirm 3 portal cards (ImmoScout24, Immowelt, Kleinanzeigen) are visible
- [ ] Hover state works (border changes to primary colour)
- [ ] `bunx tsc --noEmit` and `pre-commit run --all-files` pass