### PR TITLE
fix(infra): authenticate to ghcr on vps before docker pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,19 +50,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Deploy backend-staging via SSH
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: deploy
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GHCR_TOKEN,GHCR_USER
           script: |
             set -e
             cd /opt/heimpath
@@ -70,6 +67,8 @@ jobs:
             PREVIOUS_TAG=$(cat .last-deployed-tag 2>/dev/null || echo "")
             CURRENT_TAG="${{ needs.build.outputs.image-tag }}"
             IMAGE_PREFIX="${{ needs.build.outputs.image-prefix }}"
+
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
 
             docker pull "${IMAGE_PREFIX}/backend:${CURRENT_TAG}"
 
@@ -155,10 +154,14 @@ jobs:
     steps:
       - name: Deploy backend-prod via SSH
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: deploy
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GHCR_TOKEN,GHCR_USER
           script: |
             set -e
             cd /opt/heimpath
@@ -166,6 +169,8 @@ jobs:
             PREVIOUS_TAG=$(cat .last-prod-deployed-tag 2>/dev/null || echo "")
             CURRENT_TAG="${{ needs.build.outputs.image-tag }}"
             IMAGE_PREFIX="${{ needs.build.outputs.image-prefix }}"
+
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
 
             docker pull "${IMAGE_PREFIX}/backend:${CURRENT_TAG}"
 


### PR DESCRIPTION
## Summary
- The `docker pull` in the SSH deploy script was failing with `unauthorized` because the GHCR login step ran on the GitHub Actions runner, not on the VPS
- Fix: pass `GITHUB_TOKEN` and `github.actor` into the SSH script via appleboy `envs`, then run `docker login ghcr.io` on the VPS before pulling
- Applied to both `deploy-staging-backend` and `deploy-prod-backend` jobs

## Test plan
- [ ] Merge and confirm deploy pipeline re-runs successfully end-to-end to staging