### PR TITLE
fix(e2e): mock the document translation pipeline in tests

### DIFF
--- a/frontend/tests/translation.spec.ts
+++ b/frontend/tests/translation.spec.ts
@@ -1,36 +1,124 @@
 /**
  * Translation E2E Test
  *
- * Uploads a German Kaufvertrag PDF, watches it process through the
- * Claude translation pipeline, and verifies the English translation
- * appears live in the browser.
+ * Uploads a German Kaufvertrag PDF and watches the translation UI flow
+ * through processing to completion. The document pipeline (upload, status
+ * polling, translation content) is mocked at the network layer rather than
+ * exercising a real Celery worker + live Claude API call — a real external
+ * API call in a required CI gate is slow, costly, and flakes on transient
+ * API/rate-limit issues unrelated to this app's own code. This test verifies
+ * the frontend UI wiring (upload → processing → completed → translation
+ * viewer), not Claude's translation quality, which has its own backend-level
+ * test coverage.
  *
  * Run headed (visible browser):
  *   cd frontend && bunx playwright test translation --headed --project=chromium
- *
- * Requires: docker compose up (backend + Celery worker + Redis)
- * Requires: ANTHROPIC_API_KEY set in .env
  */
 
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { expect, test } from "@playwright/test"
+import { expect, type Page, test } from "@playwright/test"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const FIXTURE_PDF = path.join(__dirname, "fixtures/kaufvertrag-sample.pdf")
+const MOCK_DOCUMENT_ID = "0b1c2d3e-4f5a-6b7c-8d9e-0f1a2b3c4d5e"
 
