### PR TITLE
feat(rental): add Mietvertrag upload and red flag insights to contract review step

### DIFF
--- a/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
+++ b/frontend/src/components/Journey/StepContent/RentalContractReview.tsx
@@ -1,12 +1,30 @@
 /**
  * Rental Contract Review Step Content
- * Guidance on Mietvertrag clauses, red flags, and tenant rights
+ * Mietvertrag upload, translation, red flag analysis, and clause guidance
  */
 
-import { AlertTriangle, FileText, Scale, ShieldCheck } from "lucide-react"
-
+import { Link } from "@tanstack/react-router"
+import {
+  AlertTriangle,
+  ExternalLink,
+  FileText,
+  Loader2,
+  Scale,
+  ShieldCheck,
+  Zap,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { useStepDocuments } from "@/hooks/queries"
 import type { JourneyStep } from "@/models/journey"
 import { GuidanceCard } from "./GuidanceCard"
+import { StepDocumentReview } from "./StepDocumentReview"
 
 interface IProps {
   step: JourneyStep
@@ -16,9 +34,109 @@ interface IProps {
                               Components
 ******************************************************************************/
 
-function RentalContractReview(_props: Readonly<IProps>) {
+function RentalContractReview(props: Readonly<IProps>) {
+  const { step } = props
+  const { data: documents = [] } = useStepDocuments(step.id)
+
+  // Most recently uploaded completed document (sort descending by createdAt)
+  const completedDoc = documents
+    .slice()
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .find((d) => d.status === "completed")
+
+  // True only while actively processing — failed docs must not show a spinner
+  const isProcessing = documents.some(
+    (d) => d.status === "uploaded" || d.status === "processing",
+  )
+
   return (
     <div className="space-y-4">
+      {/* Mietvertrag upload */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <FileText className="h-4 w-4 shrink-0 text-primary" />
+            Upload your Mietvertrag (Rental Contract)
+          </CardTitle>
+          <CardDescription>
+            Upload your German rental contract to translate it and detect
+            potentially unfavourable clauses.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <StepDocumentReview stepId={step.id} />
+
+          {/* Action buttons — always visible; Translate enabled once a doc completes */}
+          <div className="grid grid-cols-2 gap-2 pt-1">
+            {completedDoc ? (
+              <Button size="sm" asChild>
+                <Link
+                  to="/documents/$documentId"
+                  params={{ documentId: completedDoc.id }}
+                >
+                  <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                  Translate Contract
+                </Link>
+              </Button>
+            ) : (
+              <Button size="sm" disabled>
+                {isProcessing ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    Processing…
+                  </>
+                ) : (
+                  <>
+                    <FileText className="mr-1.5 h-3.5 w-3.5" />
+                    Translate Contract
+                  </>
+                )}
+              </Button>
+            )}
+
+            <Button size="sm" variant="outline" asChild>
+              <Link to="/contract-explainer">
+                <Zap className="mr-1.5 h-3.5 w-3.5" />
+                Open Explainer
+              </Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Static red flag insights */}
+      <GuidanceCard
+        title="Common Red Flags to Watch For"
+        description="German rental contracts often contain clauses that tenants should scrutinise carefully before signing."
+        items={[
+          {
+            icon: AlertTriangle,
+            label: "Schönheitsreparaturen (Cosmetic Repairs)",
+            detail:
+              "Rigid renovation schedules requiring repainting every 3-5 years are frequently invalid under German law (BGH rulings). Any clause with fixed intervals should be flagged.",
+          },
+          {
+            icon: Scale,
+            label: "Staffelmiete (Stepped Rent Increases)",
+            detail:
+              "Pre-agreed rent increases at fixed dates. Ensure the steps are clearly specified and that increases do not exceed what is permitted under Mietpreisbremse regulations in your city.",
+          },
+          {
+            icon: ShieldCheck,
+            label: "Unusual Kündigungsfrist (Notice Periods)",
+            detail:
+              "Standard tenant notice is 3 months. Any clause extending this to 6+ months, or imposing a minimum tenancy (Mindestmietdauer) without clear justification, is worth questioning.",
+          },
+          {
+            icon: FileText,
+            label: "Nebenkostenabrechnung (Utility Billing)",
+            detail:
+              "Operating costs must be individually itemised. Flat-rate Nebenkosten without annual reconciliation or clauses excluding refunds of overpaid advance payments are red flags.",
+          },
+        ]}
+      />
+
+      {/* Key clauses guidance */}
       <GuidanceCard
         title="Key Mietvertrag Clauses"
         description="German lease agreements contain important clauses that affect your rights and obligations. Review each section carefully before signing."
@@ -31,7 +149,7 @@ function RentalContractReview(_props: Readonly<IProps>) {
           },
           {
             icon: AlertTriangle,
-            label: "Schonheitsreparaturen (Cosmetic Repairs)",
+            label: "Schönheitsreparaturen (Cosmetic Repairs)",
             detail:
               "Clauses requiring you to repaint or repair at set intervals are often invalid under German law (BGH rulings). Rigid renovation schedules are unenforceable — negotiate removal if present.",
           },
@@ -43,7 +161,7 @@ function RentalContractReview(_props: Readonly<IProps>) {
           },
           {
             icon: ShieldCheck,
-            label: "Notice Period (Kundigungsfrist)",
+            label: "Notice Period (Kündigungsfrist)",
             detail:
               "Standard tenant notice period is 3 months. Landlord notice periods increase with tenancy length (3-9 months). Minimum lease terms (Mindestmietdauer) should be checked carefully.",
           },


### PR DESCRIPTION
## Summary
- Adds a document upload dropzone (via existing `StepDocumentReview`) to the rental contract review step with the label \"Upload your Mietvertrag (Rental Contract)\"
- After upload, two action buttons appear: **Translate Contract** (links to `/documents/{documentId}` for the completed document, shows spinner while processing) and **Analyse Red Flags** (navigates to `/contract-explainer`)
- Adds a static **Common Red Flags to Watch For** card highlighting: Schönheitsreparaturen, Staffelmiete, unusual Kündigungsfrist, and Nebenkostenabrechnung irregularities
- Retains the original key clauses guidance card and Mieterverein tip
- No new API endpoints — uses existing document upload pipeline and `useStepDocuments` hook (TanStack Query deduplicates the query with `StepDocumentReview`'s internal call)
- No regression in buying journey document uploads (`StepDocumentReview` is unmodified)

## Test plan
- [ ] Navigate to the rental contract review step in a rental journey
- [ ] Verify the upload card appears above the red flag and clause guidance cards
- [ ] Upload a test PDF — verify it appears in the document list with processing status
- [ ] While processing, verify "Translate Contract" button is disabled/shows spinner; "Analyse Red Flags" is enabled
- [ ] After processing completes, verify "Translate Contract" navigates to `/documents/{id}`
- [ ] Click "Analyse Red Flags" — verify navigation to `/contract-explainer`
- [ ] Verify red flag list (4 items) is always visible without uploading
- [ ] Verify buying journey document upload steps are unaffected
- [ ] Run `bunx tsc --noEmit` and `pre-commit run --all-files` — both pass