### PR TITLE
fix(ci): grant deploy user write access to shared Caddy sites dir

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,6 +164,7 @@ jobs:
           source: "deploy/caddy/heimpath.caddy"
           target: "/opt/modish/sites"
           strip_components: 2
+          overwrite: true
 
       - name: Deploy backend-prod via SSH
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
## What changed
- Server-side: added a \`modish-deploy\` group (setgid on \`/opt/modish/sites/\`), added the \`deploy\` CI user to it, chgrp+chmod g+w on the directory and its existing files.
- \`deploy.yml\`: added \`overwrite: true\` to the scp-action step for clarity, though the permission fix above is what actually resolves this.

## Why
Discovered by actually running the deploy pipeline end-to-end (not just reviewing the diff) after merging #398: the "Copy Caddy site snippet to shared proxy" step failed every time with \`tar: heimpath.caddy: Cannot open: File exists\`. Root cause: \`/opt/modish/sites/\` and \`heimpath.caddy\` were \`root:root\`, and this workflow's SSH user (\`deploy\`, uid 1000) had no write access to them at all — this would have failed on every single future deploy, permanently, leaving the Caddy snippet stale.

## How to test
Already verified — re-ran the previously-failing job after the server-side permission fix, and it succeeded.