### PR TITLE
fix(auth): set email_verified=True on successful password reset

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -699,6 +699,9 @@ async def reset_password(
         )
 
     user.hashed_password = get_password_hash(request.new_password)
+    # Receiving and acting on the password reset email proves email ownership —
+    # treat this as implicit email verification so the user can log in immediately.
+    user.email_verified = True
     session.add(user)
     session.commit()
 

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -174,6 +174,10 @@ def reset_password(session: SessionDep, body: NewPassword) -> Message:
         db_user=user,
         user_in=user_in_update,
     )
+    # Receiving and acting on the reset email proves ownership — mark as verified.
+    user.email_verified = True
+    session.add(user)
+    session.commit()
     return Message(message="Password updated successfully")
 
 

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -168,16 +168,15 @@ def reset_password(session: SessionDep, body: NewPassword) -> Message:
         raise HTTPException(status_code=400, detail="Invalid token")
     elif not user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")
+    # Receiving and acting on the reset email proves ownership — mark as verified.
+    # Set before update_user so both changes land in its single internal commit.
+    user.email_verified = True
     user_in_update = UserUpdate(password=body.new_password)
     crud.update_user(
         session=session,
         db_user=user,
         user_in=user_in_update,
     )
-    # Receiving and acting on the reset email proves ownership — mark as verified.
-    user.email_verified = True
-    session.add(user)
-    session.commit()
     return Message(message="Password updated successfully")
 
 

--- a/backend/tests/api/routes/test_auth.py
+++ b/backend/tests/api/routes/test_auth.py
@@ -427,6 +427,28 @@ def test_reset_password_success(client: TestClient, db: Session) -> None:
     assert verified
 
 
+def test_reset_password_marks_email_verified(client: TestClient, db: Session) -> None:
+    """Resetting via a valid link proves email ownership — user should be marked verified."""
+    email = random_email()
+    client.post(f"{AUTH}/register", json={"email": email, "password": _VALID_PASSWORD})
+
+    user = get_user_by_email(session=db, email=email)
+    assert user is not None
+    assert user.email_verified is False  # just registered, not yet verified
+
+    svc = get_password_reset_service()
+    token_data = svc.generate_token(user_id=str(user.id), email=email)
+
+    r = client.post(
+        f"{AUTH}/reset-password",
+        json={"token": token_data.token, "new_password": "NewSecure3"},
+    )
+    assert r.status_code == 200
+
+    db.refresh(user)
+    assert user.email_verified is True
+
+
 def test_reset_password_invalid_token_returns_400(client: TestClient) -> None:
     r = client.post(
         f"{AUTH}/reset-password",


### PR DESCRIPTION
## Root Cause

Investigated the 'reset password email not dropping on staging' report.

**Finding 1 — immediate cause**: The user's email was not registered in the staging database. The forgot-password endpoint correctly returns 200 (anti-enumeration design) without sending an email when the user doesn't exist. The user needs to register at staging.heimpath.com first.

**Finding 2 — code bug (this PR)**: `reset_password` did not set `email_verified=True` after a successful reset. This created a permanent lockout:

1. User registers → `email_verified=False`
2. Verification email missed/deleted
3. User tries forgot-password → email sent (because `is_active=True`) ✓
4. User clicks reset link, sets new password ✓
5. User tries to login → **blocked** with "Please verify your email before logging in" ✗

Receiving a password reset link and acting on it proves email ownership to the same degree as the verification flow. The fix marks the email as verified on a successful password reset.

## Changes

- `auth.py reset_password`: add `user.email_verified = True` after password update
- `login.py reset_password` (deprecated): same fix for consistency
- New test `test_reset_password_marks_email_verified` regression test

## Test plan

- [ ] Run `pytest tests/api/routes/test_auth.py -k reset_password` — all 5 pass
- [ ] Register new account on staging, skip verification, trigger password reset, reset password, confirm login succeeds