### PR TITLE
fix: recycle celery workers periodically to bound memory growth

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,7 +72,7 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     restart: always
-    command: celery -A app.worker.celery_app worker --loglevel=info --concurrency=2 --hostname=worker@%h
+    command: celery -A app.worker.celery_app worker --loglevel=info --concurrency=2 --max-tasks-per-child=50 --hostname=worker@%h
     env_file:
       - .env
     extra_hosts:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -72,7 +72,7 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     restart: always
-    command: celery -A app.worker.celery_app worker --loglevel=info --concurrency=2 --hostname=worker-staging@%h
+    command: celery -A app.worker.celery_app worker --loglevel=info --concurrency=2 --max-tasks-per-child=50 --hostname=worker-staging@%h
     env_file:
       - .env.staging
     extra_hosts:

--- a/infra/DEPLOYMENT.md
+++ b/infra/DEPLOYMENT.md
@@ -76,6 +76,14 @@ The backend runs on a Hetzner VPS with Caddy as the reverse proxy. Both producti
 | `heimpath-celery-worker-staging-1` | Staging Celery worker | — |
 | `heimpath-celery-beat-staging-1` | Staging Celery beat | — |
 
+**Worker memory (added 2026-07-10):** both `celery-worker` commands run with `--max-tasks-per-child=50`.
+Python/glibc rarely returns memory to the OS after a heavy task (document/translation/analysis jobs),
+so a worker process's RSS climbs to whatever its biggest task needed and stays there indefinitely.
+Staging was observed at ~3x prod's per-process RSS (237MB/214MB vs 73MB/37MB) despite identical
+concurrency and uptime — not a leak, just accumulated high-water-mark from heavier QA-driven testing
+traffic. `--max-tasks-per-child` forces periodic worker process recycling, which reclaims that memory
+back to the OS.
+
 Caddy (running in the `modish_modish` Docker network on the same host) reverse-proxies:
 - `api.heimpath.com` → `heimpath-backend:8000`
 - `api.staging.heimpath.com` → `heimpath-backend-staging:8000`


### PR DESCRIPTION
## What changed
Added `--max-tasks-per-child=50` to both `celery-worker` (prod) and `celery-worker-staging` commands.

## Why
`heimpath-celery-worker-staging-1` was flagged using ~442MB on the shared Hetzner box, more than most production services including heimpath's own prod worker (~159MB). Measured per-process RSS directly on the server: both prod and staging workers have identical config (`--concurrency=2`), identical uptime (started same day, 0 restarts), yet each staging worker process sits at ~3x its prod counterpart's RSS (237MB/214MB vs 73MB/37MB).

This isn't a leak — it's Python/glibc not returning memory to the OS after a heavy task runs, so a worker process's RSS climbs to its highest-ever task's footprint and stays there. Staging naturally sees more manual/QA testing of memory-heavier features (document/translation/analysis tasks), so its high-water mark ended up much higher than prod's actual traffic has triggered so far.

`--max-tasks-per-child` forces Celery to periodically kill and respawn each worker child process, which returns that accumulated memory to the OS. Standard, low-risk practice for exactly this pattern — applied to both environments so this doesn't quietly become a prod problem later too.

## How to test
- After deploying, monitor RSS over time: `docker exec heimpath-celery-worker-staging-1 ps aux --sort=-rss`. Expect it to reset periodically (every ~50 tasks) instead of monotonically climbing.
- Confirm workers still process tasks normally after a recycle (check `docker logs heimpath-celery-worker-staging-1` for clean respawn, no errors).