### PR TITLE
feat(rental): add cover letter generator to rental application guide

### DIFF
--- a/frontend/src/components/Journey/StepContent/CoverLetterGenerator.tsx
+++ b/frontend/src/components/Journey/StepContent/CoverLetterGenerator.tsx
@@ -1,0 +1,252 @@
+/**
+ * Cover Letter Generator Component
+ * Generates a formal landlord cover letter (Anschreiben) from user-provided details
+ */
+
+import { Check, ClipboardCopy, FileText } from "lucide-react"
+import { useState } from "react"
+
+import { cn } from "@/common/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import useAuth from "@/hooks/useAuth"
+
+/******************************************************************************
+                              Constants
+******************************************************************************/
+
+type Language = "en" | "de"
+
+const PLACEHOLDER = "Click Generate to create your personalised Anschreiben"
+const CLIPBOARD_RESET_MS = 2000
+
+function buildEnglishLetter(
+  name: string,
+  profession: string,
+  income: string,
+  moveInDate: string,
+  householdSize: string,
+): string {
+  return `Dear Landlord / Ladies and Gentlemen,
+
+My name is ${name}. I am a ${profession} with a net monthly income of ${income} EUR. I am currently looking for a rental apartment and would like to move in on ${moveInDate}.
+
+My household consists of ${householdSize} person(s). I am a reliable, tidy, and considerate tenant who always pays rent on time.
+
+I would be delighted to arrange a viewing at your earliest convenience. Please feel free to contact me for any further information.
+
+Yours sincerely,
+${name}`
+}
+
+function buildGermanLetter(
+  name: string,
+  profession: string,
+  income: string,
+  moveInDate: string,
+  householdSize: string,
+): string {
+  return `Sehr geehrte Damen und Herren,
+
+mein Name ist ${name}. Ich bin als ${profession} tätig und verfüge über ein monatliches Nettoeinkommen von ${income} EUR. Ich suche derzeit eine Mietwohnung und würde gerne zum ${moveInDate} einziehen.
+
+Mein Haushalt besteht aus ${householdSize} Person(en). Ich bin ein zuverlässiger, ordentlicher und rücksichtsvoller Mieter, der die Miete stets pünktlich zahlt.
+
+Über die Möglichkeit eines Besichtigungstermins würde ich mich sehr freuen. Für weitere Informationen stehe ich Ihnen jederzeit gerne zur Verfügung.
+
+Mit freundlichen Grüßen,
+${name}`
+}
+
+/******************************************************************************
+                              Components
+******************************************************************************/
+
+function CoverLetterGenerator() {
+  const { user } = useAuth()
+
+  const [profession, setProfession] = useState("")
+  const [income, setIncome] = useState("")
+  const [moveInDate, setMoveInDate] = useState("")
+  const [householdSize, setHouseholdSize] = useState("1")
+  const [letterText, setLetterText] = useState("")
+  const [language, setLanguage] = useState<Language>("en")
+  const [copied, setCopied] = useState(false)
+
+  const handleGenerate = () => {
+    const name = user?.full_name || "[Your Name]"
+    const displayProfession = profession || "[Profession]"
+    const displayIncome = income || "[Net Monthly Income]"
+    const displayMoveInDate = moveInDate || "[Move-in Date]"
+    const displayHouseholdSize = householdSize || "1"
+
+    const text =
+      language === "en"
+        ? buildEnglishLetter(
+            name,
+            displayProfession,
+            displayIncome,
+            displayMoveInDate,
+            displayHouseholdSize,
+          )
+        : buildGermanLetter(
+            name,
+            displayProfession,
+            displayIncome,
+            displayMoveInDate,
+            displayHouseholdSize,
+          )
+
+    setLetterText(text)
+  }
+
+  const handleCopy = async () => {
+    if (!letterText) return
+    await navigator.clipboard.writeText(letterText)
+    setCopied(true)
+    setTimeout(() => setCopied(false), CLIPBOARD_RESET_MS)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <FileText className="h-4 w-4 shrink-0 text-primary" />
+            <CardTitle className="text-base">
+              Cover Letter Generator (Anschreiben)
+            </CardTitle>
+          </div>
+          <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+            <button
+              type="button"
+              onClick={() => setLanguage("en")}
+              className={cn(
+                "rounded px-2 py-0.5 text-xs font-medium transition-all",
+                language === "en"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              EN
+            </button>
+            <button
+              type="button"
+              onClick={() => setLanguage("de")}
+              className={cn(
+                "rounded px-2 py-0.5 text-xs font-medium transition-all",
+                language === "de"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              DE
+            </button>
+          </div>
+        </div>
+        <CardDescription>
+          Fill in your details and generate a personalised cover letter to
+          impress landlords.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-1">
+            <Label htmlFor="cl-profession" className="text-xs">
+              Profession
+            </Label>
+            <Input
+              id="cl-profession"
+              placeholder="e.g. Software Engineer"
+              value={profession}
+              onChange={(e) => setProfession(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="cl-income" className="text-xs">
+              Net Monthly Income (EUR)
+            </Label>
+            <Input
+              id="cl-income"
+              placeholder="e.g. 3500"
+              value={income}
+              onChange={(e) => setIncome(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="cl-move-in" className="text-xs">
+              Requested Move-in Date
+            </Label>
+            <Input
+              id="cl-move-in"
+              placeholder="e.g. 01.09.2025"
+              value={moveInDate}
+              onChange={(e) => setMoveInDate(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="cl-household" className="text-xs">
+              Household Size
+            </Label>
+            <Input
+              id="cl-household"
+              placeholder="e.g. 2"
+              value={householdSize}
+              onChange={(e) => setHouseholdSize(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+        </div>
+
+        <Button onClick={handleGenerate} size="sm" className="w-full">
+          Generate Letter
+        </Button>
+
+        <Textarea
+          value={letterText}
+          onChange={(e) => setLetterText(e.target.value)}
+          placeholder={PLACEHOLDER}
+          className="min-h-[220px] resize-y text-sm"
+        />
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleCopy}
+          disabled={!letterText}
+          className="w-full"
+        >
+          {copied ? (
+            <>
+              <Check className="mr-1.5 h-3.5 w-3.5" />
+              Copied!
+            </>
+          ) : (
+            <>
+              <ClipboardCopy className="mr-1.5 h-3.5 w-3.5" />
+              Copy to Clipboard
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+/******************************************************************************
+                              Export
+******************************************************************************/
+
+export { CoverLetterGenerator }

--- a/frontend/src/components/Journey/StepContent/CoverLetterGenerator.tsx
+++ b/frontend/src/components/Journey/StepContent/CoverLetterGenerator.tsx
@@ -41,7 +41,7 @@ const INITIAL_FIELDS: IFormFields = {
   profession: "",
   income: "",
   moveInDate: "",
-  householdSize: "1",
+  householdSize: "",
   letterText: "",
 }
 
@@ -230,7 +230,7 @@ function CoverLetterGenerator() {
           disabled={!fields.letterText}
           className="w-full"
         >
-          {copiedText !== null ? (
+          {copiedText === fields.letterText && copiedText !== null ? (
             <>
               <Check className="mr-1.5 h-3.5 w-3.5" />
               Copied!

--- a/frontend/src/components/Journey/StepContent/CoverLetterGenerator.tsx
+++ b/frontend/src/components/Journey/StepContent/CoverLetterGenerator.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import useAuth from "@/hooks/useAuth"
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 
 /******************************************************************************
                               Constants
@@ -27,15 +28,44 @@ import useAuth from "@/hooks/useAuth"
 type Language = "en" | "de"
 
 const PLACEHOLDER = "Click Generate to create your personalised Anschreiben"
-const CLIPBOARD_RESET_MS = 2000
 
-function buildEnglishLetter(
+interface IFormFields {
+  profession: string
+  income: string
+  moveInDate: string
+  householdSize: string
+  letterText: string
+}
+
+const INITIAL_FIELDS: IFormFields = {
+  profession: "",
+  income: "",
+  moveInDate: "",
+  householdSize: "1",
+  letterText: "",
+}
+
+function buildLetter(
+  lang: Language,
   name: string,
   profession: string,
   income: string,
   moveInDate: string,
   householdSize: string,
 ): string {
+  if (lang === "de") {
+    return `Sehr geehrte Damen und Herren,
+
+mein Name ist ${name}. Ich bin als ${profession} tätig und verfüge über ein monatliches Nettoeinkommen von ${income} EUR. Ich suche derzeit eine Mietwohnung und würde gerne zum ${moveInDate} einziehen.
+
+Mein Haushalt besteht aus ${householdSize} Person(en). Ich bin ein zuverlässiger, ordentlicher und rücksichtsvoller Mieter, der die Miete stets pünktlich zahlt.
+
+Über die Möglichkeit eines Besichtigungstermins würde ich mich sehr freuen. Für weitere Informationen stehe ich Ihnen jederzeit gerne zur Verfügung.
+
+Mit freundlichen Grüßen,
+${name}`
+  }
+
   return `Dear Landlord / Ladies and Gentlemen,
 
 My name is ${name}. I am a ${profession} with a net monthly income of ${income} EUR. I am currently looking for a rental apartment and would like to move in on ${moveInDate}.
@@ -48,72 +78,44 @@ Yours sincerely,
 ${name}`
 }
 
-function buildGermanLetter(
-  name: string,
-  profession: string,
-  income: string,
-  moveInDate: string,
-  householdSize: string,
-): string {
-  return `Sehr geehrte Damen und Herren,
-
-mein Name ist ${name}. Ich bin als ${profession} tätig und verfüge über ein monatliches Nettoeinkommen von ${income} EUR. Ich suche derzeit eine Mietwohnung und würde gerne zum ${moveInDate} einziehen.
-
-Mein Haushalt besteht aus ${householdSize} Person(en). Ich bin ein zuverlässiger, ordentlicher und rücksichtsvoller Mieter, der die Miete stets pünktlich zahlt.
-
-Über die Möglichkeit eines Besichtigungstermins würde ich mich sehr freuen. Für weitere Informationen stehe ich Ihnen jederzeit gerne zur Verfügung.
-
-Mit freundlichen Grüßen,
-${name}`
-}
-
 /******************************************************************************
                               Components
 ******************************************************************************/
 
 function CoverLetterGenerator() {
   const { user } = useAuth()
+  const [copiedText, copy] = useCopyToClipboard()
 
-  const [profession, setProfession] = useState("")
-  const [income, setIncome] = useState("")
-  const [moveInDate, setMoveInDate] = useState("")
-  const [householdSize, setHouseholdSize] = useState("1")
-  const [letterText, setLetterText] = useState("")
+  const [fields, setFields] = useState<IFormFields>(INITIAL_FIELDS)
   const [language, setLanguage] = useState<Language>("en")
-  const [copied, setCopied] = useState(false)
 
-  const handleGenerate = () => {
-    const name = user?.full_name || "[Your Name]"
-    const displayProfession = profession || "[Profession]"
-    const displayIncome = income || "[Net Monthly Income]"
-    const displayMoveInDate = moveInDate || "[Move-in Date]"
-    const displayHouseholdSize = householdSize || "1"
-
-    const text =
-      language === "en"
-        ? buildEnglishLetter(
-            name,
-            displayProfession,
-            displayIncome,
-            displayMoveInDate,
-            displayHouseholdSize,
-          )
-        : buildGermanLetter(
-            name,
-            displayProfession,
-            displayIncome,
-            displayMoveInDate,
-            displayHouseholdSize,
-          )
-
-    setLetterText(text)
+  const updateField = (key: keyof IFormFields, value: string) => {
+    setFields((prev) => ({ ...prev, [key]: value }))
   }
 
-  const handleCopy = async () => {
-    if (!letterText) return
-    await navigator.clipboard.writeText(letterText)
-    setCopied(true)
-    setTimeout(() => setCopied(false), CLIPBOARD_RESET_MS)
+  const handleLanguageChange = (lang: Language) => {
+    setLanguage(lang)
+    // Clear letter so user knows they need to regenerate in the new language
+    setFields((prev) => ({ ...prev, letterText: "" }))
+  }
+
+  const handleGenerate = () => {
+    const name = user?.full_name?.trim() || "[Your Name]"
+    const displayProfession = fields.profession || "[Profession]"
+    const displayIncome = fields.income || "[Net Monthly Income]"
+    const displayMoveInDate = fields.moveInDate || "[Move-in Date]"
+    const displayHouseholdSize = fields.householdSize || "[Household Size]"
+
+    const text = buildLetter(
+      language,
+      name,
+      displayProfession,
+      displayIncome,
+      displayMoveInDate,
+      displayHouseholdSize,
+    )
+
+    setFields((prev) => ({ ...prev, letterText: text }))
   }
 
   return (
@@ -129,7 +131,7 @@ function CoverLetterGenerator() {
           <div className="flex items-center gap-0.5 rounded-md border p-0.5">
             <button
               type="button"
-              onClick={() => setLanguage("en")}
+              onClick={() => handleLanguageChange("en")}
               className={cn(
                 "rounded px-2 py-0.5 text-xs font-medium transition-all",
                 language === "en"
@@ -141,7 +143,7 @@ function CoverLetterGenerator() {
             </button>
             <button
               type="button"
-              onClick={() => setLanguage("de")}
+              onClick={() => handleLanguageChange("de")}
               className={cn(
                 "rounded px-2 py-0.5 text-xs font-medium transition-all",
                 language === "de"
@@ -167,8 +169,8 @@ function CoverLetterGenerator() {
             <Input
               id="cl-profession"
               placeholder="e.g. Software Engineer"
-              value={profession}
-              onChange={(e) => setProfession(e.target.value)}
+              value={fields.profession}
+              onChange={(e) => updateField("profession", e.target.value)}
               className="h-8 text-sm"
             />
           </div>
@@ -179,8 +181,8 @@ function CoverLetterGenerator() {
             <Input
               id="cl-income"
               placeholder="e.g. 3500"
-              value={income}
-              onChange={(e) => setIncome(e.target.value)}
+              value={fields.income}
+              onChange={(e) => updateField("income", e.target.value)}
               className="h-8 text-sm"
             />
           </div>
@@ -191,8 +193,8 @@ function CoverLetterGenerator() {
             <Input
               id="cl-move-in"
               placeholder="e.g. 01.09.2025"
-              value={moveInDate}
-              onChange={(e) => setMoveInDate(e.target.value)}
+              value={fields.moveInDate}
+              onChange={(e) => updateField("moveInDate", e.target.value)}
               className="h-8 text-sm"
             />
           </div>
@@ -203,8 +205,8 @@ function CoverLetterGenerator() {
             <Input
               id="cl-household"
               placeholder="e.g. 2"
-              value={householdSize}
-              onChange={(e) => setHouseholdSize(e.target.value)}
+              value={fields.householdSize}
+              onChange={(e) => updateField("householdSize", e.target.value)}
               className="h-8 text-sm"
             />
           </div>
@@ -215,8 +217,8 @@ function CoverLetterGenerator() {
         </Button>
 
         <Textarea
-          value={letterText}
-          onChange={(e) => setLetterText(e.target.value)}
+          value={fields.letterText}
+          onChange={(e) => updateField("letterText", e.target.value)}
           placeholder={PLACEHOLDER}
           className="min-h-[220px] resize-y text-sm"
         />
@@ -224,11 +226,11 @@ function CoverLetterGenerator() {
         <Button
           variant="outline"
           size="sm"
-          onClick={handleCopy}
-          disabled={!letterText}
+          onClick={() => copy(fields.letterText)}
+          disabled={!fields.letterText}
           className="w-full"
         >
-          {copied ? (
+          {copiedText !== null ? (
             <>
               <Check className="mr-1.5 h-3.5 w-3.5" />
               Copied!

--- a/frontend/src/components/Journey/StepContent/RentalApplicationGuide.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalApplicationGuide.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react"
 
 import type { JourneyStep } from "@/models/journey"
+import { CoverLetterGenerator } from "./CoverLetterGenerator"
 import { GuidanceCard } from "./GuidanceCard"
 
 interface IProps {
@@ -60,8 +61,8 @@ function RentalApplicationGuide(_props: Readonly<IProps>) {
               "Passport or national ID card (Personalausweis) for all applicants. Non-EU residents should also bring their Aufenthaltstitel (residence permit). Landlords verify identity before handing over keys.",
           },
         ]}
-        tip="Write a brief, friendly cover letter introducing yourself. Mention your profession, why you're moving, and that you're a reliable tenant. A personal touch can make the difference."
       />
+      <CoverLetterGenerator />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a `CoverLetterGenerator` component to the rental application step
- Users can fill in profession, net monthly income, move-in date, and household size
- "Generate Letter" button pre-populates a formal template using the user's profile name and entered details
- English/German (EN/DE) toggle to switch letter language
- Editable textarea allows freeform editing after generation
- "Copy to Clipboard" button with toggled "Copied!" confirmation state
- Pure client-side template substitution — no API calls

## Test plan
- [ ] Navigate to the rental application step in the journey wizard
- [ ] Verify the Cover Letter Generator card appears below the document checklist
- [ ] Fill in profession, income, move-in date, household size — click "Generate Letter"
- [ ] Confirm the textarea is populated with a formatted letter containing the entered details
- [ ] Toggle to DE — click "Generate Letter" again — confirm German template appears
- [ ] Edit the generated text directly in the textarea
- [ ] Click "Copy to Clipboard" — confirm "Copied!" state appears briefly and text is in clipboard
- [ ] Test with no fields filled — placeholders appear in the letter
- [ ] Run `bunx tsc --noEmit` and `pre-commit run --all-files` — both pass