-// Slow motion makes the translation process visible when running headed locally.
-// Disabled in CI where no human is watching.
-test.use({
-  launchOptions: { slowMo: process.env.CI ? 0 : 400 },
-})
+const UPLOAD_RESPONSE = {
+  id: MOCK_DOCUMENT_ID,
+  original_filename: "kaufvertrag-sample.pdf",
+  file_size_bytes: 51_200,
+  page_count: 1,
+  document_type: "kaufvertrag",
+  status: "processing",
+}
+
+const TRANSLATION = {
+  id: "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+  document_id: MOCK_DOCUMENT_ID,
+  source_language: "de",
+  target_language: "en",
+  translated_pages: [
+    {
+      page_number: 1,
+      original_text: "Kaufvertrag über ein Grundstück...",
+      translated_text:
+        "Purchase agreement for a property. The buyer and seller agree, " +
+        "subject to notary review and land register (Grundbuch) entry, " +
+        "to the property transfer described below.",
+    },
+  ],
+  clauses_detected: [],
+  risk_warnings: [],
+  kaufvertrag_analysis: null,
+  type_analysis: null,
+  glossary_links: [],
+  processing_started_at: new Date().toISOString(),
+  processing_completed_at: new Date().toISOString(),
+  requires_manual_review: false,
+  translation_confidence_score: 0.95,
+  partial_translation_coverage: null,
+}
+
+/**
+ * Mocks the document upload → status-poll → detail flow so the test
+ * exercises the UI without a real Celery worker or Claude API call.
+ * The status endpoint reports "processing" on its first poll, then
+ * "completed" on every poll after — same UX shape as the real pipeline,
+ * just deterministic instead of depending on real translation latency.
+ */
+async function mockDocumentTranslationPipeline(page: Page) {
+  let statusPollCount = 0
+
+  // A real upload has a network round-trip; a truly-instant mocked response
+  // makes the transient "Uploading document..." indicator flash and vanish
+  // before Playwright's assertion gets a chance to observe it. A small
+  // artificial delay keeps that transient state actually observable.
+  await page.route("**/api/v1/documents/upload", async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    return route.fulfill({ json: UPLOAD_RESPONSE })
+  })
+
+  await page.route(
+    `**/api/v1/documents/${MOCK_DOCUMENT_ID}/status`,
+    (route) => {
+      statusPollCount += 1
+      const isDone = statusPollCount > 1
+      return route.fulfill({
+        json: {
+          id: MOCK_DOCUMENT_ID,
+          status: isDone ? "completed" : "processing",
+          error_message: null,
+          page_count: 1,
+        },
+      })
+    },
+  )
+
+  await page.route(`**/api/v1/documents/${MOCK_DOCUMENT_ID}`, (route) => {
+    const isDone = statusPollCount > 1
+    return route.fulfill({
+      json: {
+        ...UPLOAD_RESPONSE,
+        status: isDone ? "completed" : "processing",
+        error_message: null,
+        share_id: null,
+        journey_step_id: null,
+        created_at: new Date().toISOString(),
+        translation: isDone ? TRANSLATION : null,
+        requires_subscription: false,
+        upgrade_cta: null,
+      },
+    })
+  })
+}
 
 test(
-  "upload Kaufvertrag PDF and watch Claude translate it live",
+  "upload Kaufvertrag PDF and watch the translation UI complete",
   { tag: "@translation" },
   async ({ page }) => {
-    test.setTimeout(300_000)
+    await mockDocumentTranslationPipeline(page)
+
     // ── 1. Navigate to Documents page ──────────────────────────────────────
     await page.goto("/documents")
     await expect(
@@ -54,10 +142,9 @@ test(
       page.getByText(/Queued for processing|Translating document/i),
     ).toBeVisible({ timeout: 15_000 })
 
-    // ── 6. Wait for Claude to finish — "Translation completed" in green ──────
-    // Translation via Claude haiku takes 15–90 s depending on server load.
+    // ── 6. Status flips to completed once the mocked poll reports it ────────
     await expect(page.getByText("Translation completed")).toBeVisible({
-      timeout: 180_000,
+      timeout: 15_000,
     })
 
     // ── 7. Translation tab is active by default ─────────────────────────────
@@ -68,8 +155,6 @@ test(
     await expect(page.getByText(/Page 1/i)).toBeVisible({ timeout: 10_000 })
 
     // ── 9. English translation text is visible ──────────────────────────────
-    // The Kaufvertrag contains Kaufvertrag, Grundbuch, Auflassung etc.
-    // Claude should produce English terms like "purchase", "land register", etc.
     await expect(
       page
         .getByText(
@@ -78,7 +163,7 @@ test(
         .first(),
     ).toBeVisible({ timeout: 10_000 })
 
-    // ── 10. Risk warnings tab exists (legal terms were detected) ────────────
+    // ── 10. Risk warnings tab exists (always rendered, shows a count) ───────
     await expect(page.getByRole("tab", { name: /risk|warning/i })).toBeVisible()
   },
 )


### PR DESCRIPTION
## Summary
- `translation.spec.ts` made a real Celery + Claude API call inside a required CI gate (`alls-green-playwright`), making it slow (up to 180s) and prone to failing on transient external API/rate-limit issues completely unrelated to any app code change.
- Confirmed via two consecutive identical failures on an unrelated PR (#403, a sitemap-only change) — same test, same exact 180s timeout, both attempts.
- Mocks the `POST /documents/upload`, `GET /documents/{id}/status`, and `GET /documents/{id}` endpoints at the Playwright network layer instead of hitting the real backend/Celery/Claude pipeline. Response shapes were verified against the actual Pydantic schemas in `backend/app/schemas/document.py` (`DocumentUploadResponse`, `DocumentStatusResponse`, `DocumentDetailResponse`, `DocumentTranslationResponse`).
- The test still exercises the same UI flow (upload → uploading indicator → redirect → processing spinner → completed → translation viewer) — just deterministically, without needing a live `ANTHROPIC_API_KEY` or a running Celery worker.

## Test plan
- [x] `tsc --noEmit` and `biome check` clean
- [ ] CI green (this is the test itself — validated by its own CI run)