### PR TITLE
fix(ci): add --prod flag to staging Vercel deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Deploy to Vercel staging
         run: |
           npx vercel deploy \
+            --prod \
             --yes \
             --build-env VITE_API_URL=${{ vars.STAGING_API_URL }} \
             --build-env VITE_SENTRY_DSN=${{ vars.STAGING_FRONTEND_SENTRY_DSN }}


### PR DESCRIPTION
## Problem

Staging Vercel deploy was running `vercel deploy` without `--prod`, creating a preview deployment instead of a production deployment. `staging.heimpath.com` was never updated — it stayed on whatever was last manually deployed there.

Smoke tests still passed because they only grep for `"heimpath"` in the page body, not specific content.

## Fix

Add `--prod` to the staging Vercel deploy step so every pipeline run promotes the build to `staging.heimpath.com`, mirroring how the prod deploy already works.

## Effect

After this merges, the pipeline will:
1. Build from current `main`
2. Deploy backend-staging to VPS ✓
3. Deploy frontend-staging to `staging.heimpath.com` ✓ (was: preview URL only)
4. Smoke test `staging.heimpath.com` ✓
5. Await approval → deploy to prod ✓

Staging and prod will stay in sync going forward.